### PR TITLE
Cleanup cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 project(inexor-vulkan-renderer)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-
 # Stop in source builds
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # Options
 option(INEXOR_BUILD_BENCHMARKS "Build benchmarks" OFF)
@@ -20,7 +20,10 @@ message(STATUS "CXX Compiler executable: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Linker executable: ${CMAKE_LINKER}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+message(STATUS "INEXOR_BUILD_BENCHMARKS = ${INEXOR_BUILD_BENCHMARKS}")
 message(STATUS "INEXOR_BUILD_DOC = ${INEXOR_BUILD_DOC}")
+message(STATUS "INEXOR_BUILD_EXAMPLE = ${INEXOR_BUILD_EXAMPLE}")
+message(STATUS "INEXOR_BUILD_TESTS= ${INEXOR_BUILD_TESTS}")
 message(STATUS "INEXOR_USE_VMA_RECORDING = ${INEXOR_USE_VMA_RECORDING}")
 
 find_package(Vulkan REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.7)
+project(inexor-vulkan-renderer)
 
-# stop in source builds
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+# Stop in source builds
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
-# options
-option(INEXOR_BUILD_DOC "build documentation" OFF)
-
-message(STATUS "INEXOR_BUILD_DOC = ${INEXOR_BUILD_DOC}")
-
-project(inexor-vulkan-renderer)
+# Options
+option(INEXOR_BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(INEXOR_BUILD_DOC "Build documentation" OFF)
+option(INEXOR_BUILD_EXAMPLE "Build example" ON)
+option(INEXOR_BUILD_TESTS "Build tests" OFF)
+option(INEXOR_USE_VMA_RECORDING "Use VulkanMemoryAllocator recording feature" ON)
 
 message(STATUS "CMAKE_VERSION = ${CMAKE_VERSION}")
 message(STATUS "CMAKE_GENERATOR = ${CMAKE_GENERATOR}")
@@ -17,142 +20,28 @@ message(STATUS "CXX Compiler executable: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Linker executable: ${CMAKE_LINKER}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-option(INEXOR_USE_VMA_RECORDING "Use VulkanMemoryAllocator recording feature" ON)
+message(STATUS "INEXOR_BUILD_DOC = ${INEXOR_BUILD_DOC}")
+message(STATUS "INEXOR_USE_VMA_RECORDING = ${INEXOR_USE_VMA_RECORDING}")
 
-file(
-    GLOB_RECURSE source_files
-    "src/*.hpp"
-    "src/*.cpp"
-    "tests/*.*"
-    "benchmarks/*.*"
-)
+find_package(Vulkan REQUIRED)
 
-# Use the folder structure in source code directory as project structure in Visual Studio.
-function(assign_source_group)
-    foreach (source_files IN ITEMS ${ARGN})
-        if (IS_ABSOLUTE "${source_files}")
-            file(RELATIVE_PATH _source_rel "${PROJECT_SOURCE_DIR}" "${source_files}")
-        else ()
-            set(_source_rel "${source_files}")
-        endif ()
-        get_filename_component(_source_path "${_source_rel}" PATH)
-        string(REPLACE "/" "\\" _source_path_msvc "${_source_path}")
-        source_group("${_source_path_msvc}" FILES "${source_files}")
-    endforeach ()
-endfunction(assign_source_group)
+# Dependency setup with conan
+include(conan_setup)
 
-set(NORMAL_SOURCE_FILES)
-set(TEST_SOURCE_FILES)
-set(BENCHMARK_SOURCE_FILES)
+add_subdirectory(src)
 
-# Sort source files by tests and benchmarks.
-foreach (file ${source_files})
-    if (file MATCHES ".*_test.*")
-        set(TEST_SOURCE_FILES ${TEST_SOURCE_FILES} ${file})
-    elseif (file MATCHES ".*_benchmark.*")
-        set(BENCHMARK_SOURCE_FILES ${BENCHMARK_SOURCE_FILES} ${file})
-    else ()
-        set(NORMAL_SOURCE_FILES ${NORMAL_SOURCE_FILES} ${file})
-    endif ()
-endforeach ()
+if(${INEXOR_BUILD_BENCHMARKS})
+    add_subdirectory(benchmarks)
+endif()
 
-# Use the folder structure in source code directory as project structure in Visual Studio.
-assign_source_group(${NORMAL_SOURCE_FILES})
-assign_source_group(${TEST_SOURCE_FILES})
-assign_source_group(${BENCHMARK_SOURCE_FILES})
+if(${INEXOR_BUILD_DOC})
+    add_subdirectory(documentation)
+endif()
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.7.0)
-    message(STATUS "Using module to find Vulkan")
-    find_package(Vulkan REQUIRED)
-endif ()
+if(${INEXOR_BUILD_EXAMPLE})
+    add_subdirectory(example)
+endif()
 
-# dependency setup with conan
-include(${PROJECT_SOURCE_DIR}/cmake/conan_setup.cmake)
-
-add_executable(
-    inexor-vulkan-renderer
-
-    src/main.cpp
-    ${NORMAL_SOURCE_FILES}
-)
-target_include_directories(
-    inexor-vulkan-renderer PRIVATE
-    Vulkan::Vulkan
-    ${PROJECT_SOURCE_DIR}/src
-    ${PROJECT_SOURCE_DIR}/third_party
-)
-target_link_libraries(
-    inexor-vulkan-renderer
-    ${CONAN_LIBS}
-    Vulkan::Vulkan
-)
-target_compile_definitions(inexor-vulkan-renderer PRIVATE
-        VMA_RECORDING_ENABLED=$<BOOL:${INEXOR_USE_VMA_RECORDING}>
-)
-target_compile_features(inexor-vulkan-renderer PRIVATE cxx_std_17)
-# Use multiple threads to generate code.
-if (MSVC)
-    target_compile_options(inexor-vulkan-renderer PRIVATE "/MP")
-endif ()
-
-# Use root folder of the repository as working directory in Visual Studio debugger!
-# Otherwise Visual Studio can't find any files like shaders or textures.
-if (WIN32)
-    set_property(TARGET inexor-vulkan-renderer PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-endif ()
-
-file(
-    GLOB_RECURSE NORMAL_SOURCE_FILES_WITHOUT_MAIN
-    "src/vulkan-renderer/*"
-)
-
-add_executable(
-    inexor-vulkan-renderer-tests
-
-    ${NORMAL_SOURCE_FILES_WITHOUT_MAIN}
-    ${TEST_SOURCE_FILES}
-)
-target_include_directories(inexor-vulkan-renderer-tests PRIVATE Vulkan::Vulkan)
-target_link_libraries(
-    inexor-vulkan-renderer-tests
-    ${CONAN_LIBS}
-    Vulkan::Vulkan
-)
-target_compile_features(inexor-vulkan-renderer-tests PRIVATE cxx_std_17)
-if (MSVC)
-    # Use multiple threads to compile the code.
-    target_compile_options(inexor-vulkan-renderer-tests PRIVATE "/MP")
-endif ()
-
-# Use root folder of the repository as working directory in Visual Studio debugger!
-# Otherwise Visual Studio can't find any files like shaders or textures.
-if (WIN32)
-    set_property(TARGET inexor-vulkan-renderer-tests PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-endif ()
-
-add_executable(
-    inexor-vulkan-renderer-benchmarks
-
-    ${NORMAL_SOURCE_FILES_WITHOUT_MAIN}
-    ${BENCHMARK_SOURCE_FILES}
-)
-target_include_directories(inexor-vulkan-renderer-benchmarks PRIVATE Vulkan::Vulkan)
-target_link_libraries(
-    inexor-vulkan-renderer-benchmarks
-    ${CONAN_LIBS}
-    Vulkan::Vulkan
-)
-target_compile_features(inexor-vulkan-renderer-benchmarks PRIVATE cxx_std_17)
-# Use multiple threads to compile the code.
-if (MSVC)
-    target_compile_options(inexor-vulkan-renderer-benchmarks PRIVATE "/MP")
-endif ()
-
-if (WIN32)
-    set_property(TARGET inexor-vulkan-renderer-benchmarks PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-endif ()
-
-# documentation
-if (${INEXOR_BUILD_DOC})
-    add_subdirectory(${PROJECT_SOURCE_DIR}/documentation)
-endif ()
+if(${INEXOR_BUILD_TESTS})
+    add_subdirectory(tests)
+endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(inexor-vulkan-renderer-benchmarks
+    engine_benchmark_main.cpp)
+
+set_target_properties(inexor-vulkan-renderer-benchmarks PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)
+
+target_link_libraries(inexor-vulkan-renderer-benchmarks PRIVATE
+    inexor-vulkan-renderer)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,20 @@
-add_executable(inexor-vulkan-renderer-benchmarks
-    engine_benchmark_main.cpp)
+add_executable(
+    inexor-vulkan-renderer-benchmarks
 
-set_target_properties(inexor-vulkan-renderer-benchmarks PROPERTIES
+    engine_benchmark_main.cpp
+)
+
+set_target_properties(
+    inexor-vulkan-renderer-benchmarks PROPERTIES
+
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON)
+    CXX_STANDARD_REQUIRED ON
+)
 
-target_link_libraries(inexor-vulkan-renderer-benchmarks PRIVATE
-    inexor-vulkan-renderer)
+target_link_libraries(
+    inexor-vulkan-renderer-benchmarks
+
+    PRIVATE
+    inexor-vulkan-renderer
+)

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -1,16 +1,7 @@
-# https://eb2.co/blog/2012/03/sphinx-and-cmake-beautiful-documentation-for-c---projects/
-cmake_minimum_required(VERSION 3.12)
-
-find_package(Doxygen)
-if (NOT Doxygen_FOUND)
-    message(FATAL_ERROR "Doxygen not found")
-endif ()
+find_package(Doxygen REQUIRED)
 message(STATUS "Found Doxygen: ${DOXYGEN_EXECUTABLE}")
 
-find_package(Sphinx REQUIRED PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake NO_DEFAULT_PATH)
-if (NOT Sphinx_FOUND)
-    message(FATAL_ERROR "Sphinx not found")
-endif ()
+find_package(Sphinx REQUIRED PATHS ${CMAKE_CURRENT_SOURCE_DIR}/cmake NO_DEFAULT_PATH REQUIRED)
 message(STATUS "Found Sphinx: ${SPHINX_EXECUTABLE}")
 
 # Sphinx cache with pickled ReST documents

--- a/documentation/source/development/building.rst
+++ b/documentation/source/development/building.rst
@@ -21,9 +21,21 @@ Available CMake options
 - INEXOR_CONAN_PROFILE
     To adjust the conan profile, use ``-DCONNECTOR_CONAN_PROFILE=<name>``. The building type will be overriden by CMake.
     Default: ``default``
+- INEXOR_BUILD_BENCHMARKS
+    Builds inexor-renderer-benchmarks.
+    Default: ``OFF``
 - INEXOR_BUILD_DOC
-   To build the documentation enable it.
-   Default: ``OFF``
+    To build the documentation enable it.
+    Default: ``OFF``
+- INEXOR_BUILD_EXAMPLE
+    Builds inexor-renderer-example.
+    Default: ``ON``
+- INEXOR_BUILD_TESTS
+    Builds inexor-renderer tests.
+    Default: ``OFF``
+- INEXOR_USE_VMA_RECORDING
+    Enables or disables VulkanMemoryAllocator's recording feature.
+    Default: ``ON``
 
 .. note::
     When building a VS solution add ``--config Debug/Release`` to define the build type.

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(inexor-vulkan-renderer-example
+    main.cpp)
+
+set_target_properties(inexor-vulkan-renderer-example PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)
+
+target_link_libraries(inexor-vulkan-renderer-example PRIVATE
+    inexor-vulkan-renderer)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,10 +1,20 @@
-add_executable(inexor-vulkan-renderer-example
-    main.cpp)
+add_executable(
+    inexor-vulkan-renderer-example
 
-set_target_properties(inexor-vulkan-renderer-example PROPERTIES
+    main.cpp
+)
+
+set_target_properties(
+    inexor-vulkan-renderer-example PROPERTIES
+
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON)
+    CXX_STANDARD_REQUIRED ON
+)
 
-target_link_libraries(inexor-vulkan-renderer-example PRIVATE
-    inexor-vulkan-renderer)
+target_link_libraries(
+    inexor-vulkan-renderer-example
+
+    PRIVATE
+    inexor-vulkan-renderer
+)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -3,7 +3,7 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
-#include "inexor_application.hpp"
+#include "../src/inexor_application.hpp"
 
 using namespace inexor::vulkan_renderer;
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -3,7 +3,7 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
-#include "../src/inexor_application.hpp"
+#include <inexor_application.hpp>
 
 using namespace inexor::vulkan_renderer;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,49 @@
+add_library(inexor-vulkan-renderer
+    vulkan-renderer/availability-checks/availability_checks.cpp
+    vulkan-renderer/availability-checks/availability_checks_benchmarks.cpp
+    vulkan-renderer/availability-checks/availability_checks_tests.cpp
+    vulkan-renderer/camera/camera.cpp
+    vulkan-renderer/command-buffer-recording/single_time_command_buffer.cpp
+    vulkan-renderer/debug-marker/debug_marker_manager.cpp
+    vulkan-renderer/descriptor-manager/descriptor_manager.cpp
+    vulkan-renderer/error-handling/error_handling.cpp
+    vulkan-renderer/fence-manager/fence_manager.cpp
+    vulkan-renderer/fps-counter/fps_counter.cpp
+    vulkan-renderer/gltf-model-manager/gltf_model_manager.cpp
+    vulkan-renderer/gpu-info/gpu_info.cpp
+    vulkan-renderer/gpu-queue-manager/gpu_queue_manager.cpp
+    vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.cpp
+    vulkan-renderer/semaphore-manager/semaphore_manager.cpp
+    vulkan-renderer/settings-decision-maker/settings_decision_maker.cpp
+    vulkan-renderer/shader-manager/shader_manager.cpp
+    vulkan-renderer/texture/texture.cpp
+    vulkan-renderer/texture-manager/texture_manager.cpp
+    vulkan-renderer/thread-pool/thread_pool.cpp
+    vulkan-renderer/time-step/time_step.cpp
+    vulkan-renderer/tools/argument-parser/cla_parser.cpp
+    vulkan-renderer/tools/file-loader/File.cpp
+    vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.cpp
+    vulkan-renderer/renderer.cpp
+    inexor_application.cpp)
+
+set_target_properties(inexor-vulkan-renderer PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)
+
+# TODO: Move GLFW and GLM definitions here
+target_compile_definitions(inexor-vulkan-renderer PRIVATE
+    VMA_RECORDING_ENABLED=$<BOOL:${INEXOR_USE_VMA_RECORDING}>)
+
+if(MSVC)
+    target_compile_options(inexor-vulkan-renderer PRIVATE "/MP")
+    set_property(TARGET inexor-vulkan-renderer PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
+endif()
+
+target_include_directories(inexor-vulkan-renderer PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/third_party)
+
+target_link_libraries(inexor-vulkan-renderer PUBLIC
+    ${CONAN_LIBS}
+    Vulkan::Vulkan)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(inexor-vulkan-renderer
+add_library(
+    inexor-vulkan-renderer
+
     vulkan-renderer/availability-checks/availability_checks.cpp
     vulkan-renderer/availability-checks/availability_checks_benchmarks.cpp
     vulkan-renderer/availability-checks/availability_checks_tests.cpp
@@ -24,26 +26,47 @@ add_library(inexor-vulkan-renderer
     vulkan-renderer/tools/file-loader/File.cpp
     vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.cpp
     vulkan-renderer/renderer.cpp
-    inexor_application.cpp)
+    inexor_application.cpp
+)
 
-set_target_properties(inexor-vulkan-renderer PROPERTIES
+set_target_properties(
+    inexor-vulkan-renderer PROPERTIES
+
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON)
+    CXX_STANDARD_REQUIRED ON
+)
 
-# TODO: Move GLFW and GLM definitions here
-target_compile_definitions(inexor-vulkan-renderer PRIVATE
-    VMA_RECORDING_ENABLED=$<BOOL:${INEXOR_USE_VMA_RECORDING}>)
+target_compile_definitions(
+    inexor-vulkan-renderer
+
+    PRIVATE
+    GLFW_INCLUDE_VULKAN
+    GLM_FORCE_DEPTH_ZERO_TO_ONE
+    GLM_FORCE_RADIANS
+    VMA_RECORDING_ENABLED=$<BOOL:${INEXOR_USE_VMA_RECORDING}>
+)
 
 if(MSVC)
     target_compile_options(inexor-vulkan-renderer PRIVATE "/MP")
-    set_property(TARGET inexor-vulkan-renderer PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
+    set_property(
+        TARGET inexor-vulkan-renderer
+        PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    )
 endif()
 
-target_include_directories(inexor-vulkan-renderer PUBLIC
-    ${PROJECT_SOURCE_DIR}/src
-    ${PROJECT_SOURCE_DIR}/third_party)
+target_include_directories(
+    inexor-vulkan-renderer
 
-target_link_libraries(inexor-vulkan-renderer PUBLIC
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/third_party
+)
+
+target_link_libraries(
+    inexor-vulkan-renderer
+
+    PUBLIC
     ${CONAN_LIBS}
-    Vulkan::Vulkan)
+    Vulkan::Vulkan
+)

--- a/src/inexor_application.hpp
+++ b/src/inexor_application.hpp
@@ -15,7 +15,6 @@
 #include "vulkan-renderer/mesh-buffer/mesh_buffer.hpp"
 #include "vulkan-renderer/camera/camera.hpp"
 
-#define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
 #include <spdlog/spdlog.h>

--- a/src/vulkan-renderer/camera/camera.hpp
+++ b/src/vulkan-renderer/camera/camera.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#define GLM_FORCE_RADIANS
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/matrix_transform.hpp>

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_node.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_node.hpp
@@ -4,8 +4,6 @@
 #include "vulkan-renderer/gltf-model-manager/gltf_model_mesh.hpp"
 
 
-#define GLM_FORCE_RADIANS
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/src/vulkan-renderer/renderer.hpp
+++ b/src/vulkan-renderer/renderer.hpp
@@ -28,8 +28,6 @@
 #include "vulkan-renderer/fps-counter/fps_counter.hpp"
 #include "vulkan-renderer/multisampling/msaa_target.hpp"
 
-#define GLM_FORCE_RADIANS
-#define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
@@ -37,7 +35,6 @@
 
 #include <spdlog/spdlog.h>
 
-#define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
 #include <vector>

--- a/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.hpp
+++ b/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.hpp
@@ -6,8 +6,6 @@
 #include "vulkan-renderer/class-templates/manager_template.hpp"
 #include "vulkan-renderer/uniform-buffer/uniform_buffer.hpp"
 
-#define GLM_FORCE_RADIANS
-
 // This will force GLM to use a version of vec2 and mat4 that has the alignment requirements already specified for us.
 /// @warning Unfortunately this method can break down if you start using nested structures.
 #define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,20 @@
-add_executable(inexor-vulkan-renderer-tests
-    unit_tests_main.cpp)
+add_executable(
+    inexor-vulkan-renderer-tests
 
-set_target_properties(inexor-vulkan-renderer-tests PROPERTIES
+    unit_tests_main.cpp
+)
+
+set_target_properties(
+    inexor-vulkan-renderer-tests PROPERTIES
+
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON)
+    CXX_STANDARD_REQUIRED ON
+)
 
-target_link_libraries(inexor-vulkan-renderer-tests PRIVATE
-    inexor-vulkan-renderer)
+target_link_libraries(
+    inexor-vulkan-renderer-tests
+
+    PRIVATE
+    inexor-vulkan-renderer
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(inexor-vulkan-renderer-tests
+    unit_tests_main.cpp)
+
+set_target_properties(inexor-vulkan-renderer-tests PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)
+
+target_link_libraries(inexor-vulkan-renderer-tests PRIVATE
+    inexor-vulkan-renderer)


### PR DESCRIPTION
Initial commit splits up the root CMakeLists.txt into multiple ones located in subdirectories. inexor-vulkan-renderer is now built as a library that the three subprojects - benchmarks, example and tests all link against.