### PR TITLE
[ci] Cleanup and fix clang build

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -10,15 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-          name: "Ubuntu CLang",
-          artifact: "linux-clang.tar.xz",
-          build_type: "Release", cc: "clang", cxx: "clang++",
-          vulkan_version: "1.2.131.1",
-          vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
-          conan_path: "$HOME/.local/bin",
-        }
-        - {
+          - {
+            name: "Ubuntu CLang",
+            artifact: "linux-clang.tar.xz",
+            build_type: "Release", cc: "clang", cxx: "clang++",
+            vulkan_version: "1.2.131.1",
+            vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
+            conan_path: "$HOME/.local/bin",
+          }
+          - {
             name: "Ubuntu GCC",
             artifact: "linux-gcc.tar.xz",
             build_type: "Release", cc: "gcc", cxx: "g++",
@@ -28,60 +28,60 @@ jobs:
           }
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
-    - name: Update environment
-      shell: bash
-      run: |
-        sudo apt update -qq
-        sudo apt install -y libglm-dev libxcb-dri3-0 libxcb-present0 libpciaccess0 libpng-dev libxcb-keysyms1-dev libxcb-dri3-dev libx11-dev  libmirclient-dev libwayland-dev libxrandr-dev libxcb-ewmh-dev
-        sudo apt install -y cmake ninja-build clang-tidy
-        pip3 install wheel setuptools
-        pip3 install conan mako
+      - name: Update environment
+        shell: bash
+        run: |
+          sudo apt update -qq
+          sudo apt install -y libglm-dev libxcb-dri3-0 libxcb-present0 libpciaccess0 libpng-dev libxcb-keysyms1-dev libxcb-dri3-dev libx11-dev  libmirclient-dev libwayland-dev libxrandr-dev libxcb-ewmh-dev
+          sudo apt install -y cmake ninja-build clang-tidy
+          pip3 install wheel setuptools
+          pip3 install conan mako
 
-    - name: Install Vulkan SDK
-      shell: bash
-      run: |
-        curl -L -S -o vulkansdk.tar.gz https://sdk.lunarg.com/sdk/download/${{ matrix.config.vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ matrix.config.vulkan_version }}.tar.gz
-        mkdir "${{ matrix.config.vulkan_sdk }}"
-        tar zxf vulkansdk.tar.gz -C "${{ matrix.config.vulkan_sdk }}"
+      - name: Install Vulkan SDK
+        shell: bash
+        run: |
+          curl -L -S -o vulkansdk.tar.gz https://sdk.lunarg.com/sdk/download/${{ matrix.config.vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ matrix.config.vulkan_version }}.tar.gz
+          mkdir "${{ matrix.config.vulkan_sdk }}"
+          tar zxf vulkansdk.tar.gz -C "${{ matrix.config.vulkan_sdk }}"
 
-    - name: Create CMake
-      shell: bash
-      run: |
-        export CC=${{ matrix.config.cc }}
-        export CXX=${{ matrix.config.cxx }}
-        export PATH="${{ matrix.config.conan_path }}":$PATH
-        export VULKAN_SDK="${{ matrix.config.vulkan_sdk }}/${{ matrix.config.vulkan_version }}/x86_64"
-        export PATH=$VULKAN_SDK/bin:$PATH
-        export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
-        export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
-        conan profile new default --detect
-        conan profile update settings.compiler.libcxx=libstdc++11 default
-        cmake -G Ninja -B ./build/ -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D INEXOR_CONAN_PROFILE=default -D INEXOR_USE_VMA_RECORDING=OFF ./
+      - name: Create CMake
+        shell: bash
+        run: |
+          export CC=${{ matrix.config.cc }}
+          export CXX=${{ matrix.config.cxx }}
+          export PATH="${{ matrix.config.conan_path }}":$PATH
+          export VULKAN_SDK="${{ matrix.config.vulkan_sdk }}/${{ matrix.config.vulkan_version }}/x86_64"
+          export PATH=$VULKAN_SDK/bin:$PATH
+          export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
+          export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
+          conan profile new default --detect
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          cmake -G Ninja -B ./build/ -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D INEXOR_CONAN_PROFILE=default -D INEXOR_USE_VMA_RECORDING=OFF ./
 
-    - name: Build
-      shell: bash
-      run: |
-        cmake --build ./build/
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build ./build/
 
-    - name: Analyze
-      if: matrix.config.name == 'Ubuntu CLang'
-      shell: bash
-      run: |
-        clang-tidy -dump-config
-        clang-tidy -p ./build/ ./src/*.cpp ./example/*.cpp ./tests/*.cpp ./benchmarks/*.cpp
+      - name: Analyze
+        if: matrix.config.name == 'Ubuntu CLang'
+        shell: bash
+        run: |
+          clang-tidy -dump-config
+          clang-tidy -p ./build/ ./src/*.cpp ./example/*.cpp ./tests/*.cpp ./benchmarks/*.cpp
 
-    - name: Prepare upload
-      run: |
-        tar czvf ./${{ matrix.config.artifact }} ./build/
+      - name: Prepare upload
+        run: |
+          tar czvf ./${{ matrix.config.artifact }} ./build/
 
-    - name: Upload
-      uses: actions/upload-artifact@v1
-      with:
-        path: ./${{ matrix.config.artifact }}
-        name: ${{ matrix.config.artifact }}
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          path: ./${{ matrix.config.artifact }}
+          name: ${{ matrix.config.artifact }}
 
   windows:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -18,6 +18,7 @@ jobs:
             name: "Ubuntu Clang",
             artifact: "linux-clang.tar.xz",
             cc: "clang", cxx: "clang++",
+            cmake_configure_options: '-DCMAKE_EXE_LINKER_FLAGS="-v -fuse-ld=lld"',
           }
           - {
             name: "Ubuntu GCC",
@@ -35,16 +36,11 @@ jobs:
           # Update package lists
           sudo apt update -qq
 
-          # Install dependencies
-          sudo apt install -y \
-            libglm-dev \
-            libpng-dev \
-            libx11-dev
-
           # Install build tools
           sudo apt install -y \
             clang-tidy \
             cmake \
+            lld \
             ninja-build
 
           pip3 install wheel setuptools
@@ -83,7 +79,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.build_type }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DINEXOR_USE_VMA_RECORDING=OFF \
-            -GNinja
+            -GNinja \
+            ${{ matrix.config.cmake_configure_options }}
 
       - name: Build
         shell: bash

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,30 +1,28 @@
 name: CMake Build
-
 on: [push, pull_request]
 
 jobs:
   linux:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
+    env:
+      build_type: "Release"
+      conan_path: "$HOME/.local/bin"
+      vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/"
+      vulkan_version: "1.2.131.1"
     strategy:
       fail-fast: false
       matrix:
         config:
           - {
-            name: "Ubuntu CLang",
+            name: "Ubuntu Clang",
             artifact: "linux-clang.tar.xz",
-            build_type: "Release", cc: "clang", cxx: "clang++",
-            vulkan_version: "1.2.131.1",
-            vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
-            conan_path: "$HOME/.local/bin",
+            cc: "clang", cxx: "clang++",
           }
           - {
             name: "Ubuntu GCC",
             artifact: "linux-gcc.tar.xz",
-            build_type: "Release", cc: "gcc", cxx: "g++",
-            vulkan_version: "1.2.131.1",
-            vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
-            conan_path: "$HOME/.local/bin",
+            cc: "gcc", cxx: "g++",
           }
 
     steps:
@@ -34,40 +32,66 @@ jobs:
       - name: Update environment
         shell: bash
         run: |
+          # Update package lists
           sudo apt update -qq
-          sudo apt install -y libglm-dev libxcb-dri3-0 libxcb-present0 libpciaccess0 libpng-dev libxcb-keysyms1-dev libxcb-dri3-dev libx11-dev  libmirclient-dev libwayland-dev libxrandr-dev libxcb-ewmh-dev
-          sudo apt install -y cmake ninja-build clang-tidy
+
+          # Install dependencies
+          sudo apt install -y \
+            libglm-dev \
+            libpng-dev \
+            libx11-dev
+
+          # Install build tools
+          sudo apt install -y \
+            clang-tidy \
+            cmake \
+            ninja-build
+
           pip3 install wheel setuptools
           pip3 install conan mako
 
       - name: Install Vulkan SDK
         shell: bash
         run: |
-          curl -L -S -o vulkansdk.tar.gz https://sdk.lunarg.com/sdk/download/${{ matrix.config.vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ matrix.config.vulkan_version }}.tar.gz
-          mkdir "${{ matrix.config.vulkan_sdk }}"
-          tar zxf vulkansdk.tar.gz -C "${{ matrix.config.vulkan_sdk }}"
+          # Download Vulkan SDK
+          curl -LS -o vulkansdk.tar.gz \
+            https://sdk.lunarg.com/sdk/download/${{ env.vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ env.vulkan_version }}.tar.gz
 
-      - name: Create CMake
+          # Create Vulkan SDK directory and extract
+          mkdir "${{ env.vulkan_sdk }}"
+          tar xfz vulkansdk.tar.gz -C "${{ env.vulkan_sdk }}"
+
+      - name: Configure CMake
         shell: bash
         run: |
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
-          export PATH="${{ matrix.config.conan_path }}":$PATH
-          export VULKAN_SDK="${{ matrix.config.vulkan_sdk }}/${{ matrix.config.vulkan_version }}/x86_64"
+          export PATH="${{ env.conan_path }}":$PATH
+          export VULKAN_SDK="${{ env.vulkan_sdk }}/${{ env.vulkan_version }}/x86_64"
           export PATH=$VULKAN_SDK/bin:$PATH
           export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
           export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
+
+          # Setup conan
+          # Note: libstdc++11 is needed to use new libc++ ABI
           conan profile new default --detect
           conan profile update settings.compiler.libcxx=libstdc++11 default
-          cmake -G Ninja -B ./build/ -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D INEXOR_CONAN_PROFILE=default -D INEXOR_USE_VMA_RECORDING=OFF ./
+
+          # Configure cmake
+          cmake . \
+            -Bbuild \
+            -DCMAKE_BUILD_TYPE=${{ env.build_type }} \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DINEXOR_USE_VMA_RECORDING=OFF \
+            -GNinja
 
       - name: Build
         shell: bash
         run: |
-          cmake --build ./build/
+          cmake --build build
 
       - name: Analyze
-        if: matrix.config.name == 'Ubuntu CLang'
+        if: matrix.name == 'Ubuntu Clang'
         shell: bash
         run: |
           clang-tidy -dump-config
@@ -75,17 +99,21 @@ jobs:
 
       - name: Prepare upload
         run: |
-          tar czvf ./${{ matrix.config.artifact }} ./build/
+          tar cfz ${{ matrix.config.artifact }} build
 
       - name: Upload
         uses: actions/upload-artifact@v1
         with:
-          path: ./${{ matrix.config.artifact }}
+          path: ${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
 
   windows:
     name: ${{ matrix.config.name }}
     runs-on: windows-latest
+    env:
+      build_type: "Release"
+      vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/"
+      vulkan_version: "1.2.131.1"
     strategy:
       fail-fast: false
       matrix:
@@ -93,21 +121,17 @@ jobs:
           - {
             name: "Windows MSVC",
             artifact: "windows-msvc.zip",
-            build_type: "Release", cc: "cl", cxx: "cl",
-            vulkan_version: "1.2.131.1",
-            vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
+            cc: "cl", cxx: "cl",
+            cmake_build_options: "--config Release",
+            cmake_configure_options: '-G "Visual Studio 16 2019" -A x64',
             conan_profile_update: 'conan profile update settings.compiler="Visual Studio" default; conan profile update settings.compiler.version=16 default',
-            cmake_options: '-G "Visual Studio 16 2019" -A x64',
-            cmake_build_options: '--config Release',
           }
           - {
             name: "Windows MinGW",
             artifact: "windows-mingw.zip",
-            build_type: "Release", cc: "gcc", cxx: "g++",
-            vulkan_version: "1.2.131.1",
-            vulkan_sdk: "$GITHUB_WORKSPACE/vulkan_sdk/",
+            cc: "gcc", cxx: "g++",
+            cmake_configure_options: '-GNinja',
             conan_profile_update: 'conan profile update settings.compiler.libcxx=libstdc++11 default',
-            cmake_options: '-G Ninja',
           }
 
     steps:
@@ -124,31 +148,40 @@ jobs:
       - name: Install Vulkan SDK
         shell: pwsh
         run: |
-          curl -L -S -o vulkansdk.exe https://vulkan.lunarg.com/sdk/download/${{ matrix.config.vulkan_version }}/windows/VulkanSDK-${{ matrix.config.vulkan_version }}-Installer.exe?Human=true
-          7z x vulkansdk.exe -o"${{ matrix.config.vulkan_sdk }}"
+          curl -LS -o vulkansdk.exe `
+            https://vulkan.lunarg.com/sdk/download/${{ env.vulkan_version }}/windows/VulkanSDK-${{ env.vulkan_version }}-Installer.exe?Human=true
 
-      - name: Create CMake
+          7z x vulkansdk.exe -o"${{ env.vulkan_sdk }}"
+
+      - name: Configure CMake
         shell: pwsh
         run: |
           $env:CC="${{ matrix.config.cc }}"
           $env:CXX="${{ matrix.config.cxx }}"
-          $env:Path += ";${{ matrix.config.vulkan_sdk }}\;${{ matrix.config.vulkan_sdk }}\Bin\"
+          $env:Path += ";${{ env.vulkan_sdk }}\;${{ env.vulkan_sdk }}\Bin\"
+
+          # Setup conan
           conan profile new default --detect --force
           ${{ matrix.config.conan_profile_update }}
-          cmake ${{ matrix.config.cmake_options }} -B ./build/ -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -D INEXOR_CONAN_PROFILE=default ./
+
+          # Configure CMake
+          cmake . `
+            -Bbuild `
+            -DCMAKE_BUILD_TYPE=${{ env.build_type }} `
+            ${{ matrix.config.cmake_configure_options }}
 
       - name: Build
         shell: pwsh
         run: |
-          cmake --build ./build/ ${{ matrix.config.cmake_build_options }}
+          cmake --build build ${{ matrix.config.cmake_build_options }}
 
       - name: Prepare upload
         shell: pwsh
         run: |
-          7z a -tzip ./${{ matrix.config.artifact }} ./build/*
+          7z a -tzip ${{ matrix.config.artifact }} build/*
 
       - name: Upload
         uses: actions/upload-artifact@v1
         with:
-          path: ./${{ matrix.config.artifact }}
+          path: ${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}


### PR DESCRIPTION
- Reformatted whole file
- Cleaned up arguments
  - Made all `cmake` arguments go over multiple lines
  - Made all `apt install` arguments go over multiple lines
- Added a few comments
- Renamed `Create CMake` to `Configure CMake`
- Renamed all uses of `CLang` to `Clang`
- Remove all dependency installs - only build tools are installed now
- Fixed clang build
  - Switched to using `lld` on clang build
- Removed passing `-DINEXOR_CONAN_PROFILE` in cmake configure stage
- Use `env` for variables the same across jobs. These variables are now in `env`:
  - `build_type`
  - `conan_path`
  - `vulkan_sdk`
  - `vulkan_version`
