### PR TITLE
[code] Remove Application global from example

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -7,8 +7,6 @@
 
 using namespace inexor::vulkan_renderer;
 
-Application renderer;
-
 int main(int argc, char *argv[]) {
     spdlog::init_thread_pool(8192, 2);
 
@@ -23,9 +21,9 @@ int main(int argc, char *argv[]) {
     spdlog::set_default_logger(vulkan_renderer_log);
 
     spdlog::debug("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
-
     spdlog::debug("Parsing command line arguments.");
 
+    Application renderer;
     // We use some simple command line argument parser we wrote ourselves.
     renderer.parse_command_line_arguments(argc, argv);
 

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -107,7 +107,7 @@ protected:
 
     VkPresentModeKHR selected_present_mode;
 
-    VkSwapchainKHR swapchain;
+    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
 
     uint32_t number_of_images_in_swapchain = 0;
 


### PR DESCRIPTION
Moved `renderer` in `example/main.cpp` to be on the stack rather than a global variable. Also had to make sure that `VulkanRenderer::swapchain` was always being initialised to `VK_NULL_HANDLE` as it was left in an undefined state which caused issues when it was meant to be null when being passed into `VkSwapchainCreateInfoKHR`.