### PR TITLE
Replace apostrophe with typewriter apostrophe

### DIFF
--- a/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.cpp
+++ b/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.cpp
@@ -45,8 +45,8 @@ namespace vulkan_renderer {
 		command_buffer_begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
 		command_buffer_begin_info.pNext = nullptr;
 
-		// We’re only going to use the command buffer once and wait with returning from the function until
-		// the copy operation has finished executing. It’s good practice to tell the driver about our intent
+		// We're only going to use the command buffer once and wait with returning from the function until
+		// the copy operation has finished executing. It's good practice to tell the driver about our intent
 		// using VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT.
 		command_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 

--- a/src/vulkan-renderer/error-handling/error_handling.cpp
+++ b/src/vulkan-renderer/error-handling/error_handling.cpp
@@ -76,7 +76,7 @@ namespace vulkan_renderer {
 			error_string = "A requested format is not supported on this device.";
 			break;
 			case VK_ERROR_FRAGMENTED_POOL:
-			error_string = "A pool allocation has failed due to fragmentation of the pool’s memory. This must only be returned if no attempt to allocate host or device memory was made to accommodate the new allocation. This should be returned in preference to VK_ERROR_OUT_OF_POOL_MEMORY, but only if the implementation is certain that the pool allocation failure was due to fragmentation.";
+			error_string = "A pool allocation has failed due to fragmentation of the pool's memory. This must only be returned if no attempt to allocate host or device memory was made to accommodate the new allocation. This should be returned in preference to VK_ERROR_OUT_OF_POOL_MEMORY, but only if the implementation is certain that the pool allocation failure was due to fragmentation.";
 			break;
 			case VK_ERROR_SURFACE_LOST_KHR:
 			error_string = "A surface is no longer available.";
@@ -106,7 +106,7 @@ namespace vulkan_renderer {
 			error_string = "A buffer creation failed because the requested address is not available.";
 			break;
 			case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
-			error_string = "An operation on a swapchain created with VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT failed as it did not have exlusive full-screen access. This may occur due to implementation-dependent reasons, outside of the application’s control.";
+			error_string = "An operation on a swapchain created with VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT failed as it did not have exlusive full-screen access. This may occur due to implementation-dependent reasons, outside of the application's control.";
 			break;
 			default:
 			error_string = "Unknown error";

--- a/src/vulkan-renderer/texture-manager/texture_manager.cpp
+++ b/src/vulkan-renderer/texture-manager/texture_manager.cpp
@@ -398,7 +398,7 @@ namespace vulkan_renderer {
 		// can simply use coordinates within the [0, texWidth) and [0, texHeight)
 		// range. If it is VK_FALSE, then the texels are addressed using the [0, 1) range
 		// on all axes. Real-world applications almost always use normalized coordinates,
-		// because then it’s possible to use textures of varying resolutions with the exact
+		// because then it's possible to use textures of varying resolutions with the exact
 		// same coordinates.
 		sampler_create_info.unnormalizedCoordinates = VK_FALSE;
 


### PR DESCRIPTION
The typewriter apostrophe is used everywhere else.