### PR TITLE
[cmake] Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,18 +36,18 @@ include(conan_setup)
 add_subdirectory(shaders)
 add_subdirectory(src)
 
-if(${INEXOR_BUILD_BENCHMARKS})
+if(INEXOR_BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
 
-if(${INEXOR_BUILD_DOC})
+if(INEXOR_BUILD_DOC)
     add_subdirectory(documentation)
 endif()
 
-if(${INEXOR_BUILD_EXAMPLE})
+if(INEXOR_BUILD_EXAMPLE)
     add_subdirectory(example)
 endif()
 
-if(${INEXOR_BUILD_TESTS})
+if(INEXOR_BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,8 +1,4 @@
-add_executable(
-    inexor-vulkan-renderer-benchmarks
-
-    engine_benchmark_main.cpp
-)
+add_executable(inexor-vulkan-renderer-benchmarks engine_benchmark_main.cpp)
 
 set_target_properties(
     inexor-vulkan-renderer-benchmarks PROPERTIES

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,8 +1,4 @@
-add_executable(
-    inexor-vulkan-renderer-example
-
-    main.cpp
-)
+add_executable(inexor-vulkan-renderer-example main.cpp)
 
 set_target_properties(
     inexor-vulkan-renderer-example PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ set_target_properties(
 target_compile_definitions(
     inexor-vulkan-renderer
 
-    PRIVATE
+    PUBLIC
     GLFW_INCLUDE_VULKAN
     GLM_FORCE_DEPTH_ZERO_TO_ONE
     GLM_FORCE_RADIANS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,4 @@
-add_executable(
-    inexor-vulkan-renderer-tests
-
-    unit_tests_main.cpp
-)
+add_executable(inexor-vulkan-renderer-tests unit_tests_main.cpp)
 
 set_target_properties(
     inexor-vulkan-renderer-tests PROPERTIES


### PR DESCRIPTION
- Cleanup option checks in root `CMakeLists.txt`
- Merge simple statements onto one line
- Make `target_compile_definitions` for `inexor-vulkan-renderer` target `PUBLIC`
  - This changes makes it so a program linking against `inexor-vulkan-renderer` also has `GLM_FORCE_RADIANS` set