### PR TITLE
[vcs] Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# [clang-format] Tested clang-format file.
+eed81253b402cc456b885edb990f66ed00311e74
+
+# [clang-format] Applied clang-format to all files.
+714528c9197c77c5cfac08abefad03e41271cc88
+
+# [code] Apply code style on missing files.
+fe3440a2a7d23552169d03040078c3502f9676db


### PR DESCRIPTION
Add .git-blame-ignores-revs that contains the recent clang-format commits.