### PR TITLE
Add USE_VMA_RECORDING cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ message(STATUS "CXX Compiler executable: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Linker executable: ${CMAKE_LINKER}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+option(INEXOR_USE_VMA_RECORDING "Use VulkanMemoryAllocator recording feature" ON)
+
 file(
     GLOB_RECURSE source_files
     "src/*.hpp"
@@ -83,6 +85,9 @@ target_link_libraries(
     inexor-vulkan-renderer
     ${CONAN_LIBS}
     Vulkan::Vulkan
+)
+target_compile_definitions(inexor-vulkan-renderer PRIVATE
+        VMA_RECORDING_ENABLED=$<BOOL:${INEXOR_USE_VMA_RECORDING}>
 )
 target_compile_features(inexor-vulkan-renderer PRIVATE cxx_std_17)
 # Use multiple threads to generate code.

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -8,9 +8,6 @@
 #pragma warning(disable: 4005)
 #endif
 
-// Enable VMA memory recording and replay.
-#define VMA_RECORDING_ENABLED 1
-
 // It makes memory of all new allocations initialized to bit pattern 0xDCDCDCDC.
 // Before an allocation is destroyed, its memory is filled with bit pattern 0xEFEFEFEF.
 // Memory is automatically mapped and unmapped if necessary.
@@ -480,7 +477,9 @@ namespace inexor
 
 			allocator_info.physicalDevice = selected_graphics_card;
 			allocator_info.device = device;
+#if VMA_RECORDING_ENABLED
 			allocator_info.pRecordSettings = &vma_record_settings;
+#endif
 			allocator_info.instance = instance;
 
 			// Create an instance of Vulkan memory allocator.


### PR DESCRIPTION
Adds a new configure option to cmake. This fixes #19 as linux users can now pass -DUSE_VMA_RECORDING=Off to disable vulkan memory allocator's recording feature.