### PR TITLE
Format fix and improve readability

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,3 +3,9 @@ BasedOnStyle: LLVM
 AccessModifierOffset: -4
 ColumnLimit: 160
 IndentWidth: 4
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes

--- a/include/inexor/vulkan-renderer/gltf-model/mesh.hpp
+++ b/include/inexor/vulkan-renderer/gltf-model/mesh.hpp
@@ -31,7 +31,9 @@ struct Mesh {
 
     /// @brief Sets the model matrix.
     /// @param mat [in] The input matrix.
-    void set_matrix(const glm::mat4 &mat) { uniform_block.matrix = mat; }
+    void set_matrix(const glm::mat4 &mat) {
+        uniform_block.matrix = mat;
+    }
 
     /// @brief Sets the bounding box of the model.
     /// @param min [in] The minimum vector (edge of the bounding box)

--- a/include/inexor/vulkan-renderer/gltf-model/node.hpp
+++ b/include/inexor/vulkan-renderer/gltf-model/node.hpp
@@ -56,7 +56,9 @@ struct ModelNode {
 
     BoundingBox aabb;
 
-    glm::mat4 localMatrix() { return glm::translate(glm::mat4(1.0f), translation) * glm::mat4(rotation) * glm::scale(glm::mat4(1.0f), scale) * matrix; }
+    glm::mat4 localMatrix() {
+        return glm::translate(glm::mat4(1.0f), translation) * glm::mat4(rotation) * glm::scale(glm::mat4(1.0f), scale) * matrix;
+    }
 
     glm::mat4 getMatrix() {
         glm::mat4 m = localMatrix();

--- a/include/inexor/vulkan-renderer/manager_template.hpp
+++ b/include/inexor/vulkan-renderer/manager_template.hpp
@@ -12,7 +12,8 @@ namespace inexor::vulkan_renderer {
 /// key/value pairs for various data types. In most cases, std::string is the
 /// key. The value however can be of an arbitrary data type. This template class
 /// bundles common add/get/update/delete methods in a thread safe enviroment.
-template <typename T> class ManagerClassTemplate {
+template <typename T>
+class ManagerClassTemplate {
 private:
     std::unordered_map<std::string, std::shared_ptr<T>> stored_types;
 

--- a/include/inexor/vulkan-renderer/texture_manager.hpp
+++ b/include/inexor/vulkan-renderer/texture_manager.hpp
@@ -60,8 +60,8 @@ private:
     /// @param buffer_usage [in] The buffer usage flags.
     /// @param memory_usage [in] The VMA memory usage flags.
     /// @param image_usage_flags [in] The image usage flags.
-    VkResult create_texture_image(std::shared_ptr<Texture> texture, const VkFormat &format, const VkImageTiling &tiling,
-                                  const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage, const VkImageUsageFlags &image_usage_flags);
+    VkResult create_texture_image(std::shared_ptr<Texture> texture, const VkFormat &format, const VkImageTiling &tiling, const VkBufferUsageFlags &buffer_usage,
+                                  const VmaMemoryUsage &memory_usage, const VkImageUsageFlags &image_usage_flags);
 
     /// @brief Creates a texture image view.
     /// @param texture [in] The texture for which a buffer will be created.
@@ -102,8 +102,7 @@ public:
     /// @param internal_texture_name [in] The internal name which will be used inside the engine.
     /// @param texture_file_name [in] The name of the texture file.
     /// @param output_texture [out] The texture which will be created. It can be nullptr if creating the texture fails.
-    VkResult create_texture_from_file(const std::string &internal_texture_name, const std::string &texture_file_name,
-                                      std::shared_ptr<Texture> output_texture);
+    VkResult create_texture_from_file(const std::string &internal_texture_name, const std::string &texture_file_name, std::shared_ptr<Texture> output_texture);
 
     /// @brief Create a texture from an unsigned char buffer.
     /// @param internal_texture_name [in] The internal name which will be used inside the engine.
@@ -117,8 +116,7 @@ public:
     /// @param internal_texture_name [in] The internal name which will be used inside the engine.
     /// @param gltf_image [in] The glTF 2.0 image.
     /// @param output_texture [out] The texture which will be created. It can be nullptr if creating the texture fails.
-    VkResult create_texture_from_glTF2_image(const std::string &internal_texture_name, tinygltf::Image &gltf_image,
-                                             std::shared_ptr<Texture> output_texture);
+    VkResult create_texture_from_glTF2_image(const std::string &internal_texture_name, tinygltf::Image &gltf_image, std::shared_ptr<Texture> output_texture);
 
     /// @brief Returns a certain texture by internal name (key).
     /// @param internal_texture_name [in] The internal name of the texture

--- a/include/inexor/vulkan-renderer/thread_pool.hpp
+++ b/include/inexor/vulkan-renderer/thread_pool.hpp
@@ -125,8 +125,7 @@ private:
     std::atomic<bool> stop_threads = false;
 };
 
-template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int>>
-auto ThreadPool::execute(F function, Args &&... args) {
+template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int>> auto ThreadPool::execute(F function, Args &&... args) {
     spdlog::warn("Executing task from task list.");
 
     // Lock the task list so we can add the new task.

--- a/include/inexor/vulkan-renderer/thread_pool.hpp
+++ b/include/inexor/vulkan-renderer/thread_pool.hpp
@@ -55,7 +55,8 @@ public:
 
     /// @brief Executes a task from the tasklist.
     /// @note We only accept invokable arguments in the template.
-    template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int> = 0> auto execute(F, Args &&...);
+    template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int> = 0>
+    auto execute(F, Args &&...);
 
 private:
     //_task_container_base and _task_container exist simply as a wrapper around a
@@ -81,7 +82,8 @@ private:
     ///
     ///
     ///
-    template <typename F> class TaskContainer : public TaskContainerBase {
+    template <typename F>
+    class TaskContainer : public TaskContainerBase {
     public:
         // here, std::forward is needed because we need the construction of _f *not* to
         //  bind an lvalue reference - it is not a guarantee that an object of type F is
@@ -95,14 +97,17 @@ private:
         ///
         ///
         ///
-        void operator()() override { _f(); }
+        void operator()() override {
+            _f();
+        }
 
     private:
         F _f;
     };
 
     /// @brief Returns a unique pointer to a Task container that wraps around a given function
-    template <typename Task> static std::unique_ptr<TaskContainerBase> allocate_task_container(Task &&f) {
+    template <typename Task>
+    static std::unique_ptr<TaskContainerBase> allocate_task_container(Task &&f) {
         spdlog::debug("Allocating task container.");
 
         // in the construction of the _task_container, f must be std::forward'ed because
@@ -125,7 +130,8 @@ private:
     std::atomic<bool> stop_threads = false;
 };
 
-template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int>> auto ThreadPool::execute(F function, Args &&... args) {
+template <typename F, typename... Args, std::enable_if_t<std::is_invocable_v<F &&, Args &&...>, int>>
+auto ThreadPool::execute(F function, Args &&... args) {
     spdlog::warn("Executing task from task list.");
 
     // Lock the task list so we can add the new task.

--- a/include/inexor/vulkan-renderer/uniform_buffer_manager.hpp
+++ b/include/inexor/vulkan-renderer/uniform_buffer_manager.hpp
@@ -75,8 +75,7 @@ public:
     /// @param uniform_buffer_new_data_source [in] A pointer to the new uniform buffer data.
     /// @param uniform_buffer_size [in] The size of the uniform buffer to copy from.
     /// @warning The size of the source memory must not be greater than the size of the target memory!
-    VkResult update_uniform_buffer(std::shared_ptr<UniformBuffer> &uniform_buffer, void *uniform_buffer_new_data_source,
-                                   const std::size_t uniform_buffer_size);
+    VkResult update_uniform_buffer(std::shared_ptr<UniformBuffer> &uniform_buffer, void *uniform_buffer_new_data_source, const std::size_t uniform_buffer_size);
 
     /// @brief Destroys all uniform buffers.
     VkResult shutdown_uniform_buffers();

--- a/src/vulkan-renderer/bezier_curve.cpp
+++ b/src/vulkan-renderer/bezier_curve.cpp
@@ -19,16 +19,22 @@ float BezierCurve::bernstein_polynomial(uint32_t n, uint32_t k, const float curv
     return binomial_coefficient(n, k) * static_cast<float>(pow(curve_precision, k)) * static_cast<float>(pow(1 - curve_precision, n - k)) * coordinate_value;
 }
 
-void BezierCurve::clear_output() { std::vector<BezierOutputPoint> output_points; }
+void BezierCurve::clear_output() {
+    std::vector<BezierOutputPoint> output_points;
+}
 
-void BezierCurve::clear_input() { std::vector<BezierInputPoint> input_points; }
+void BezierCurve::clear_input() {
+    std::vector<BezierInputPoint> input_points;
+}
 
 void BezierCurve::clear() {
     clear_input();
     clear_output();
 }
 
-bool BezierCurve::is_curve_generated() { return curve_generated; }
+bool BezierCurve::is_curve_generated() {
+    return curve_generated;
+}
 
 std::vector<BezierOutputPoint> BezierCurve::get_output_points() {
     assert(curve_generated);

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -12,7 +12,9 @@ void Camera::set_direction(const glm::vec3 &direction) {
     update_matrices();
 }
 
-glm::vec3 Camera::get_direction() const { return this->direction; }
+glm::vec3 Camera::get_direction() const {
+    return this->direction;
+}
 
 void Camera::start_camera_movement(bool moving_backwards) {
     this->camera_is_moving = true;
@@ -38,23 +40,41 @@ void Camera::update(const float timestep) {
     }
 }
 
-void Camera::move_forwards() { this->position += (camera_speed * timestep * direction); }
+void Camera::move_forwards() {
+    this->position += (camera_speed * timestep * direction);
+}
 
-void Camera::move_backwards() { this->position -= (camera_speed * timestep * direction); }
+void Camera::move_backwards() {
+    this->position -= (camera_speed * timestep * direction);
+}
 
-glm::vec3 Camera::get_position() const { return this->position; }
+glm::vec3 Camera::get_position() const {
+    return this->position;
+}
 
-void Camera::set_yaw(const float yaw) { this->yaw = yaw; }
+void Camera::set_yaw(const float yaw) {
+    this->yaw = yaw;
+}
 
-void Camera::set_pitch(const float pitch) { this->pitch = pitch; }
+void Camera::set_pitch(const float pitch) {
+    this->pitch = pitch;
+}
 
-void Camera::set_roll(const float roll) { this->roll = roll; }
+void Camera::set_roll(const float roll) {
+    this->roll = roll;
+}
 
-float Camera::get_yaw() const { return this->yaw; }
+float Camera::get_yaw() const {
+    return this->yaw;
+}
 
-float Camera::get_pitch() const { return this->pitch; }
+float Camera::get_pitch() const {
+    return this->pitch;
+}
 
-float Camera::get_roll() const { return this->roll; }
+float Camera::get_roll() const {
+    return this->roll;
+}
 
 void Camera::set_rotation(const float yaw, const float pitch, const float roll) {
     this->yaw = yaw;
@@ -63,11 +83,17 @@ void Camera::set_rotation(const float yaw, const float pitch, const float roll) 
     // TODO: Update Matrices!
 }
 
-void Camera::move_camera_x(const float x) { this->position.x += (camera_speed * timestep * x); }
+void Camera::move_camera_x(const float x) {
+    this->position.x += (camera_speed * timestep * x);
+}
 
-void Camera::move_camera_y(const float y) { this->position.y += (camera_speed * timestep * y); }
+void Camera::move_camera_y(const float y) {
+    this->position.y += (camera_speed * timestep * y);
+}
 
-void Camera::move_camera_z(const float z) { this->position.z += (camera_speed * timestep * z); }
+void Camera::move_camera_z(const float z) {
+    this->position.z += (camera_speed * timestep * z);
+}
 
 void Camera::set_speed(const float camera_speed) {
     assert(camera_speed > 0.0f);
@@ -75,35 +101,45 @@ void Camera::set_speed(const float camera_speed) {
     update_matrices();
 }
 
-float Camera::get_speed() const { return this->camera_speed; }
+float Camera::get_speed() const {
+    return this->camera_speed;
+}
 
 void Camera::set_near_plane(const float near_plane) {
     assert(near_plane > 0.0f);
     this->near_plane = near_plane;
 }
 
-float Camera::get_near_plane() const { return this->near_plane; }
+float Camera::get_near_plane() const {
+    return this->near_plane;
+}
 
 void Camera::set_far_plane(const float far_plane) {
     assert(far_plane > 0.0f);
     this->far_plane = far_plane;
 }
 
-float Camera::get_far_plane() const { return this->far_plane; }
+float Camera::get_far_plane() const {
+    return this->far_plane;
+}
 
 void Camera::set_zoom(const float zoom) {
     assert(zoom > 0.0f);
     this->zoom = zoom;
 }
 
-float Camera::get_zoom() const { return zoom; }
+float Camera::get_zoom() const {
+    return zoom;
+}
 
 void Camera::set_aspect_ratio(const float aspect_ratio) {
     assert(aspect_ratio > 0.0f);
     this->aspect_ratio = aspect_ratio;
 }
 
-float Camera::get_aspect_ratio() const { return this->aspect_ratio; }
+float Camera::get_aspect_ratio() const {
+    return this->aspect_ratio;
+}
 
 void Camera::update_matrices() {
     update_view_matrix();
@@ -115,16 +151,28 @@ void Camera::update_view_matrix() {
     ;
 }
 
-void Camera::update_projection_matrix() { this->projection_matrix = glm::perspective(glm::radians(45.0f), aspect_ratio, near_plane, far_plane); }
+void Camera::update_projection_matrix() {
+    this->projection_matrix = glm::perspective(glm::radians(45.0f), aspect_ratio, near_plane, far_plane);
+}
 
-glm::mat4 Camera::get_view_matrix() { return this->view_matrix; }
+glm::mat4 Camera::get_view_matrix() {
+    return this->view_matrix;
+}
 
-glm::mat4 Camera::get_projection_matrix() { return this->projection_matrix; }
+glm::mat4 Camera::get_projection_matrix() {
+    return this->projection_matrix;
+}
 
-glm::vec3 Camera::get_up() const { return this->world_up; }
+glm::vec3 Camera::get_up() const {
+    return this->world_up;
+}
 
-glm::vec3 Camera::get_front() const { return this->world_front; }
+glm::vec3 Camera::get_front() const {
+    return this->world_front;
+}
 
-glm::vec3 Camera::get_right() const { return this->world_right; }
+glm::vec3 Camera::get_right() const {
+    return this->world_right;
+}
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/descriptor_manager.cpp
+++ b/src/vulkan-renderer/descriptor_manager.cpp
@@ -3,7 +3,7 @@
 namespace inexor::vulkan_renderer {
 
 VkResult DescriptorManager::init(const VkDevice &device, const std::size_t number_of_images_in_swapchain,
-                                       const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
+                                 const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
     assert(!descriptor_manager_initialised);
     assert(device);
     assert(debug_marker_manager);
@@ -19,7 +19,7 @@ VkResult DescriptorManager::init(const VkDevice &device, const std::size_t numbe
 }
 
 VkResult DescriptorManager::create_descriptor_pool(const std::string &internal_descriptor_pool_name, const std::vector<VkDescriptorPoolSize> &pool_sizes,
-                                                         std::shared_ptr<DescriptorPool> &descriptor_pool) {
+                                                   std::shared_ptr<DescriptorPool> &descriptor_pool) {
     assert(descriptor_manager_initialised);
     assert(number_of_images_in_swapchain > 0);
     assert(!internal_descriptor_pool_name.empty());
@@ -60,7 +60,7 @@ VkResult DescriptorManager::create_descriptor_pool(const std::string &internal_d
 }
 
 VkResult DescriptorManager::create_descriptor_bundle(const std::string &internal_descriptor_name, std::shared_ptr<DescriptorPool> &descriptor_pool,
-                                                           std::shared_ptr<DescriptorBundle> &descriptor_bundle) {
+                                                     std::shared_ptr<DescriptorBundle> &descriptor_bundle) {
     assert(descriptor_manager_initialised);
     assert(number_of_images_in_swapchain > 0);
     assert(!internal_descriptor_name.empty());
@@ -84,7 +84,7 @@ VkResult DescriptorManager::create_descriptor_bundle(const std::string &internal
 }
 
 VkResult DescriptorManager::add_descriptor_set_layout_binding(std::shared_ptr<DescriptorBundle> descriptor_bundle,
-                                                                    const VkDescriptorSetLayoutBinding &descriptor_set_layout_binding) {
+                                                              const VkDescriptorSetLayoutBinding &descriptor_set_layout_binding) {
     assert(descriptor_manager_initialised);
     assert(descriptor_bundle);
 
@@ -96,8 +96,7 @@ VkResult DescriptorManager::add_descriptor_set_layout_binding(std::shared_ptr<De
     return VK_SUCCESS;
 }
 
-VkResult DescriptorManager::add_write_descriptor_set(std::shared_ptr<DescriptorBundle> descriptor_bundle,
-                                                           const VkWriteDescriptorSet &write_descriptor_set) {
+VkResult DescriptorManager::add_write_descriptor_set(std::shared_ptr<DescriptorBundle> descriptor_bundle, const VkWriteDescriptorSet &write_descriptor_set) {
     assert(descriptor_manager_initialised);
     assert(descriptor_bundle);
 

--- a/src/vulkan-renderer/gltf-model/manager.cpp
+++ b/src/vulkan-renderer/gltf-model/manager.cpp
@@ -7,9 +7,8 @@
 namespace inexor::vulkan_renderer::gltf_model {
 
 VkResult Manager::init(const VkDevice &device, const std::shared_ptr<VulkanTextureManager> texture_manager,
-                                  const std::shared_ptr<UniformBufferManager> uniform_buffer_manager,
-                                  const std::shared_ptr<MeshBufferManager> mesh_buffer_manager,
-                                  const std::shared_ptr<DescriptorManager> descriptor_manager) {
+                       const std::shared_ptr<UniformBufferManager> uniform_buffer_manager, const std::shared_ptr<MeshBufferManager> mesh_buffer_manager,
+                       const std::shared_ptr<DescriptorManager> descriptor_manager) {
     assert(texture_manager);
     assert(uniform_buffer_manager);
     assert(mesh_buffer_manager);
@@ -30,8 +29,7 @@ VkResult Manager::init(const VkDevice &device, const std::shared_ptr<VulkanTextu
     return VK_SUCCESS;
 }
 
-void Manager::load_node(std::shared_ptr<ModelNode> parent, const tinygltf::Node &node, uint32_t node_index, std::shared_ptr<Model> model,
-                                   float globalscale) {
+void Manager::load_node(std::shared_ptr<ModelNode> parent, const tinygltf::Node &node, uint32_t node_index, std::shared_ptr<Model> model, float globalscale) {
     assert(model_manager_initialised);
     assert(texture_manager);
     assert(uniform_buffer_manager);
@@ -770,8 +768,8 @@ VkResult Manager::load_model_from_file(const std::string &file_name, std::shared
     if (number_of_indices > 0) {
         // Create a vertex buffer with an index buffer, as it should always be!
         VkResult result = mesh_buffer_manager->create_vertex_buffer_with_index_buffer(
-            file_name, new_model->vertex_buffer_cache.data(), sizeof(ModelVertex), new_model->vertex_buffer_cache.size(),
-            new_model->index_buffer_cache.data(), sizeof(uint32_t), number_of_indices, new_model->mesh);
+            file_name, new_model->vertex_buffer_cache.data(), sizeof(ModelVertex), new_model->vertex_buffer_cache.size(), new_model->index_buffer_cache.data(),
+            sizeof(uint32_t), number_of_indices, new_model->mesh);
         vulkan_error_check(result);
     } else {
         // Always make sure you use a model which has indices.
@@ -788,8 +786,7 @@ VkResult Manager::load_model_from_file(const std::string &file_name, std::shared
     return VK_SUCCESS;
 }
 
-void Manager::render_node(std::shared_ptr<ModelNode> node, VkCommandBuffer commandBuffer, VkPipelineLayout pipeline_layout,
-                                     std::size_t current_image_index) {
+void Manager::render_node(std::shared_ptr<ModelNode> node, VkCommandBuffer commandBuffer, VkPipelineLayout pipeline_layout, std::size_t current_image_index) {
     assert(model_manager_initialised);
     assert(texture_manager);
     assert(uniform_buffer_manager);
@@ -831,7 +828,7 @@ void Manager::render_node(std::shared_ptr<ModelNode> node, VkCommandBuffer comma
 }
 
 VkResult Manager::render_model(const std::string &internal_model_name, VkCommandBuffer commandBuffer, VkPipelineLayout pipeline_layout,
-                                          std::size_t current_image_index) {
+                               std::size_t current_image_index) {
     assert(model_manager_initialised);
     assert(texture_manager);
     assert(uniform_buffer_manager);
@@ -861,8 +858,7 @@ VkResult Manager::render_model(const std::string &internal_model_name, VkCommand
     return VK_SUCCESS;
 }
 
-void Manager::calculate_bounding_box(std::shared_ptr<Model> model, std::shared_ptr<ModelNode> node,
-                                                std::shared_ptr<ModelNode> parent) {
+void Manager::calculate_bounding_box(std::shared_ptr<Model> model, std::shared_ptr<ModelNode> node, std::shared_ptr<ModelNode> parent) {
     assert(model_manager_initialised);
     assert(texture_manager);
     assert(uniform_buffer_manager);

--- a/src/vulkan-renderer/gltf-model/manager.cpp
+++ b/src/vulkan-renderer/gltf-model/manager.cpp
@@ -1066,7 +1066,9 @@ VkResult Manager::render_all_models(VkCommandBuffer command_buffer, VkPipelineLa
     return VK_SUCCESS;
 }
 
-VkResult Manager::create_model_descriptors(const std::size_t number_of_images_in_swapchain) { return VK_SUCCESS; }
+VkResult Manager::create_model_descriptors(const std::size_t number_of_images_in_swapchain) {
+    return VK_SUCCESS;
+}
 
 VkResult Manager::setup_node_descriptor_set(std::shared_ptr<ModelNode> node) {
     if (node->mesh) {

--- a/src/vulkan-renderer/mesh_buffer_manager.cpp
+++ b/src/vulkan-renderer/mesh_buffer_manager.cpp
@@ -3,7 +3,7 @@
 namespace inexor::vulkan_renderer {
 
 VkResult MeshBufferManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager,
-                                       const VmaAllocator &vma_allocator, const uint32_t data_transfer_queue_family_index, const VkQueue &data_transfer_queue) {
+                                 const VmaAllocator &vma_allocator, const uint32_t data_transfer_queue_family_index, const VkQueue &data_transfer_queue) {
     assert(device);
     assert(vma_allocator);
     assert(data_transfer_queue);
@@ -28,7 +28,7 @@ VkResult MeshBufferManager::init(const VkDevice &device, const std::shared_ptr<V
 }
 
 VkResult MeshBufferManager::create_buffer(std::string buffer_description, Buffer &buffer_object, const VkDeviceSize &buffer_size,
-                                                const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage) {
+                                          const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage) {
     assert(mesh_buffer_manager_initialised);
     assert(vma_allocator);
     assert(debug_marker_manager);
@@ -122,9 +122,8 @@ VkResult MeshBufferManager::upload_data_to_gpu() {
     return result;
 }
 
-VkResult MeshBufferManager::create_vertex_buffer(const std::string &internal_mesh_buffer_name, const void *vertices,
-                                                       const std::size_t size_of_vertex_structure, const std::size_t number_of_vertices,
-                                                       std::shared_ptr<MeshBuffer> &output_mesh_buffer) {
+VkResult MeshBufferManager::create_vertex_buffer(const std::string &internal_mesh_buffer_name, const void *vertices, const std::size_t size_of_vertex_structure,
+                                                 const std::size_t number_of_vertices, std::shared_ptr<MeshBuffer> &output_mesh_buffer) {
     assert(mesh_buffer_manager_initialised);
     assert(size_of_vertex_structure > 0);
     assert(number_of_vertices > 0);
@@ -270,10 +269,9 @@ VkResult MeshBufferManager::create_vertex_buffer(const std::string &internal_mes
 }
 
 VkResult MeshBufferManager::create_vertex_buffer_with_index_buffer(const std::string &internal_mesh_buffer_name, const void *vertices,
-                                                                         const std::size_t size_of_vertex_structure, const std::size_t number_of_vertices,
-                                                                         const void *indices, const std::size_t size_of_index_structure,
-                                                                         const std::size_t number_of_indices,
-                                                                         std::shared_ptr<MeshBuffer> &mesh_buffer_output) {
+                                                                   const std::size_t size_of_vertex_structure, const std::size_t number_of_vertices,
+                                                                   const void *indices, const std::size_t size_of_index_structure,
+                                                                   const std::size_t number_of_indices, std::shared_ptr<MeshBuffer> &mesh_buffer_output) {
     assert(mesh_buffer_manager_initialised);
     assert(!internal_mesh_buffer_name.empty());
     assert(vertices);

--- a/src/vulkan-renderer/tools/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/cla_parser.cpp
@@ -113,7 +113,9 @@ void CommandLineArgumentParser::parse_command_line_arguments(std::size_t argumen
     }
 }
 
-const std::int64_t CommandLineArgumentParser::get_number_of_parsed_command_line_arguments() { return number_of_parsed_command_line_arguments; }
+const std::int64_t CommandLineArgumentParser::get_number_of_parsed_command_line_arguments() {
+    return number_of_parsed_command_line_arguments;
+}
 
 const std::optional<bool> CommandLineArgumentParser::get_command_line_argument_bool(const std::string &argument_name) {
     if (does_command_line_argument_template_exist(argument_name)) {

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -2,9 +2,13 @@
 
 namespace inexor::vulkan_renderer::tools {
 
-const std::size_t File::get_file_size() const { return file_size; }
+const std::size_t File::get_file_size() const {
+    return file_size;
+}
 
-const std::vector<char> &File::get_file_data() const { return file_data; }
+const std::vector<char> &File::get_file_data() const {
+    return file_data;
+}
 
 bool File::load_file(const std::string &file_name) {
     assert(file_name.size() > 0);

--- a/src/vulkan-renderer/uniform_buffer_manager.cpp
+++ b/src/vulkan-renderer/uniform_buffer_manager.cpp
@@ -3,7 +3,7 @@
 namespace inexor::vulkan_renderer {
 
 VkResult UniformBufferManager::init(const VkDevice &device, const VmaAllocator &vma_allocator,
-                                          const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
+                                    const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {
     assert(device);
     assert(vma_allocator);
     assert(debug_marker_manager);
@@ -25,7 +25,7 @@ VkResult UniformBufferManager::init(const VkDevice &device, const VmaAllocator &
 }
 
 VkResult UniformBufferManager::create_buffer(std::string &internal_buffer_name, const VkDeviceSize &buffer_size,
-                                                   std::shared_ptr<UniformBuffer> &buffer_object) {
+                                             std::shared_ptr<UniformBuffer> &buffer_object) {
     assert(uniform_buffer_initialised);
     assert(vma_allocator);
     assert(debug_marker_manager);
@@ -50,7 +50,7 @@ VkResult UniformBufferManager::create_buffer(std::string &internal_buffer_name, 
 }
 
 VkResult UniformBufferManager::create_uniform_buffer(const std::string &internal_uniform_buffer_name, const VkDeviceSize &uniform_buffer_size,
-                                                           std::shared_ptr<UniformBuffer> &uniform_buffer) {
+                                                     std::shared_ptr<UniformBuffer> &uniform_buffer) {
     assert(uniform_buffer_initialised);
     assert(uniform_buffer_size > 0);
     assert(!internal_uniform_buffer_name.empty());
@@ -84,7 +84,7 @@ VkResult UniformBufferManager::create_uniform_buffer(const std::string &internal
 }
 
 VkResult UniformBufferManager::update_uniform_buffer(const std::string &internal_uniform_buffer_name, void *data_source_address,
-                                                           const std::size_t uniform_buffer_size) {
+                                                     const std::size_t uniform_buffer_size) {
     assert(uniform_buffer_initialised);
     assert(!internal_uniform_buffer_name.empty());
     assert(data_source_address);
@@ -114,7 +114,7 @@ VkResult UniformBufferManager::update_uniform_buffer(const std::string &internal
 }
 
 VkResult UniformBufferManager::update_uniform_buffer(std::shared_ptr<UniformBuffer> &uniform_buffer, void *uniform_buffer_new_data_source,
-                                                           const std::size_t uniform_buffer_size) {
+                                                     const std::size_t uniform_buffer_size) {
     assert(uniform_buffer_initialised);
     assert(uniform_buffer_new_data_source);
     assert(uniform_buffer_size > 0);


### PR DESCRIPTION
Format changes:
```
AllowShortBlocksOnASingleLine: Empty
AllowShortFunctionsOnASingleLine: Empty
AllowShortCaseLabelsOnASingleLine: false
AllowShortIfStatementsOnASingleLine: Never
AllowShortLoopsOnASingleLine: false
AlwaysBreakTemplateDeclarations: Yes
```
It disallows one liners with code inside and the template decleration gets his own line.
I think this improves the readability a lot, because one liner are now empty, less search where the implementation begins.

@yeetari @IAmNotHanni 