### PR TITLE
[code] Cleanup shader

### DIFF
--- a/include/inexor/vulkan-renderer/shader.hpp
+++ b/include/inexor/vulkan-renderer/shader.hpp
@@ -1,41 +1,41 @@
 #pragma once
 
-#include "spdlog/spdlog.h"
-#include "vma/vk_mem_alloc.h"
+#include <vma/vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 
-#include <cassert>
-#include <fstream>
 #include <string>
+#include <vector>
 
 namespace inexor::vulkan_renderer {
 
 class Shader {
 private:
-    std::string name;
-
-    VkShaderStageFlagBits type;
-
-    std::string entry_point;
-
     VkDevice device;
-
-    VmaAllocator vma_allocator;
+    VkShaderStageFlagBits type;
+    std::string name;
+    std::string entry_point;
 
     VkShaderModule shader_module;
 
 public:
-    // To make this class uncopiable and move only, we implement the "rule of 5".
+    /// @brief Creates a shader from a SPIR-V memory block.
+    Shader(VkDevice device, VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code, const std::string &entry_point = "main");
 
-    VkShaderModule get_module() const {
-        return shader_module;
-    }
+    /// @brief Creates a shader from a SPIR-V file.
+    Shader(VkDevice device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name, const std::string &entry_point = "main");
 
-    std::string get_name() const {
+    Shader(const Shader &) = delete;
+    Shader(Shader && shader) noexcept;
+    ~Shader();
+
+    Shader &operator=(const Shader &) = delete;
+    Shader &operator=(Shader &&) noexcept = default;
+
+    const std::string &get_name() const {
         return name;
     }
 
-    std::string get_entry_point() const {
+    const std::string &get_entry_point() const {
         return entry_point;
     }
 
@@ -43,28 +43,9 @@ public:
         return type;
     }
 
-    // Delete the copy constructor.
-    Shader(const Shader &) = delete;
-
-    // Delete the copy assignment operator.
-    Shader &operator=(const Shader &) = delete;
-
-    // Use the move constructor.
-    Shader(Shader &&) noexcept = default;
-
-    // Use the move assignment operator.
-    Shader &operator=(Shader &&) noexcept = default;
-
-    /// @brief Creates a shader from a SPIR-V file.
-    Shader(const VkDevice &device, const VmaAllocator &vma_allocator, const VkShaderStageFlagBits shader_type, const std::string &file_name,
-           const std::string internal_shader_name, const std::string shader_entry_point = "main");
-
-    /// @brief Creates a shader from a SPIR-V memory block.
-    Shader(const VkDevice &device, const VmaAllocator &vma_allocator, const VkShaderStageFlagBits shader_type, const std::vector<char> &shader_memory,
-           const std::string internal_shader_name, const std::string shader_entry_point = "main");
-
-    /// @brief The destructor cleans up all memory allocations
-    ~Shader();
+    VkShaderModule get_module() const {
+        return shader_module;
+    }
 };
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -147,7 +147,7 @@ VkResult Application::load_shaders() {
         spdlog::debug("Loading vertex shader file {}.", vertex_shader_file);
 
         // Insert the new shader into the list of shaders.
-        shaders.emplace_back(device, vma_allocator, VK_SHADER_STAGE_VERTEX_BIT, vertex_shader_file, "unnamed vertex shader");
+        shaders.emplace_back(device, VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader", vertex_shader_file);
     }
 
     spdlog::debug("Loading fragment shaders.");
@@ -161,7 +161,7 @@ VkResult Application::load_shaders() {
         spdlog::debug("Loading fragment shader file {}.", fragment_shader_file);
 
         // Insert the new shader into the list of shaders.
-        shaders.emplace_back(device, vma_allocator, VK_SHADER_STAGE_FRAGMENT_BIT, fragment_shader_file, "unnamed vertex shader");
+        shaders.emplace_back(device, VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader", fragment_shader_file);
     }
 
     spdlog::debug("Loading shaders finished.");

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -1815,6 +1815,9 @@ VkResult VulkanRenderer::shutdown_vulkan() {
     spdlog::debug("------------------------------------------------------------------------------------------------------------");
     spdlog::debug("Shutting down Vulkan API.");
 
+    // TODO(yeetari): Remove once this class is RAII-ified
+    shaders.clear();
+
     cleanup_swapchain();
 
     spdlog::debug("Destroying swapchain images.");

--- a/src/vulkan-renderer/shader.cpp
+++ b/src/vulkan-renderer/shader.cpp
@@ -1,143 +1,82 @@
 #include "inexor/vulkan-renderer/shader.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <fstream>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+
+std::vector<char> read_binary(const std::string &file_name) {
+    // Open stream at the end of the file to read it's size.
+    std::ifstream file(file_name.c_str(), std::ios::ate | std::ios::binary | std::ios::in);
+
+    if (!file) {
+        throw std::runtime_error("Error: Could not pen file " + file_name + "!");
+    }
+
+    const auto file_size = file.tellg();
+    std::vector<char> buffer(file_size);
+
+    file.seekg(0);
+    file.read(buffer.data(), file_size);
+
+    return buffer;
+}
+
+} // namespace
+
 namespace inexor::vulkan_renderer {
 
-Shader::Shader(const VkDevice &device, const VmaAllocator &vma_allocator, const VkShaderStageFlagBits shader_type, const std::string &file_name,
-               const std::string internal_shader_name, const std::string shader_entry_point) {
+Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code, const std::string &entry_point)
+    : device(device), type(type), name(name), entry_point(entry_point) {
     assert(device);
-    assert(vma_allocator);
-    assert(!file_name.empty());
-    assert(!shader_entry_point.empty());
-    assert(!internal_shader_name.empty());
+    assert(!name.empty());
+    assert(!code.empty());
+    assert(!entry_point.empty());
 
-    spdlog::debug("Loading SPIR-V shader file {}.", file_name);
-
-    std::vector<char> shader_file_data;
-
-    // Open stream at the end of the file to read it's size.
-    std::ifstream spirv_shader_file(file_name.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
-
-    if (spirv_shader_file.is_open()) {
-        spdlog::debug("File {} has been opened.", file_name);
-
-        auto file_size = spirv_shader_file.tellg();
-
-        if (file_size == 0) {
-            std::string exception_error_message = "Error: File" + file_name + " is empty!";
-            throw std::runtime_error(exception_error_message);
-        }
-
-        // Preallocate memory for the file buffer.
-        shader_file_data.resize(file_size);
-
-        // Reset the file read position to the beginning of the file.
-        spirv_shader_file.seekg(0, std::ios::beg);
-        spirv_shader_file.read(shader_file_data.data(), file_size);
-        spirv_shader_file.close();
-
-        spdlog::debug("File {} has been closed.", file_name.c_str());
-    } else {
-        std::string exception_error_message = "Error: Could not open file " + file_name + "!";
-        throw std::runtime_error(exception_error_message);
-    }
-
-    VkShaderModuleCreateInfo shader_create_info = {};
-
-    shader_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    shader_create_info.pNext = nullptr;
-    shader_create_info.flags = 0;
-    shader_create_info.codeSize = shader_file_data.size();
+    VkShaderModuleCreateInfo create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    create_info.codeSize = code.size();
 
     // When you perform a cast like this, you also need to ensure that the data satisfies the alignment
     // requirements of std::uint32_t. Lucky for us, the data is stored in an std::vector where the default
     // allocator already ensures that the data satisfies the worst case alignment requirements.
-    shader_create_info.pCode = reinterpret_cast<const std::uint32_t *>(shader_file_data.data());
+    create_info.pCode = reinterpret_cast<const std::uint32_t *>(code.data());
 
-    spdlog::debug("Creating shader module {} from file {}.", internal_shader_name, file_name);
-
-    if (vkCreateShaderModule(device, &shader_create_info, nullptr, &shader_module) != VK_SUCCESS) {
-        throw std::runtime_error("Error: vkCreateShaderModule failed for shader " + internal_shader_name);
+    spdlog::debug("Creating shader module {}.", name);
+    if (vkCreateShaderModule(device, &create_info, nullptr, &shader_module) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreateShaderModule failed for shader " + name);
     }
 
     // Try to find the Vulkan debug marker function.
-    auto vkDebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT");
+    auto *vkDebugMarkerSetObjectNameEXT = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
 
     if (vkDebugMarkerSetObjectNameEXT != nullptr) {
         // Since the function vkDebugMarkerSetObjectNameEXT has been found, we can assign an internal name for debugging.
-        VkDebugMarkerObjectNameInfoEXT nameInfo = {};
+        VkDebugMarkerObjectNameInfoEXT name_info = {};
+        name_info.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
 
-        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-        nameInfo.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;
-        nameInfo.object = reinterpret_cast<std::uint64_t>(shader_module);
-        nameInfo.pObjectName = internal_shader_name.c_str();
+        name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;
+        name_info.object = reinterpret_cast<std::uint64_t>(shader_module);
+        name_info.pObjectName = name.c_str();
 
-        spdlog::debug("Assigning internal name {} to shader module.", internal_shader_name);
-
-        vkDebugMarkerSetObjectNameEXT(device, &nameInfo);
+        spdlog::debug("Assigning internal name {} to shader module.", name);
+        vkDebugMarkerSetObjectNameEXT(device, &name_info);
     }
-
-    this->name = internal_shader_name;
-    this->type = shader_type;
-    this->entry_point = shader_entry_point;
-    this->device = device;
-    this->vma_allocator = vma_allocator;
-    this->shader_module = shader_module;
 }
 
-Shader::Shader(const VkDevice &device, const VmaAllocator &vma_allocator, const VkShaderStageFlagBits shader_type, const std::vector<char> &shader_memory,
-               const std::string internal_shader_name, const std::string shader_entry_point) {
-    assert(device);
-    assert(vma_allocator);
-    assert(!shader_memory.empty());
-    assert(!shader_entry_point.empty());
-    assert(!internal_shader_name.empty());
+Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::string &name, const std::string &file_name, const std::string &entry_point)
+    : Shader(device, type, name, read_binary(file_name), entry_point) {}
 
-    VkShaderModuleCreateInfo shader_create_info = {};
-
-    shader_create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    shader_create_info.pNext = nullptr;
-    shader_create_info.flags = 0;
-    shader_create_info.codeSize = shader_memory.size();
-
-    // When you perform a cast like this, you also need to ensure that the data satisfies the alignment
-    // requirements of std::uint32_t. Lucky for us, the data is stored in an std::vector where the default
-    // allocator already ensures that the data satisfies the worst case alignment requirements.
-    shader_create_info.pCode = reinterpret_cast<const std::uint32_t *>(shader_memory.data());
-
-    spdlog::debug("Creating shader module {} from memory.", internal_shader_name);
-
-    if (vkCreateShaderModule(device, &shader_create_info, nullptr, &shader_module) != VK_SUCCESS) {
-        throw std::runtime_error("Error: vkCreateShaderModule failed for shader " + internal_shader_name);
-    }
-
-    // Try to find the Vulkan debug marker function.
-    auto vkDebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT");
-
-    if (vkDebugMarkerSetObjectNameEXT != nullptr) {
-        // Since the function vkDebugMarkerSetObjectNameEXT has been found, we can assign an internal name for debugging.
-        VkDebugMarkerObjectNameInfoEXT nameInfo = {};
-
-        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-        nameInfo.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;
-        nameInfo.object = reinterpret_cast<std::uint64_t>(shader_module);
-        nameInfo.pObjectName = internal_shader_name.c_str();
-
-        spdlog::debug("Assigning internal name {} to shader module.", internal_shader_name);
-
-        vkDebugMarkerSetObjectNameEXT(device, &nameInfo);
-    }
-
-    this->name = internal_shader_name;
-    this->type = shader_type;
-    this->entry_point = shader_entry_point;
-    this->device = device;
-    this->vma_allocator = vma_allocator;
-    this->shader_module = shader_module;
-}
+Shader::Shader(Shader &&shader) noexcept
+    : device(shader.device), type(shader.type), name(std::move(shader.name)), entry_point(std::move(shader.entry_point)),
+      shader_module(std::exchange(shader.shader_module, nullptr)) {}
 
 Shader::~Shader() {
-    // Destroy the shader module in the constructor.
     vkDestroyShaderModule(device, shader_module, nullptr);
 }
 
-}; // namespace inexor::vulkan_renderer
+} // namespace inexor::vulkan_renderer


### PR DESCRIPTION
- Fixed crash
  - Implemented move constructor for shader
  - Also had to make sure shader vector was clear at the top of `shutdown_vulkan`
- Cleaned up constructors
  - Switched to using initialiser lists
  - Switched to using a cascading constructor to avoid code duplication
  - Cleaned up file handling code
- Refactored includes
  - Moved some includes to source file
  - Added some missing includes
- Made vulkan handles be passed by value instead of const reference
- Made strings be passed by const reference instead of value to avoid copy
- Remove vma allocator from shader
- Removed a c style cast
- Removed trailing commas from namespace declarations
- Lots of renaming
  - Renamed `nameInfo` to `name_info`
  - Renamed `shader_memory` to `code`
  - Renamed `shader_create_info` to just `create_info`