### PR TITLE
Remove spurious using namespace std

### DIFF
--- a/src/vulkan-renderer/renderer.hpp
+++ b/src/vulkan-renderer/renderer.hpp
@@ -41,7 +41,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-using namespace std;
 
 // The maximum number of images to process simultaneously.
 // TODO: Refactoring! That is triple buffering essentially!


### PR DESCRIPTION
Remove an unneeded `using namespace std` in renderer.hpp