### PR TITLE
Cleanup namespaces

### DIFF
--- a/src/inexor_application.cpp
+++ b/src/inexor_application.cpp
@@ -1,7 +1,6 @@
 ﻿#include "inexor_application.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @brief Static callback for window resize events.
 /// @note Because GLFW is a C-style API, we can't pass a poiner to a class method, so we have to do it this way!
@@ -724,5 +723,4 @@ void InexorApplication::cleanup() {
     gltf_model_files.clear();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/inexor_application.hpp
+++ b/src/inexor_application.hpp
@@ -19,8 +19,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class InexorApplication : public VulkanRenderer, public tools::InexorCommandLineArgumentParser {
 public:
@@ -106,5 +105,4 @@ public:
     void cleanup();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/availability-checks/availability_checks.cpp
+++ b/src/vulkan-renderer/availability-checks/availability_checks.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/availability-checks/availability_checks.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult InexorAvailabilityChecksManager::create_instance_extensions_cache() {
     // First ask Vulkan how many instance extensions are available on the system.
@@ -198,5 +197,4 @@ bool InexorAvailabilityChecksManager::is_swapchain_available(const VkPhysicalDev
     return is_device_extension_available(graphics_card, VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/availability-checks/availability_checks.hpp
+++ b/src/vulkan-renderer/availability-checks/availability_checks.hpp
@@ -8,8 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class InexorAvailabilityChecksManager {
 private:
@@ -88,5 +87,4 @@ public:
     bool is_swapchain_available(const VkPhysicalDevice &graphics_card);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/bezier-curve/bezier_curve.cpp
+++ b/src/vulkan-renderer/bezier-curve/bezier_curve.cpp
@@ -1,7 +1,6 @@
 #include "bezier_curve.h"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 uint32_t BezierCurve::binomial_coefficient(uint32_t n, const uint32_t k) {
     uint32_t r = 1;
@@ -129,5 +128,4 @@ void BezierCurve::calculate_bezier_curve(const float curve_precision) {
     curve_generated = true;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/bezier-curve/bezier_curve.h
+++ b/src/vulkan-renderer/bezier-curve/bezier_curve.h
@@ -35,8 +35,7 @@
 #include <cmath>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @brief Those are the points that we pass into the bezier curve generator.
 /// Every bezier curve will be generated from a list of BezierInputPoint.
@@ -95,5 +94,4 @@ public:
     bool is_curve_generated();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/camera/camera.cpp
+++ b/src/vulkan-renderer/camera/camera.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/camera/camera.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 void InexorCamera::set_position(const glm::vec3 &position) {
     this->position = position;
@@ -128,5 +127,4 @@ glm::vec3 InexorCamera::get_front() const { return this->world_front; }
 
 glm::vec3 InexorCamera::get_right() const { return this->world_right; }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/camera/camera.hpp
+++ b/src/vulkan-renderer/camera/camera.hpp
@@ -8,8 +8,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorCamera
 /// TODO: Add mutex!
@@ -209,5 +208,4 @@ public:
     glm::mat4 get_projection_matrix();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/class-templates/manager_template.hpp
+++ b/src/vulkan-renderer/class-templates/manager_template.hpp
@@ -5,8 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class ManagerClassTemplate
 /// @brief A manager class template for type managers.
@@ -197,5 +196,4 @@ protected:
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.cpp
+++ b/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/command-buffer-recording/single_time_command_buffer.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult SingleTimeCommandBufferRecorder::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager,
                                                const VkQueue &data_transfer_queue) {
@@ -100,5 +99,4 @@ void SingleTimeCommandBufferRecorder::destroy_command_pool() {
     vkDestroyCommandPool(device, data_transfer_command_pool, nullptr);
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.hpp
+++ b/src/vulkan-renderer/command-buffer-recording/single_time_command_buffer.hpp
@@ -8,8 +8,7 @@
 
 #include <cassert>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class CommandBufferRecorder
 /// @brief A class for managing the recording of single time command buffers.
@@ -49,5 +48,4 @@ protected:
     void destroy_command_pool();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/debug-callback/debug_callback.hpp
+++ b/src/vulkan-renderer/debug-callback/debug_callback.hpp
@@ -4,8 +4,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @brief Vulkan validation layer callback.
 static VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugMessageCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object,
@@ -26,5 +25,4 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugMessageCallback(VkDebugReportFl
     return VK_FALSE;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/debug-marker/debug_marker_manager.cpp
+++ b/src/vulkan-renderer/debug-marker/debug_marker_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/debug-marker/debug_marker_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 void VulkanDebugMarkerManager::init(const VkDevice &device, const VkPhysicalDevice &graphics_card, bool enable_debug_markers) {
     if (enable_debug_markers) {
@@ -135,5 +134,4 @@ void VulkanDebugMarkerManager::end_region(const VkCommandBuffer &command_buffer)
     }
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/debug-marker/debug_marker_manager.hpp
+++ b/src/vulkan-renderer/debug-marker/debug_marker_manager.hpp
@@ -9,8 +9,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 // Predefined color markers.
 // These colors will be visible in RenderDoc.
@@ -71,5 +70,4 @@ public:
     void end_region(const VkCommandBuffer &command_buffer);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/descriptor-manager/descriptor_manager.cpp
+++ b/src/vulkan-renderer/descriptor-manager/descriptor_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/descriptor-manager/descriptor_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult InexorDescriptorManager::init(const VkDevice &device, const std::size_t number_of_images_in_swapchain,
                                        const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
@@ -230,5 +229,4 @@ VkResult InexorDescriptorManager::shutdown_descriptors(bool clear_descriptor_lay
     return VK_SUCCESS;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/descriptor-manager/descriptor_manager.hpp
+++ b/src/vulkan-renderer/descriptor-manager/descriptor_manager.hpp
@@ -14,8 +14,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorDescriptorManager.
 /// @brief A manager class for descriptor pools, descriptor set layouts and descriptor sets.
@@ -94,5 +93,4 @@ public:
     VkResult shutdown_descriptors(bool clear_descriptor_layout_bindings = false);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/descriptor-pool/descriptor_pool.hpp
+++ b/src/vulkan-renderer/descriptor-pool/descriptor_pool.hpp
@@ -5,8 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 ///
@@ -27,5 +26,4 @@ struct InexorDescriptorPool {
     VkDescriptorPool pool;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/descriptor-set/descriptor_bundle.hpp
+++ b/src/vulkan-renderer/descriptor-set/descriptor_bundle.hpp
@@ -8,8 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 ///
@@ -36,5 +35,4 @@ public:
     std::vector<VkDescriptorSetLayoutBinding> descriptor_set_layout_bindings;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/error-handling/error_handling.cpp
+++ b/src/vulkan-renderer/error-handling/error_handling.cpp
@@ -4,8 +4,7 @@
 #include <Windows.h>
 #endif
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @brief Returns a user friendly error description text.
 /// @param result_code The error code.
@@ -167,5 +166,4 @@ void vulkan_error_check(const VkResult &result) {
     }
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/error-handling/error_handling.hpp
+++ b/src/vulkan-renderer/error-handling/error_handling.hpp
@@ -6,8 +6,7 @@
 
 #include <vulkan/vulkan.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 // These functions help to abstract error handling in Vulkan.
 
@@ -35,5 +34,4 @@ void display_warning_message(const std::string &warning_message, const std::stri
 // @param result The result which is to be validated.
 void vulkan_error_check(const VkResult &result);
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/fence-manager/fence_manager.cpp
+++ b/src/vulkan-renderer/fence-manager/fence_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/fence-manager/fence_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanFenceManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
     assert(device);
@@ -90,5 +89,4 @@ void VulkanFenceManager::shutdown_fences() {
     delete_all_entries();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/fence-manager/fence_manager.hpp
+++ b/src/vulkan-renderer/fence-manager/fence_manager.hpp
@@ -10,8 +10,7 @@
 #include <memory>
 #include <mutex>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 class VulkanFenceManager : public ManagerClassTemplate<VkFence> {
@@ -55,5 +54,4 @@ public:
     void shutdown_fences();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/fps-counter/fps_counter.cpp
+++ b/src/vulkan-renderer/fps-counter/fps_counter.cpp
@@ -1,7 +1,6 @@
 ﻿#include "vulkan-renderer/fps-counter/fps_counter.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 std::optional<uint32_t> InexorFPSCounter::update() {
     auto current_time = std::chrono::high_resolution_clock::now();
@@ -22,5 +21,4 @@ std::optional<uint32_t> InexorFPSCounter::update() {
     return std::nullopt;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/fps-counter/fps_counter.hpp
+++ b/src/vulkan-renderer/fps-counter/fps_counter.hpp
@@ -3,8 +3,7 @@
 #include <chrono>
 #include <optional>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class InexorFPSCounter {
 private:
@@ -22,5 +21,4 @@ public:
     std::optional<uint32_t> update();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model.hpp
@@ -19,8 +19,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 struct InexorModel {
     tinygltf::Model gltf2_container;
@@ -56,5 +55,4 @@ struct InexorModel {
     std::size_t uniform_buffer_index = 0;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_animation.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_animation.hpp
@@ -6,8 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 struct InexorModelAnimation {
@@ -22,5 +21,4 @@ struct InexorModelAnimation {
     float end = std::numeric_limits<float>::min();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_animation_channel.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_animation_channel.hpp
@@ -4,8 +4,7 @@
 
 #include <memory>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 struct InexorModelAnimationChannel {
@@ -18,5 +17,4 @@ struct InexorModelAnimationChannel {
     uint32_t samplerIndex;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_animation_sampler.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_animation_sampler.hpp
@@ -5,8 +5,7 @@
 #include <memory>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 struct InexorModelAnimationSampler {
@@ -19,5 +18,4 @@ struct InexorModelAnimationSampler {
     std::vector<glm::vec4> outputsVec4;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_bounding_box.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_bounding_box.hpp
@@ -2,8 +2,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 struct BoundingBox {
@@ -46,5 +45,4 @@ struct BoundingBox {
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_dimensions.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_dimensions.hpp
@@ -2,8 +2,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// TODO: Remove this!
 struct InexorDimensions {
@@ -11,5 +10,4 @@ struct InexorDimensions {
     glm::vec3 max = glm::vec3(-FLT_MAX);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_manager.cpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_manager.cpp
@@ -7,8 +7,7 @@
 #define TINYGLTF_IMPLEMENTATION
 #include <tiny_gltf/tiny_gltf.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult InexorModelManager::init(const VkDevice &device, const std::shared_ptr<VulkanTextureManager> texture_manager,
                                   const std::shared_ptr<VulkanUniformBufferManager> uniform_buffer_manager,
@@ -1134,5 +1133,4 @@ std::shared_ptr<InexorModelNode> InexorModelManager::node_from_index(std::shared
     return node_found;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_manager.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_manager.hpp
@@ -33,8 +33,7 @@
 #include <nlohmann/json.hpp>
 #define TINYGLTF_NO_INCLUDE_JSON
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorModelManager
 /// TODO: Make InexorModelLoader and inherit!
@@ -157,5 +156,4 @@ private:
     std::shared_ptr<InexorModelNode> node_from_index(std::shared_ptr<InexorModel> model, const uint32_t index);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_material.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_material.hpp
@@ -6,8 +6,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 enum InexorModelMaterialAlphaMode { ALPHAMODE_OPAQUE, ALPHAMODE_MASK, ALPHAMODE_BLEND };
@@ -61,5 +60,4 @@ struct InexorModelMaterial {
     VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_mesh.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_mesh.hpp
@@ -10,8 +10,7 @@
 #include <memory>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 struct InexorModelMesh {
 
@@ -45,5 +44,4 @@ struct InexorModelMesh {
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_node.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_node.hpp
@@ -13,8 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 struct InexorModelNode;
 
@@ -112,5 +111,4 @@ struct InexorModelNode {
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_primitive.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_primitive.hpp
@@ -5,8 +5,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 struct InexorModelPrimitive {
     uint32_t first_index;
@@ -39,5 +38,4 @@ struct InexorModelPrimitive {
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_skin.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_skin.hpp
@@ -8,10 +8,8 @@
 
 #include "vulkan-renderer/gltf-model-manager/gltf_model_node.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 // TODO: Remove this!
 
-};
-}; // namespace inexor
+}

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_texture_sampler.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_texture_sampler.hpp
@@ -2,8 +2,7 @@
 
 #include <vulkan/vulkan.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorTextureSampler
 struct InexorTextureSampler {
@@ -14,5 +13,4 @@ struct InexorTextureSampler {
     VkSamplerAddressMode addressModeW;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_uniform_buffer.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_uniform_buffer.hpp
@@ -5,8 +5,7 @@
 // Changing this value here also requires changing it in the vertex shader.
 #define MAX_NUM_JOINTS 128u
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorModelStandardUniformBuffer
 /// @brief Inexor's standard uniform buffer block for glTF 2.0 models.
@@ -18,5 +17,4 @@ struct InexorModelStandardUniformBufferBlock {
     float joint_count{0};
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gltf-model-manager/gltf_model_vertex.hpp
+++ b/src/vulkan-renderer/gltf-model-manager/gltf_model_vertex.hpp
@@ -3,8 +3,7 @@
 #include <array>
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 struct InexorModelVertex {
     glm::vec3 pos;
@@ -64,5 +63,4 @@ struct InexorModelVertex {
     }
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gpu-info/gpu_info.cpp
+++ b/src/vulkan-renderer/gpu-info/gpu_info.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/gpu-info/gpu_info.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 void VulkanGraphicsCardInfoViewer::print_driver_vulkan_version() {
     // The version of the available Vulkan API is encoded as a 32 bit integer.
@@ -680,5 +679,4 @@ void VulkanGraphicsCardInfoViewer::print_all_physical_devices(const VkInstance &
     }
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gpu-info/gpu_info.hpp
+++ b/src/vulkan-renderer/gpu-info/gpu_info.hpp
@@ -11,8 +11,7 @@
 #include "vulkan-renderer/error-handling/error_handling.hpp"
 #include "vulkan-renderer/helpers/surface_formats.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class VulkanGraphicsCardInfoViewer
 /// @brief Prints information related to graphics card's capabilities and limits.
@@ -85,5 +84,4 @@ public:
     void print_all_physical_devices(const VkInstance &vulkan_instance, const VkSurfaceKHR &vulkan_surface);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gpu-memory-buffer/gpu_memory_buffer.hpp
+++ b/src/vulkan-renderer/gpu-memory-buffer/gpu_memory_buffer.hpp
@@ -8,8 +8,7 @@
 #include <cstddef>
 #include <string>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorStagingBuffer
 /// @brief An abstraction class for the creation of staging buffers.
@@ -31,5 +30,4 @@ struct InexorBuffer {
     VmaAllocationCreateInfo allocation_create_info = {};
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gpu-queue-manager/gpu_queue_manager.cpp
+++ b/src/vulkan-renderer/gpu-queue-manager/gpu_queue_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/gpu-queue-manager/gpu_queue_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanQueueManager::init(const std::shared_ptr<VulkanSettingsDecisionMaker> settings_decision_maker) {
     // TODO: Add mutex.
@@ -255,5 +254,4 @@ std::vector<VkDeviceQueueCreateInfo> VulkanQueueManager::get_queues_to_create() 
     return device_queues_to_create;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/gpu-queue-manager/gpu_queue_manager.hpp
+++ b/src/vulkan-renderer/gpu-queue-manager/gpu_queue_manager.hpp
@@ -10,8 +10,7 @@
 
 #include "vulkan-renderer/settings-decision-maker/settings_decision_maker.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class VulkanQueueManager {
 public:
@@ -94,5 +93,4 @@ public:
     std::vector<VkDeviceQueueCreateInfo> get_queues_to_create();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/helpers/surface_formats.hpp
+++ b/src/vulkan-renderer/helpers/surface_formats.hpp
@@ -2,8 +2,7 @@
 
 #include <unordered_map>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 // Since VkSurfaceFormatKHR::format only contains an unsigned integer
 // which describes the format, we cannot get the format name without
@@ -250,5 +249,4 @@ const std::unordered_map<int, std::string> surface_format_names = {{0, "VK_FORMA
                                                                    {1000066012, "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT"},
                                                                    {1000066013, "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT"}};
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/image-buffer/image_buffer.hpp
+++ b/src/vulkan-renderer/image-buffer/image_buffer.hpp
@@ -7,8 +7,7 @@
 // License: MIT
 #include <vma/vma_usage.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 ///
@@ -27,5 +26,4 @@ struct InexorImageBuffer {
     VkFormat format;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.cpp
+++ b/src/vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.cpp
@@ -1,7 +1,6 @@
 ﻿#include "vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult InexorMeshBufferManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager,
                                        const VmaAllocator &vma_allocator, const uint32_t data_transfer_queue_family_index, const VkQueue &data_transfer_queue) {
@@ -515,5 +514,4 @@ void InexorMeshBufferManager::shutdown_vertex_and_index_buffers() {
     list_of_meshes.clear();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.hpp
+++ b/src/vulkan-renderer/mesh-buffer-manager/mesh_buffer_manager.hpp
@@ -18,8 +18,7 @@
 #include <spdlog/spdlog.h>
 #include <vulkan/vulkan.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorMeshBufferManager.
 /// @brief A manager class for vertex buffers and index buffers.
@@ -111,5 +110,4 @@ public:
     void shutdown_vertex_and_index_buffers();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/mesh-buffer/mesh_buffer.hpp
+++ b/src/vulkan-renderer/mesh-buffer/mesh_buffer.hpp
@@ -9,8 +9,7 @@
 // License: MIT
 #include <vma/vma_usage.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorMeshBuffer
 /// @brief A structure which bundles vertex buffer and index buffer (if existent).
@@ -38,5 +37,4 @@ struct InexorMeshBuffer {
     bool index_buffer_available = false;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/multisampling/msaa_target.hpp
+++ b/src/vulkan-renderer/multisampling/msaa_target.hpp
@@ -2,8 +2,7 @@
 
 #include "vulkan-renderer/image-buffer/image_buffer.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 ///
@@ -16,5 +15,4 @@ struct InexorMSAATarget {
     InexorImageBuffer depth;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -24,8 +24,7 @@
 // License: MIT.
 #include <vma/vk_mem_alloc.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanRenderer::create_vulkan_instance(const std::string &application_name, const std::string &engine_name, const uint32_t application_version,
                                                 const uint32_t engine_version, bool enable_validation_instance_layers, bool enable_renderdoc_instance_layer) {
@@ -1917,5 +1916,4 @@ VkResult VulkanRenderer::shutdown_vulkan() {
     return VK_SUCCESS;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/renderer.hpp
+++ b/src/vulkan-renderer/renderer.hpp
@@ -46,8 +46,7 @@
 // TODO: Refactoring! That is triple buffering essentially!
 #define INEXOR_MAX_FRAMES_IN_FLIGHT 3
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class VulkanRenderer {
 public:
@@ -282,5 +281,4 @@ protected:
     VkResult shutdown_vulkan();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/semaphore-manager/semaphore_manager.cpp
+++ b/src/vulkan-renderer/semaphore-manager/semaphore_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/semaphore-manager/semaphore_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanSemaphoreManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
     assert(device);
@@ -97,5 +96,4 @@ void VulkanSemaphoreManager::shutdown_semaphores() {
     delete_all_entries();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/semaphore-manager/semaphore_manager.hpp
+++ b/src/vulkan-renderer/semaphore-manager/semaphore_manager.hpp
@@ -11,8 +11,7 @@
 
 #include <cassert>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @brief VulkanSemaphoreManager
 class VulkanSemaphoreManager : public ManagerClassTemplate<VkSemaphore> {
@@ -55,5 +54,4 @@ public:
     void shutdown_semaphores();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/settings-decision-maker/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings-decision-maker/settings_decision_maker.cpp
@@ -2,8 +2,7 @@
 
 using namespace std;
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 uint32_t VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface) {
     assert(graphics_card);
@@ -831,5 +830,4 @@ std::optional<VkFormat> VulkanSettingsDecisionMaker::find_depth_buffer_format(co
     return std::nullopt;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/settings-decision-maker/settings_decision_maker.hpp
+++ b/src/vulkan-renderer/settings-decision-maker/settings_decision_maker.hpp
@@ -12,8 +12,7 @@
 
 #include <vulkan/vulkan.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class VulkanSettingsDecisionMaker
 /// @brief This class makes automatic decisions which are relevant to setting up Vulkan:
@@ -153,5 +152,4 @@ public:
                                                      const VkFormatFeatureFlags feature_flags);
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/shader-manager/shader_manager.cpp
+++ b/src/vulkan-renderer/shader-manager/shader_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/shader-manager/shader_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanShaderManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
     assert(device);
@@ -141,5 +140,4 @@ std::vector<std::shared_ptr<InexorShader>> VulkanShaderManager::get_all_shaders(
     return get_all_values();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/shader-manager/shader_manager.hpp
+++ b/src/vulkan-renderer/shader-manager/shader_manager.hpp
@@ -11,8 +11,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class VulkanShaderManager
 /// @brief A class for managing SPIR-V shaders.
@@ -71,5 +70,4 @@ public:
     void shutdown_shaders();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/shader/shader.hpp
+++ b/src/vulkan-renderer/shader/shader.hpp
@@ -6,8 +6,7 @@
 
 #include <string>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class InexorShader : public tools::InexorFile {
 public:
@@ -24,5 +23,4 @@ public:
     VkShaderModule module;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/texture-manager/texture_manager.cpp
+++ b/src/vulkan-renderer/texture-manager/texture_manager.cpp
@@ -6,8 +6,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanTextureManager::init(const VkDevice &device, const VkPhysicalDevice &graphics_card,
                                     const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager, const VmaAllocator &vma_allocator,
@@ -557,5 +556,4 @@ void VulkanTextureManager::shutdown_textures() {
     destroy_command_pool();
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/texture-manager/texture_manager.hpp
+++ b/src/vulkan-renderer/texture-manager/texture_manager.hpp
@@ -29,8 +29,7 @@
 #include <memory>
 #include <string>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 // TODO: 2D textures, 3D textures and cube maps.
 // TODO: Scan asset directory automatically.
@@ -151,5 +150,4 @@ public:
     void shutdown_textures();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/texture/texture.cpp
+++ b/src/vulkan-renderer/texture/texture.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/texture/texture.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 void InexorTexture::destroy_texture(const VkDevice &device, const VmaAllocator &vma_allocator) {
     vkDestroySampler(device, sampler, nullptr);
@@ -37,5 +36,4 @@ void InexorTexture::update_descriptor() {
     descriptor.imageLayout = image_layout;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/texture/texture.hpp
+++ b/src/vulkan-renderer/texture/texture.hpp
@@ -6,8 +6,7 @@
 
 #include <string>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class InexorTexture {
 public:
@@ -64,5 +63,4 @@ public:
     void update_descriptor();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/thread-pool/thread_pool.cpp
+++ b/src/vulkan-renderer/thread-pool/thread_pool.cpp
@@ -101,4 +101,4 @@ void InexorThreadPool::start_thread() {
         }));
 }
 
-}; // namespace inexor
+} // namespace inexor

--- a/src/vulkan-renderer/thread-pool/thread_pool.hpp
+++ b/src/vulkan-renderer/thread-pool/thread_pool.hpp
@@ -163,4 +163,4 @@ auto InexorThreadPool::execute(F function, Args &&... args) {
     return std::move(future);
 }
 
-}; // namespace inexor
+} // namespace inexor

--- a/src/vulkan-renderer/time-step/time_step.cpp
+++ b/src/vulkan-renderer/time-step/time_step.cpp
@@ -1,7 +1,6 @@
 ﻿#include "vulkan-renderer/time-step/time_step.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 InexorTimeStep::InexorTimeStep() {
     initialisation_time = std::chrono::high_resolution_clock::now();
@@ -27,5 +26,4 @@ float InexorTimeStep::get_time_step_since_initialisation() {
     return time_duration;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/time-step/time_step.hpp
+++ b/src/vulkan-renderer/time-step/time_step.hpp
@@ -2,8 +2,7 @@
 
 #include <chrono>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class InexorTimeStep
 /// @brief Responsible for calculating the amount of time which has passed between rendering two frames.
@@ -31,5 +30,4 @@ public:
     float get_time_step_since_initialisation();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/tools/argument-parser/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/argument-parser/cla_parser.cpp
@@ -1,8 +1,6 @@
 ﻿#include "vulkan-renderer/tools/argument-parser/cla_parser.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
-namespace tools {
+namespace inexor::vulkan_renderer::tools {
 
 bool InexorCommandLineArgumentParser::does_command_line_argument_template_exist(const std::string argument_name) {
     for (const auto &accepted_argument : list_of_accepted_command_line_arguments) {
@@ -169,6 +167,4 @@ const std::optional<std::uint32_t> InexorCommandLineArgumentParser::get_command_
     return std::nullopt;
 }
 
-}; // namespace tools
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/argument-parser/cla_parser.hpp
+++ b/src/vulkan-renderer/tools/argument-parser/cla_parser.hpp
@@ -7,9 +7,7 @@
 
 #include <spdlog/spdlog.h>
 
-namespace inexor {
-namespace vulkan_renderer {
-namespace tools {
+namespace inexor::vulkan_renderer::tools {
 
 /// @brief Defines the type of an accepted command line argument.
 enum INEXOR_COMMAND_LINE_ARGUMENT_TYPE {
@@ -128,6 +126,4 @@ public:
     const std::optional<std::uint32_t> get_command_line_argument_uint32_t(const std::string &argument_name);
 };
 
-}; // namespace tools
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/file-loader/File.cpp
+++ b/src/vulkan-renderer/tools/file-loader/File.cpp
@@ -1,9 +1,7 @@
 #include "vulkan-renderer/tools/file-loader/File.hpp"
 using namespace std;
 
-namespace inexor {
-namespace vulkan_renderer {
-namespace tools {
+namespace inexor::vulkan_renderer::tools {
 
 const std::size_t InexorFile::get_file_size() const { return file_size; }
 
@@ -44,6 +42,4 @@ bool InexorFile::load_file(const std::string &file_name) {
     return true;
 }
 
-}; // namespace tools
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/file-loader/File.hpp
+++ b/src/vulkan-renderer/tools/file-loader/File.hpp
@@ -8,9 +8,7 @@
 
 #include <cassert>
 
-namespace inexor {
-namespace vulkan_renderer {
-namespace tools {
+namespace inexor::vulkan_renderer::tools {
 
 /// @class InexorFile
 /// @brief A class for loading files into memory.
@@ -39,6 +37,4 @@ public:
     bool load_file(const std::string &file_name);
 };
 
-}; // namespace tools
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.cpp
+++ b/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.cpp
@@ -1,7 +1,6 @@
 #include "vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 VkResult VulkanUniformBufferManager::init(const VkDevice &device, const VmaAllocator &vma_allocator,
                                           const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
@@ -159,5 +158,4 @@ VkResult VulkanUniformBufferManager::shutdown_uniform_buffers() {
     return VK_SUCCESS;
 }
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.hpp
+++ b/src/vulkan-renderer/uniform-buffer-manager/uniform_buffer_manager.hpp
@@ -19,8 +19,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 class VulkanUniformBufferManager : public ManagerClassTemplate<InexorUniformBuffer> {
 private:
@@ -85,5 +84,4 @@ public:
     VkResult shutdown_uniform_buffers();
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/uniform-buffer/standard_ubo.hpp
+++ b/src/vulkan-renderer/uniform-buffer/standard_ubo.hpp
@@ -2,8 +2,7 @@
 
 #include <glm/glm.hpp>
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 /// @class UniformBufferObject
 /// @note We can exactly match the definition in the shader using data types in GLM.
@@ -15,5 +14,4 @@ struct UniformBufferObject {
     glm::mat4 proj;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/uniform-buffer/uniform_buffer.hpp
+++ b/src/vulkan-renderer/uniform-buffer/uniform_buffer.hpp
@@ -2,8 +2,7 @@
 
 #include "vulkan-renderer/gpu-memory-buffer/gpu_memory_buffer.hpp"
 
-namespace inexor {
-namespace vulkan_renderer {
+namespace inexor::vulkan_renderer {
 
 ///
 ///
@@ -16,5 +15,4 @@ struct InexorUniformBuffer : public InexorBuffer {
     VkDescriptorSet descriptor_set;
 };
 
-}; // namespace vulkan_renderer
-}; // namespace inexor
+} // namespace vulkan_renderer


### PR DESCRIPTION
Modifies all namespace declarations to: 

- use c++ 17 nested namespaces
- not end in a trailing semicolon