### PR TITLE
Octree: Bug-fixes and overloading

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,7 @@ eed81253b402cc456b885edb990f66ed00311e74
 
 # [code] Apply code style on missing files.
 fe3440a2a7d23552169d03040078c3502f9676db
+
+# [clang-format] Apply to inexor::world::*
+d2d9eaebbf13ef52a8716967b593f4b7c1136953
+

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -36,6 +36,11 @@ private:
     /// Run on-change events.
     void change();
 
+    /// Copy the values from another indentation to this one.
+    /// @param indentation The indentation to copy the values from.
+    /// @return Whether any value has changed.
+    bool copy_values(const Indentation &indentation);
+
     /// Parse one axis from a BitStream.
     /// @param stream The BitStream to parse one axis from.
     /// @return The indentation level on that axis.
@@ -67,7 +72,7 @@ public:
     /// Argument: the indentation emitting the signal ("this").
     boost::signals2::signal<void(Indentation *)> on_change;
 
-    Indentation& operator=(Indentation&& other) noexcept;
+    Indentation& operator=(Indentation&& lhs) noexcept;
     Indentation& operator=(const Indentation& rhs);
     Indentation& operator=(const glm::tvec3<uint8_t>& rhs);
     Indentation& operator+=(const glm::tvec3<int8_t>& other);
@@ -146,6 +151,14 @@ public:
 /// | 6.    | higher | axis   | axis   |
 class Cube {
 private:
+    Cube(
+        CubeType type,
+        float size,
+        const glm::vec3 &position,
+        const std::optional<std::array<Indentation, 8>> &indentations,
+        std::optional<std::array<std::shared_ptr<Cube>, 8>> octants
+        );
+
     /// Insert all polygons into memory.
     /// @param polygons Pointer to the memory where the polygons should be saved to.
     void all_polygons(std::array<glm::vec3, 3> *&polygons);
@@ -155,6 +168,11 @@ private:
 
     /// Run on-change events.
     void change(Indentation *indentation);
+
+    /// Copy the values from another cube to this one.
+    /// @param cube The cube to copy the values from.
+    /// @return Whether any value has changed (this != &cube).
+    bool copy_values(const Cube &cube);
 
     /// Get all vertices of this cube (not its children).
     /// @return vertices of this cube.
@@ -246,6 +264,12 @@ public:
     /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
     /// x, y, and z-axis).
     Cube(std::array<std::shared_ptr<Cube>, 8> &octants, float size, const glm::vec3 &position);
+
+    Cube(const Cube& cube);
+    Cube(Cube &&cube) noexcept;
+
+    Cube& operator=(Cube&& lhs) noexcept;
+    Cube& operator=(const Cube& rhs);
 
     /// Parse an octree from binary data.
     /// @param data The data to parse the octree from.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -11,305 +11,315 @@
 #include <optional>
 
 namespace inexor::vulkan_renderer::world {
-/// How often a cube can be indented, results in MAX_INDENTATION+1 steps.
-constexpr std::uint8_t MAX_INDENTATION = 8;
-/// The default size of a cube / the octree size boundaries.
-constexpr float DEFAULT_CUBE_SIZE = 1;
-/// The default position of the cube in the coordinate system.
-constexpr glm::vec3 DEFAULT_CUBE_POSITION = {0., 0., 0.};
+    /// How often a cube can be indented, results in MAX_INDENTATION+1 steps.
+    constexpr std::uint8_t MAX_INDENTATION = 8;
 
-/// The types a cube can have and its bit-representation.
-enum class CubeType {
-    /// The cube has no surface and no vertices.
-    EMPTY = 0b00,
-    /// The cube is a "real" cube where each edge has the same length.
-    FULL = 0b01,
-    /// The cube has at least on edge which has been indented from at least one axis.
-    /// That means that the cube may or may not be a perfect cube with same-length edges.
-    INDENTED = 0b10,
-    /// The cube is divided in 8 octants (same-sized cubes).
-    OCTANT = 0b11
-};
+    /// The default size of a cube / the octree size boundaries.
+    constexpr float DEFAULT_CUBE_SIZE = 1;
 
-class Indentation {
-private:
-    /// Run on-change events.
-    void change();
+    /// The default position of the cube in the coordinate system.
+    constexpr glm::vec3 DEFAULT_CUBE_POSITION = {0., 0., 0.};
 
-    /// Copy the values from another indentation to this one.
-    /// @param indentation The indentation to copy the values from.
-    /// @return Whether any value has changed.
-    bool copy_values(const Indentation &indentation);
+    /// The types a cube can have and its bit-representation.
+    enum class CubeType {
+        /// The cube has no surface and no vertices.
+        EMPTY = 0b00,
+        /// The cube is a "real" cube where each edge has the same length.
+        FULL = 0b01,
+        /// The cube has at least on edge which has been indented from at least one axis.
+        /// That means that the cube may or may not be a perfect cube with same-length edges.
+        INDENTED = 0b10,
+        /// The cube is divided in 8 octants (same-sized cubes).
+        OCTANT = 0b11
+    };
 
-    /// Parse one axis from a BitStream.
-    /// @param stream The BitStream to parse one axis from.
-    /// @return The indentation level on that axis.
-    static std::uint8_t parse_one(BitStream &stream);
+    class Indentation {
+    private:
+        /// Run on-change events.
+        void change();
 
-    /// Indentation level on the x-axis.
-    std::uint8_t x_level = 0;
+        /// Copy the values from another indentation to this one.
+        /// @param indentation The indentation to copy the values from.
+        /// @return Whether any value has changed.
+        bool copy_values(const Indentation &indentation);
 
-    /// Indentation level on the y-axis.
-    std::uint8_t y_level = 0;
+        /// Parse one axis from a BitStream.
+        /// @param stream The BitStream to parse one axis from.
+        /// @return The indentation level on that axis.
+        static std::uint8_t parse_one(BitStream &stream);
 
-    /// Indentation level on the z-axis.
-    std::uint8_t z_level = 0;
+        /// Indentation level on the x-axis.
+        std::uint8_t x_level = 0;
 
-public:
-    /// Create an Indentation to assign to a cube corner.
-    Indentation();
+        /// Indentation level on the y-axis.
+        std::uint8_t y_level = 0;
 
-    /// Create an Indentation to assign to a cube corner.
-    /// @param x Indentation leven on the x-axis
-    /// @param y Indentation leven on the y-axis
-    /// @param z Indentation leven on the z-axis
-    Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
+        /// Indentation level on the z-axis.
+        std::uint8_t z_level = 0;
 
-    Indentation(const Indentation& indentation);
-    Indentation(Indentation &&indentation) noexcept;
+    public:
+        /// Create an Indentation to assign to a cube corner.
+        Indentation();
 
-    /// Signal emitted when one of the indentation levels changes.
-    /// Argument: the indentation emitting the signal ("this").
-    boost::signals2::signal<void(Indentation *)> on_change;
+        /// Create an Indentation to assign to a cube corner.
+        /// @param x Indentation leven on the x-axis
+        /// @param y Indentation leven on the y-axis
+        /// @param z Indentation leven on the z-axis
+        Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
 
-    Indentation& operator=(Indentation&& lhs) noexcept;
-    Indentation& operator=(const Indentation& rhs);
-    Indentation& operator=(const glm::tvec3<uint8_t>& rhs);
-    Indentation& operator+=(const glm::tvec3<int8_t>& other);
-    Indentation& operator-=(const glm::tvec3<int8_t>& other);
+        Indentation(const Indentation &indentation);
 
-    [[nodiscard]] bool equal_values(const Indentation &other) const;
-    [[nodiscard]] bool equal_values(const glm::tvec3<uint8_t> &other) const;
+        Indentation(Indentation &&indentation) noexcept;
 
-    /// Set the indentations depth for the axis.
-    /// @param x Indentation leven on the x-axis.
-    /// @param y Indentation leven on the y-axis.
-    /// @param z Indentation leven on the z-axis.
-    void set(std::optional<std::uint8_t> x, std::optional<std::uint8_t> y, std::optional<std::uint8_t> z);
+        /// Signal emitted when one of the indentation levels changes.
+        /// Argument: the indentation emitting the signal ("this").
+        boost::signals2::signal<void(Indentation *)> on_change;
 
-    /// Set the indentation level for the x axis.
-    /// @param x Indentation level on the x axis.
-    void set_x(std::uint8_t x);
+        Indentation &operator=(Indentation &&lhs) noexcept;
 
-    /// Set the indentation level for the y axis.
-    /// @param x Indentation level on the y axis.
-    void set_y(std::uint8_t y);
+        Indentation &operator=(const Indentation &rhs);
 
-    /// Set the indentation level for the z axis.
-    /// @param x Indentation level on the z axis.
-    void set_z(std::uint8_t z);
+        Indentation &operator=(const glm::tvec3<uint8_t> &rhs);
 
-    /// Parse an indentation from a bitstream.
-    /// @param stream The stream to extract the bitstream from.
-    /// @return The indentation on all three axes.
-    static Indentation parse(BitStream &stream);
+        Indentation &operator+=(const glm::tvec3<int8_t> &other);
 
-    /// Get the x-axis indentation level.
-    /// @return the x-axis indentation level.
-    [[nodiscard]] std::uint8_t x() const;
+        Indentation &operator-=(const glm::tvec3<int8_t> &other);
 
-    /// Get the y-axis indentation level.
-    /// @return the y-axis indentation level.
-    [[nodiscard]] std::uint8_t y() const;
+        [[nodiscard]] bool equal_values(const Indentation &other) const;
 
-    /// Get the z-axis indentation level.
-    /// @return the z-axis indentation level.
-    [[nodiscard]] std::uint8_t z() const;
+        [[nodiscard]] bool equal_values(const glm::tvec3<uint8_t> &other) const;
 
-    /// Get the indentation levels on all three axes as a glm::tvec3<std::uint8_t>.
-    /// @return indentation levels on all three axes
-    [[nodiscard]] glm::tvec3<std::uint8_t> vec() const;
+        /// Set the indentations depth for the axis.
+        /// @param x Indentation leven on the x-axis.
+        /// @param y Indentation leven on the y-axis.
+        /// @param z Indentation leven on the z-axis.
+        void set(std::optional<std::uint8_t> x, std::optional<std::uint8_t> y, std::optional<std::uint8_t> z);
 
-    // TODO: Get bits from values.
-    // [[nodiscard]] dynamic_bitset<> bits();
-};
+        /// Set the indentation level for the x axis.
+        /// @param x Indentation level on the x axis.
+        void set_x(std::uint8_t x);
 
-/// A cube or octree representing the maps geometry.
-///
-/// Values connected to corners of cubes are saved in the following order.
-///
-/// | Order | X      | Y      | Z      |
-/// |-------|--------|--------|--------|
-/// | 1.    | lower  | lower  | lower  |
-/// | 2.    | lower  | lower  | higher |
-/// | 3.    | lower  | higher | lower  |
-/// | 4.    | lower  | higher | higher |
-/// | 5.    | higher | lower  | lower  |
-/// | 6.    | higher | lower  | higher |
-/// | 7.    | higher | higher | lower  |
-/// | 8.    | higher | higher | higher |
-///
-/// Values connected to sides of cubes are saved in the following order.
-///
-/// | Order | X      | Y      | Z      |
-/// |-------|--------|--------|--------|
-/// | 1.    | axis   | axis   | lower  |
-/// | 2.    | axis   | axis   | higher |
-/// | 3.    | axis   | lower  | axis   |
-/// | 4.    | axis   | higher | axis   |
-/// | 5.    | lower  | axis   | axis   |
-/// | 6.    | higher | axis   | axis   |
-class Cube {
-private:
-    Cube(
-        CubeType type,
-        float size,
-        const glm::vec3 &position,
-        const std::optional<std::array<Indentation, 8>> &indentations,
-        std::optional<std::array<std::shared_ptr<Cube>, 8>> octants
+        /// Set the indentation level for the y axis.
+        /// @param x Indentation level on the y axis.
+        void set_y(std::uint8_t y);
+
+        /// Set the indentation level for the z axis.
+        /// @param x Indentation level on the z axis.
+        void set_z(std::uint8_t z);
+
+        /// Parse an indentation from a bitstream.
+        /// @param stream The stream to extract the bitstream from.
+        /// @return The indentation on all three axes.
+        static Indentation parse(BitStream &stream);
+
+        /// Get the x-axis indentation level.
+        /// @return the x-axis indentation level.
+        [[nodiscard]] std::uint8_t x() const;
+
+        /// Get the y-axis indentation level.
+        /// @return the y-axis indentation level.
+        [[nodiscard]] std::uint8_t y() const;
+
+        /// Get the z-axis indentation level.
+        /// @return the z-axis indentation level.
+        [[nodiscard]] std::uint8_t z() const;
+
+        /// Get the indentation levels on all three axes as a glm::tvec3<std::uint8_t>.
+        /// @return indentation levels on all three axes
+        [[nodiscard]] glm::tvec3<std::uint8_t> vec() const;
+
+        // TODO: Get bits from values.
+        // [[nodiscard]] dynamic_bitset<> bits();
+    };
+
+    /// A cube or octree representing the maps geometry.
+    ///
+    /// Values connected to corners of cubes are saved in the following order.
+    ///
+    /// | Order | X      | Y      | Z      |
+    /// |-------|--------|--------|--------|
+    /// | 1.    | lower  | lower  | lower  |
+    /// | 2.    | lower  | lower  | higher |
+    /// | 3.    | lower  | higher | lower  |
+    /// | 4.    | lower  | higher | higher |
+    /// | 5.    | higher | lower  | lower  |
+    /// | 6.    | higher | lower  | higher |
+    /// | 7.    | higher | higher | lower  |
+    /// | 8.    | higher | higher | higher |
+    ///
+    /// Values connected to sides of cubes are saved in the following order.
+    ///
+    /// | Order | X      | Y      | Z      |
+    /// |-------|--------|--------|--------|
+    /// | 1.    | axis   | axis   | lower  |
+    /// | 2.    | axis   | axis   | higher |
+    /// | 3.    | axis   | lower  | axis   |
+    /// | 4.    | axis   | higher | axis   |
+    /// | 5.    | lower  | axis   | axis   |
+    /// | 6.    | higher | axis   | axis   |
+    class Cube {
+    private:
+        Cube(
+            CubeType type,
+            float size,
+            const glm::vec3 &position,
+            const std::optional<std::array<Indentation, 8>> &indentations,
+            std::optional<std::array<std::shared_ptr<Cube>, 8>> octants
         );
 
-    /// Insert all polygons into memory.
-    /// @param polygons Pointer to the memory where the polygons should be saved to.
-    void all_polygons(std::array<glm::vec3, 3> *&polygons);
+        /// Insert all polygons into memory.
+        /// @param polygons Pointer to the memory where the polygons should be saved to.
+        void all_polygons(std::array<glm::vec3, 3> *&polygons);
 
-    /// Run on-change events.
-    void change();
+        /// Run on-change events.
+        void change();
 
-    /// Run on-change events.
-    void change(Indentation *indentation);
+        /// Run on-change events.
+        void change(Indentation *indentation);
 
-    /// Copy the values from another cube to this one.
-    /// @param cube The cube to copy the values from.
-    /// @return Whether any value has changed (this != &cube).
-    bool copy_values(const Cube &cube);
+        /// Copy the values from another cube to this one.
+        /// @param cube The cube to copy the values from.
+        /// @return Whether any value has changed (this != &cube).
+        bool copy_values(const Cube &cube);
 
-    /// Get all vertices of this cube (not its children).
-    /// @return vertices of this cube.
-    [[nodiscard]] std::array<glm::vec3, 8> vertices();
+        /// Get all vertices of this cube (not its children).
+        /// @return vertices of this cube.
+        [[nodiscard]] std::array<glm::vec3, 8> vertices();
 
-    /// Get the polygons of this cube as if it is a full cube.
-    /// @return polygons of this cube as if it is a full cube
-    std::array<std::array<glm::vec3, 3>, 12> full_polygons();
+        /// Get the polygons of this cube as if it is a full cube.
+        /// @return polygons of this cube as if it is a full cube
+        std::array<std::array<glm::vec3, 3>, 12> full_polygons();
 
-    /// Get the vertices in a structure which is ordered in triangles of the order of a full cube.
-    /// @param v The vertices of the the sides of a cube.
-    /// @return polygons of this cube in the order of a full cube.
-    std::array<std::array<glm::vec3, 3>, 12> full_polygons(std::array<glm::vec3, 8> &v);
+        /// Get the vertices in a structure which is ordered in triangles of the order of a full cube.
+        /// @param v The vertices of the the sides of a cube.
+        /// @return polygons of this cube in the order of a full cube.
+        std::array<std::array<glm::vec3, 3>, 12> full_polygons(std::array<glm::vec3, 8> &v);
 
-    /// Get the polygons of this cube (only when it is an indented cube).
-    /// @return polygons of this cube
-    std::array<std::array<glm::vec3, 3>, 12> indented_polygons();
+        /// Get the polygons of this cube (only when it is an indented cube).
+        /// @return polygons of this cube
+        std::array<std::array<glm::vec3, 3>, 12> indented_polygons();
 
-    /// Get the indentation levels for each side of the cube.
-    /// @return The indentation lebvels for each side of the cube.
-    std::array<glm::tvec3<std::uint8_t>, 8> indentation_levels();
+        /// Get the indentation levels for each side of the cube.
+        /// @return The indentation lebvels for each side of the cube.
+        std::array<glm::tvec3<std::uint8_t>, 8> indentation_levels();
 
-    /// Cache of this cubes polygons. Not of its octants (i.e., empty of the cube is of type CubeType::OCTANTS).
-    std::array<std::array<glm::vec3, 3>, 12> polygons_cache = {}; // Vertices of this cube (not its octants)
+        /// Cache of this cubes polygons. Not of its octants (i.e., empty of the cube is of type CubeType::OCTANTS).
+        std::array<std::array<glm::vec3, 3>, 12> polygons_cache = {}; // Vertices of this cube (not its octants)
 
-    /// Whether this->polygons_cache is valid and might be used.
-    bool valid_cache = false;
+        /// Whether this->polygons_cache is valid and might be used.
+        bool valid_cache = false;
 
-    /// Whether this octree is reactive (i.e. updates when childs update).
-    bool is_reactive = false;
+        /// Whether this octree is reactive (i.e. updates when childs update).
+        bool is_reactive = false;
 
-    /// Type of the cube.
-    CubeType cube_type = CubeType::EMPTY;
+        /// Type of the cube.
+        CubeType cube_type = CubeType::EMPTY;
 
-    /// The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
-    /// x, y, and z-axis).
-    glm::vec3 cube_position = {0.0f, 0.0f, 0.0f};
+        /// The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
+        /// x, y, and z-axis).
+        glm::vec3 cube_position = {0.0f, 0.0f, 0.0f};
 
-    /// The maximum size of the cube (i.e. if the cube is not indented).
-    float cube_size = 32;
+        /// The maximum size of the cube (i.e. if the cube is not indented).
+        float cube_size = 32;
 
-public:
-    /// Signal emitted when any of the geometry of this cube or its child cubes changes.
-    /// Argument: the cube which was originally changed ("this" or a child-cube).
-    boost::signals2::signal<void(Cube *)> on_change;
+    public:
+        /// Signal emitted when any of the geometry of this cube or its child cubes changes.
+        /// Argument: the cube which was originally changed ("this" or a child-cube).
+        boost::signals2::signal<void(Cube *)> on_change;
 
-    /// The indentations of this cube if this cube is of CubeType::INDENTED.
-    /// Ordered as following:
-    /// 0. Corner with lower x-axis-value, lower y-value, lower z-value.
-    /// 1. Corner with lower x-axis-value, lower y-value, higher z-value.
-    /// 2. Corner with lower x-axis-value, higher y-value, lower z-value.
-    /// 3. Corner with lower x-axis-value, higher y-value, higher z-value.
-    /// 4. Corner with higher x-axis-value, lower y-value, lower z-value.
-    /// 5. Corner with higher x-axis-value, lower y-value, higher z-value.
-    /// 6. Corner with higher x-axis-value, higher y-value, lower z-value.
-    /// 7. Corner with higher x-axis-value, higher y-value, higher z-value.
-    std::optional<std::array<Indentation, 8>> indentations = std::nullopt;
+        /// The indentations of this cube if this cube is of CubeType::INDENTED.
+        /// Ordered as following:
+        /// 0. Corner with lower x-axis-value, lower y-value, lower z-value.
+        /// 1. Corner with lower x-axis-value, lower y-value, higher z-value.
+        /// 2. Corner with lower x-axis-value, higher y-value, lower z-value.
+        /// 3. Corner with lower x-axis-value, higher y-value, higher z-value.
+        /// 4. Corner with higher x-axis-value, lower y-value, lower z-value.
+        /// 5. Corner with higher x-axis-value, lower y-value, higher z-value.
+        /// 6. Corner with higher x-axis-value, higher y-value, lower z-value.
+        /// 7. Corner with higher x-axis-value, higher y-value, higher z-value.
+        std::optional<std::array<Indentation, 8>> indentations = std::nullopt;
 
-    /// The octants of this cube if this cube is of CubeType::OCTANTS.
-    /// Ordered as following:
-    /// 0. Octant with lower x-axis-value, lower y-value, lower z-value.
-    /// 1. Octant with lower x-axis-value, lower y-value, higher z-value.
-    /// 2. Octant with lower x-axis-value, higher y-value, lower z-value.
-    /// 3. Octant with lower x-axis-value, higher y-value, higher z-value.
-    /// 4. Octant with higher x-axis-value, lower y-value, lower z-value.
-    /// 5. Octant with higher x-axis-value, lower y-value, higher z-value.
-    /// 6. Octant with higher x-axis-value, higher y-value, lower z-value.
-    /// 7. Octant with higher x-axis-value, higher y-value, higher z-value.
-    std::optional<std::array<std::shared_ptr<Cube>, 8>> octants = std::nullopt;
+        /// The octants of this cube if this cube is of CubeType::OCTANTS.
+        /// Ordered as following:
+        /// 0. Octant with lower x-axis-value, lower y-value, lower z-value.
+        /// 1. Octant with lower x-axis-value, lower y-value, higher z-value.
+        /// 2. Octant with lower x-axis-value, higher y-value, lower z-value.
+        /// 3. Octant with lower x-axis-value, higher y-value, higher z-value.
+        /// 4. Octant with higher x-axis-value, lower y-value, lower z-value.
+        /// 5. Octant with higher x-axis-value, lower y-value, higher z-value.
+        /// 6. Octant with higher x-axis-value, higher y-value, lower z-value.
+        /// 7. Octant with higher x-axis-value, higher y-value, higher z-value.
+        std::optional<std::array<std::shared_ptr<Cube>, 8>> octants = std::nullopt;
 
-    /// Create a cube.
-    /// @param type The type of the cube. The cube needs further adjustment after construction if not of CubeType::FULL or CubeType::EMPTY.
-    /// @param size The maximum size of the cube.
-    /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
-    /// x, y, and z-axis).
-    Cube(CubeType type, float size, const glm::vec3 &position);
+        /// Create a cube.
+        /// @param type The type of the cube. The cube needs further adjustment after construction if not of CubeType::FULL or CubeType::EMPTY.
+        /// @param size The maximum size of the cube.
+        /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
+        /// x, y, and z-axis).
+        Cube(CubeType type, float size, const glm::vec3 &position);
 
-    /// Create a CubeType::INDENTED cube.
-    /// @param indentations The indentations of the cube.
-    /// @param size The maximum size of the cube.
-    /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
-    /// x, y, and z-axis).
-    Cube(std::array<Indentation, 8> &indentations, float size, const glm::vec3 &position);
+        /// Create a CubeType::INDENTED cube.
+        /// @param indentations The indentations of the cube.
+        /// @param size The maximum size of the cube.
+        /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
+        /// x, y, and z-axis).
+        Cube(std::array<Indentation, 8> &indentations, float size, const glm::vec3 &position);
 
-    /// Create a CubeType::Octants cube.
-    ///
-    /// @param octants The octants (i.e. sub-cubes) of the cube.
-    /// @param size The maximum size of the cube.
-    /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
-    /// x, y, and z-axis).
-    Cube(std::array<std::shared_ptr<Cube>, 8> &octants, float size, const glm::vec3 &position);
+        /// Create a CubeType::Octants cube.
+        ///
+        /// @param octants The octants (i.e. sub-cubes) of the cube.
+        /// @param size The maximum size of the cube.
+        /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
+        /// x, y, and z-axis).
+        Cube(std::array<std::shared_ptr<Cube>, 8> &octants, float size, const glm::vec3 &position);
 
-    Cube(const Cube& cube);
-    Cube(Cube &&cube) noexcept;
+        Cube(const Cube &cube);
 
-    Cube& operator=(Cube&& lhs) noexcept;
-    Cube& operator=(const Cube& rhs);
+        Cube(Cube &&cube) noexcept;
 
-    /// Parse an octree from binary data.
-    /// @param data The data to parse the octree from.
-    /// @return Cube object representing the cubes / octrees from the data.
-    static Cube parse(std::vector<unsigned char> &data);
+        Cube &operator=(Cube &&lhs) noexcept;
 
-    /// Parse an octree from a BitStream.
-    /// @param stream The BitStream to parse the octree from.
-    /// @return Cube object representing the cubes / octrees from the stream.
-    static Cube parse(BitStream &stream);
+        Cube &operator=(const Cube &rhs);
 
-    /// Parse an octree from a BitStream.
-    /// @param stream The BitStream to parse the octree from.
-    /// @param size The maximum size of the cube.
-    /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
-    /// x, y, and z-axis).
-    /// @return Cube object representing the cubes / octrees from the stream.
-    static Cube parse(BitStream &stream, float size, const glm::vec3 &position);
+        /// Parse an octree from binary data.
+        /// @param data The data to parse the octree from.
+        /// @return Cube object representing the cubes / octrees from the data.
+        static Cube parse(std::vector<unsigned char> &data);
 
-    /// Get the type of the cube.
-    /// @return type of the cube.
-    [[nodiscard]] CubeType type();
+        /// Parse an octree from a BitStream.
+        /// @param stream The BitStream to parse the octree from.
+        /// @return Cube object representing the cubes / octrees from the stream.
+        static Cube parse(BitStream &stream);
 
-    /// Get the number of leaves, this octree contains.
-    /// Leaves are cubes of CubeType::INDENTED or CubeTYPE::FULL.
-    /// @return Number of leaves, this octree contains.
-    [[nodiscard]] std::uint64_t leaves();
+        /// Parse an octree from a BitStream.
+        /// @param stream The BitStream to parse the octree from.
+        /// @param size The maximum size of the cube.
+        /// @param position The position of the cube in the coordinate system (i.e., the vector from (0, 0, 0) to the bounds of the cube with the lowest values on
+        /// x, y, and z-axis).
+        /// @return Cube object representing the cubes / octrees from the stream.
+        static Cube parse(BitStream &stream, float size, const glm::vec3 &position);
 
-    // [[nodiscard]] dynamic_bitset<> bits(); // Bit representation of this cube
-    // [[nodiscard]] vector<array<glm::vec3, 8>> vertices(); // All vertices this cube contains.
-    // [[nodiscard]] vector<array<glm::vec3, 4>> sides(); // All sides this cube contains.
-    /// Get all polygons (triangles) of each cube of this octree.
-    /// @return A vector which contains the three vertices representing a triangle.
-    [[nodiscard]] std::vector<std::array<glm::vec3, 3>> polygons(); // All polygons this cube contains.
+        /// Get the type of the cube.
+        /// @return type of the cube.
+        [[nodiscard]] CubeType type();
 
-    /// Invalidate the cache of this cube / octree (not its children).
-    void invalidate_cache();
+        /// Get the number of leaves, this octree contains.
+        /// Leaves are cubes of CubeType::INDENTED or CubeTYPE::FULL.
+        /// @return Number of leaves, this octree contains.
+        [[nodiscard]] std::uint64_t leaves();
 
-    /// Make this octree reactive (update its values when one of its attributes changes).
-    /// @param force Whether to make it reactive again even though the connections were established before.
-    void make_reactive(bool force = false);
-};
+        // [[nodiscard]] dynamic_bitset<> bits(); // Bit representation of this cube
+        // [[nodiscard]] vector<array<glm::vec3, 8>> vertices(); // All vertices this cube contains.
+        // [[nodiscard]] vector<array<glm::vec3, 4>> sides(); // All sides this cube contains.
+        /// Get all polygons (triangles) of each cube of this octree.
+        /// @return A vector which contains the three vertices representing a triangle.
+        [[nodiscard]] std::vector<std::array<glm::vec3, 3>> polygons(); // All polygons this cube contains.
+
+        /// Invalidate the cache of this cube / octree (not its children).
+        void invalidate_cache();
+
+        /// Make this octree reactive (update its values when one of its attributes changes).
+        /// @param force Whether to make it reactive again even though the connections were established before.
+        void make_reactive(bool force = false);
+    };
 } // namespace inexor::vulkan_renderer::world

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -60,7 +60,7 @@ public:
     /// @param z Indentation leven on the z-axis
     explicit Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
 
-    Indentation(Indentation& indentation);
+    Indentation(const Indentation& indentation);
     Indentation(Indentation &&indentation) noexcept;
 
     /// Signal emitted when one of the indentation levels changes.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -63,7 +63,7 @@ public:
     /// @param x Indentation leven on the x-axis
     /// @param y Indentation leven on the y-axis
     /// @param z Indentation leven on the z-axis
-    explicit Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
+    Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
 
     Indentation(const Indentation& indentation);
     Indentation(Indentation &&indentation) noexcept;

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -100,7 +100,7 @@ public:
     [[nodiscard]] std::uint8_t z() const;
 
     /// Get the indentation levels on all three axes as a glm::tvec3<std::uint8_t>.
-    /// @return all three axes as a glm::tvec3<std::uint8_t>
+    /// @return indentation levels on all three axes
     [[nodiscard]] glm::tvec3<std::uint8_t> vec() const;
 
     // TODO: Get bits from values.
@@ -170,6 +170,9 @@ private:
 
     /// Whether this->_polygons_cache is valid and might be used.
     bool valid_cache = false;
+
+    /// Whether this octree is reactive (i.e. updates when childs update).
+    bool is_reactive = false;
 
     /// Type of the cube.
     CubeType cube_type = CubeType::EMPTY;
@@ -268,5 +271,9 @@ public:
 
     /// Invalidate the cache of this cube / octree (not its children).
     void invalidate_cache();
+
+    /// Make this octree reactive (update its values when one of its attributes changes).
+    /// @param force Whether to make it reactive again even though the connections were established before.
+    void make_reactive(bool force = false);
 };
 } // namespace inexor::vulkan_renderer::world

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -60,9 +60,21 @@ public:
     /// @param z Indentation leven on the z-axis
     explicit Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z);
 
+    Indentation(Indentation& indentation);
+    Indentation(Indentation &&indentation) noexcept;
+
     /// Signal emitted when one of the indentation levels changes.
     /// Argument: the indentation emitting the signal ("this").
     boost::signals2::signal<void(Indentation *)> on_change;
+
+    Indentation& operator=(Indentation&& other) noexcept;
+    Indentation& operator=(const Indentation& rhs);
+    Indentation& operator=(const glm::tvec3<uint8_t>& rhs);
+    Indentation& operator+=(const glm::tvec3<int8_t>& other);
+    Indentation& operator-=(const glm::tvec3<int8_t>& other);
+
+    [[nodiscard]] bool equal_values(const Indentation &other) const;
+    [[nodiscard]] bool equal_values(const glm::tvec3<uint8_t> &other) const;
 
     /// Set the indentations depth for the axis.
     /// @param x Indentation leven on the x-axis.
@@ -168,7 +180,7 @@ private:
     /// Cache of this cubes polygons. Not of its octants (i.e., empty of the cube is of type CubeType::OCTANTS).
     std::array<std::array<glm::vec3, 3>, 12> polygons_cache = {}; // Vertices of this cube (not its octants)
 
-    /// Whether this->_polygons_cache is valid and might be used.
+    /// Whether this->polygons_cache is valid and might be used.
     bool valid_cache = false;
 
     /// Whether this octree is reactive (i.e. updates when childs update).

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -272,7 +272,14 @@ VkResult Application::load_octree_geometry() {
     std::vector<unsigned char> test = {0xC4, 0x52, 0x03, 0xC0, 0x00, 0x00};
 
     world::Cube cube = world::Cube::parse(test);
+    cube.make_reactive();
+
+    cube.on_change.connect([](world::Cube* c) {
+        spdlog::debug("THE WORLD (octree) HAS CHANGED!");
+    });
+
     cube.octants.value()[6]->indentations.value()[4].set_z(4);
+
     std::vector<std::array<glm::vec3, 3>> polygons = cube.polygons();
     std::vector<OctreeVertex> octree_vertices;
     octree_vertices.resize(polygons.size() * 3);

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -279,6 +279,7 @@ VkResult Application::load_octree_geometry() {
     });
 
     cube.octants.value()[6]->indentations.value()[4].set_z(4);
+    cube.octants.value()[6]->indentations.value()[4] += {1, 1, -3};
 
     std::vector<std::array<glm::vec3, 3>> polygons = cube.polygons();
     std::vector<OctreeVertex> octree_vertices;

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -269,7 +269,7 @@ VkResult Application::load_octree_geometry() {
 
     spdlog::debug("Creating octree geometry.");
 
-    std::vector<unsigned char> test = {0xC4, 0x52, 0x03, 0x00, 0x00, 0x00};
+    std::vector<unsigned char> test = {0xC4, 0x52, 0x03, 0xC0, 0x00, 0x00};
 
     world::Cube cube = world::Cube::parse(test);
     cube.octants.value()[6]->indentations.value()[4].set_z(4);

--- a/src/vulkan-renderer/world/bit_stream.cpp
+++ b/src/vulkan-renderer/world/bit_stream.cpp
@@ -52,6 +52,6 @@ std::optional<std::uint8_t> BitStream::get(std::uint8_t size) {
     this->data++;
 
     assert(this->bytes_left);
-    return current | this->get(overflow).value();
+    return current << overflow | this->get(overflow).value();
 }
 } // namespace inexor::vulkan_renderer::world

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -454,4 +454,4 @@ std::array<glm::tvec3<std::uint8_t>, 8> Cube::indentation_levels() {
     }
     return in;
 }
-}// namespace inexor::vulkan_render::world
+} // namespace inexor::vulkan_render::world

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -4,13 +4,13 @@
 namespace inexor::vulkan_renderer::world {
 void Indentation::set(std::optional<std::uint8_t> x, std::optional<std::uint8_t> y, std::optional<std::uint8_t> z) {
     assert(x <= MAX_INDENTATION && y <= MAX_INDENTATION && z <= MAX_INDENTATION);
-    if (x != std::nullopt) {
+    if (x) {
         this->x_level = x.value();
     }
-    if (y != std::nullopt) {
+    if (y) {
         this->y_level = y.value();
     }
-    if (z != std::nullopt) {
+    if (z) {
         this->z_level = z.value();
     }
     this->change();
@@ -207,14 +207,14 @@ void Cube::make_reactive(bool force) {
     if (!force && this->is_reactive) {
         return;
     }
-    if (this->indentations != std::nullopt) {
+    if (this->indentations) {
         for (auto &indentation : this->indentations.value()) {
             indentation.on_change.connect([this](Indentation *i) {
                 this->change(i);
             });
         }
     }
-    if (this->octants != std::nullopt) {
+    if (this->octants) {
         for (auto &octant : this->octants.value()) {
             octant->make_reactive(force);
             octant->on_change.connect([this](Cube *o) {

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -133,7 +133,7 @@ Indentation &Indentation::operator=(Indentation&& lhs) noexcept {
     }
     return *this;
 }
-Indentation::Indentation(Indentation& indentation): Indentation(indentation.x_level, indentation.y_level, indentation.z_level) {}
+Indentation::Indentation(const Indentation& indentation): Indentation(indentation.x_level, indentation.y_level, indentation.z_level) {}
 Indentation::Indentation(Indentation&& indentation) noexcept : Indentation(indentation.x_level, indentation.y_level, indentation.z_level) {}
 
 #pragma clang diagnostic pop

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -2,456 +2,465 @@
 #include <utility>
 
 namespace inexor::vulkan_renderer::world {
-void Indentation::set(std::optional<std::uint8_t> x, std::optional<std::uint8_t> y, std::optional<std::uint8_t> z) {
-    assert(x <= MAX_INDENTATION && y <= MAX_INDENTATION && z <= MAX_INDENTATION);
-    if (x) {
-        this->x_level = x.value();
-    }
-    if (y) {
-        this->y_level = y.value();
-    }
-    if (z) {
-        this->z_level = z.value();
-    }
-    this->change();
-}
-
-void Indentation::set_x(std::uint8_t x) {
-    assert(x <= MAX_INDENTATION);
-    this->x_level = x;
-    this->change();
-}
-
-void Indentation::set_y(std::uint8_t y) {
-    assert(y <= MAX_INDENTATION);
-    this->y_level = y;
-    this->change();
-}
-
-void Indentation::set_z(std::uint8_t z) {
-    assert(z <= MAX_INDENTATION);
-    this->z_level = z;
-    this->change();
-}
-
-std::uint8_t Indentation::x() const {
-    return this->x_level;
-}
-
-std::uint8_t Indentation::y() const {
-    return this->y_level;
-}
-
-std::uint8_t Indentation::z() const {
-    return this->z_level;
-}
-
-Indentation Indentation::parse(BitStream &stream) {
-    // Parse each indentation level one by one.
-    return Indentation(Indentation::parse_one(stream), Indentation::parse_one(stream),
-                       Indentation::parse_one(stream));
-}
-
-std::uint8_t Indentation::parse_one(BitStream &stream) {
-    bool indented = stream.get(1).value();
-    if (indented) {
-        // If it is indented it cannot be 0.
-        // Thus the format saves the real value - 1.
-        return stream.get(3).value() + 1;
-    }
-    return 0;
-}
-
-Indentation::Indentation() = default;
-
-Indentation::Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z) {
-    assert(x <= MAX_INDENTATION && y <= MAX_INDENTATION && z <= MAX_INDENTATION);
-    this->x_level = x;
-    this->y_level = y;
-    this->z_level = z;
-}
-
-Indentation::Indentation(const Indentation &indentation) : Indentation(indentation.x_level, indentation.y_level,
-                                                                       indentation.z_level) {}
-
-Indentation::Indentation(Indentation &&indentation) noexcept: Indentation(indentation.x_level, indentation.y_level,
-                                                                          indentation.z_level) {}
-
-glm::tvec3<std::uint8_t> Indentation::vec() const {
-    return {this->x_level, this->y_level, this->z_level};
-}
-
-Indentation &Indentation::operator=(const Indentation &rhs) {
-    if (this->copy_values(rhs)) {
-        this->on_change(this);
-    }
-    return *this;
-}
-
-bool Indentation::equal_values(const glm::tvec3<uint8_t> &other) const {
-    return this->x_level != other.x && this->y_level != other.y && this->z_level != other.z;
-}
-
-bool Indentation::equal_values(const Indentation &other) const {
-    return this->x_level == other.x_level && this->y_level == other.y_level && this->z_level == other.z_level;
-}
-
-void Indentation::change() {
-    this->on_change(this);
-}
-
-bool Indentation::copy_values(const Indentation &indentation) {
-    if (this != &indentation && !this->equal_values(indentation)) {
-        this->x_level = indentation.x_level;
-        this->y_level = indentation.y_level;
-        this->z_level = indentation.z_level;
-        return true;
-    }
-    return false;
-}
-
-Indentation &Indentation::operator=(const glm::tvec3<uint8_t> &rhs) {
-    assert(rhs.x >= 0 && rhs.x <= MAX_INDENTATION);
-    assert(rhs.y >= 0 && rhs.y <= MAX_INDENTATION);
-    assert(rhs.z >= 0 && rhs.z <= MAX_INDENTATION);
-    if (!this->equal_values(rhs)) {
-        this->x_level = rhs.x;
-        this->y_level = rhs.y;
-        this->z_level = rhs.z;
-        this->on_change(this);
-    }
-    return *this;
-}
-
-Indentation &Indentation::operator=(Indentation &&lhs) noexcept {
-    if (this->copy_values(lhs)) {
-        this->on_change(this);
-    }
-    return *this;
-}
-
-Indentation &Indentation::operator+=(const glm::tvec3<int8_t> &other) {
-    if (other.x != 0 || other.y != 0 || other.z != 0) {
-        this->x_level = std::clamp(this->x_level + other.x, 0, static_cast<int>(MAX_INDENTATION));
-        this->y_level = std::clamp(this->y_level + other.y, 0, static_cast<int>(MAX_INDENTATION));
-        this->z_level = std::clamp(this->z_level + other.z, 0, static_cast<int>(MAX_INDENTATION));
-        this->on_change(this);
-    }
-    return *this;
-}
-
-Indentation &Indentation::operator-=(const glm::tvec3<int8_t> &other) {
-    return (*this += {-other.x, -other.y, -other.z});
-}
-
-
-Cube::Cube(CubeType type, float size, const glm::vec3 &position,
-           const std::optional<std::array<Indentation, 8>> &indentations,
-           std::optional<std::array<std::shared_ptr<Cube>, 8>> octants) {
-    this->cube_type = type;
-    this->cube_size = size;
-    this->cube_position = position;
-    this->indentations = indentations;
-    this->octants = std::move(octants);
-}
-
-Cube::Cube(CubeType type, float size, const glm::vec3 &position) {
-    this->cube_type = type;
-    this->cube_size = size;
-    this->cube_position = position;
-}
-
-Cube::Cube(std::array<Indentation, 8> &indentations, float size, const glm::vec3 &position) : Cube(
-    CubeType::INDENTED, size, position) {
-    // Parse indentations to std::optional<...>
-    this->indentations = {indentations};
-}
-
-Cube::Cube(std::array<std::shared_ptr<Cube>, 8> &octants, float size, const glm::vec3 &position) : Cube(
-    CubeType::OCTANT, size, position) {
-    // Parse octants to std::optional<...>
-    this->octants = {static_cast<std::array<std::shared_ptr<Cube>, 8> &&>(octants)};
-}
-
-Cube::Cube(const Cube &cube): Cube(cube.cube_type, cube.cube_size, cube.cube_position, cube.indentations, cube.octants) {}
-
-Cube::Cube(Cube &&cube) noexcept: Cube(cube.cube_type, cube.cube_size, cube.cube_position, cube.indentations, cube.octants) {}
-
-Cube &Cube::operator=(Cube &&lhs) noexcept {
-    if (this->copy_values(lhs)) {
-        this->on_change(this);
-    }
-    return *this;
-}
-
-Cube &Cube::operator=(const Cube &rhs) {
-    if (this->copy_values(rhs)) {
-        this->on_change(this);
-    }
-    return *this;
-}
-
-bool Cube::copy_values(const Cube &cube) {
-    if (this != &cube) {
-        this->cube_position = cube.cube_position;
-        this->cube_size = cube.cube_size;
-        this->cube_type = cube.cube_type;
-        this->octants = cube.octants;
-        this->indentations = cube.indentations;
-        return true;
-    }
-    return false;
-}
-
-void Cube::make_reactive(bool force) {
-    if (!force && this->is_reactive) {
-        return;
-    }
-    if (this->indentations) {
-        for (auto &indentation : this->indentations.value()) {
-            indentation.on_change.connect([this](Indentation *i) {
-                this->change(i);
-            });
+    void Indentation::set(std::optional<std::uint8_t> x, std::optional<std::uint8_t> y, std::optional<std::uint8_t> z) {
+        assert(x <= MAX_INDENTATION && y <= MAX_INDENTATION && z <= MAX_INDENTATION);
+        if (x) {
+            this->x_level = x.value();
         }
-    }
-    if (this->octants) {
-        for (auto &octant : this->octants.value()) {
-            octant->make_reactive(force);
-            octant->on_change.connect([this](Cube *o) {
-                this->change();
-            });
+        if (y) {
+            this->y_level = y.value();
         }
-    }
-}
-
-Cube Cube::parse(std::vector<unsigned char> &data) {
-    BitStream stream = BitStream(data.data(), data.size());
-    return Cube::parse(stream);
-}
-
-Cube Cube::parse(BitStream &stream) {
-    return Cube::parse(stream, DEFAULT_CUBE_SIZE, DEFAULT_CUBE_POSITION);
-}
-
-Cube Cube::parse(BitStream &stream, float size, const glm::vec3 &position) {
-    CubeType type = static_cast<CubeType>(stream.get(2).value());
-    if (type == CubeType::EMPTY || type == CubeType::FULL) {
-        return Cube(type, size, position);
-    }
-    if (type == CubeType::INDENTED) {
-        // Parse indentations
-        std::array<Indentation, 8> indentations;
-        for (std::uint8_t i = 0; i < 8; i++) {
-            indentations[i] = Indentation::parse(stream);
+        if (z) {
+            this->z_level = z.value();
         }
-        return Cube(indentations, size, position);
+        this->change();
     }
 
-    assert(type == CubeType::OCTANT);
-    // Parse the octants.
-    const float half = size / 2;
-    const float x = position.x;
-    const float y = position.y;
-    const float z = position.z;
-    const float xh = x + half;
-    const float yh = y + half;
-    const float zh = z + half;
-    std::array<std::shared_ptr<Cube>, 8> octants = {
-        std::make_shared<Cube>(Cube::parse(stream, half, {x, y, z})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {x, y, zh})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {x, yh, z})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {x, yh, zh})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {xh, y, z})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {xh, y, zh})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {xh, yh, z})),
-        std::make_shared<Cube>(Cube::parse(stream, half, {xh, yh, zh}))};
-    return Cube(octants, size, position);
-}
-
-CubeType Cube::type() {
-    return this->cube_type;
-}
-
-std::vector<std::array<glm::vec3, 3>> Cube::polygons() {
-    std::vector<std::array<glm::vec3, 3>> polygons;
-
-    std::uint64_t i = 0;
-
-    polygons.resize(this->leaves() * 12);
-
-    auto polygons_pointer = polygons.data();
-    this->all_polygons(polygons_pointer);
-    return polygons;
-}
-
-void Cube::all_polygons(std::array<glm::vec3, 3> *&polygons) {
-    if (this->cube_type == CubeType::EMPTY) {
-        return;
+    void Indentation::set_x(std::uint8_t x) {
+        assert(x <= MAX_INDENTATION);
+        this->x_level = x;
+        this->change();
     }
-    if (this->cube_type == CubeType::OCTANT) {
-        for (const auto &octant : this->octants.value()) {
-            octant->all_polygons(polygons);
+
+    void Indentation::set_y(std::uint8_t y) {
+        assert(y <= MAX_INDENTATION);
+        this->y_level = y;
+        this->change();
+    }
+
+    void Indentation::set_z(std::uint8_t z) {
+        assert(z <= MAX_INDENTATION);
+        this->z_level = z;
+        this->change();
+    }
+
+    std::uint8_t Indentation::x() const {
+        return this->x_level;
+    }
+
+    std::uint8_t Indentation::y() const {
+        return this->y_level;
+    }
+
+    std::uint8_t Indentation::z() const {
+        return this->z_level;
+    }
+
+    Indentation Indentation::parse(BitStream &stream) {
+        // Parse each indentation level one by one.
+        return Indentation(Indentation::parse_one(stream), Indentation::parse_one(stream),
+                           Indentation::parse_one(stream));
+    }
+
+    std::uint8_t Indentation::parse_one(BitStream &stream) {
+        bool indented = stream.get(1).value();
+        if (indented) {
+            // If it is indented it cannot be 0.
+            // Thus the format saves the real value - 1.
+            return stream.get(3).value() + 1;
         }
-        return;
+        return 0;
     }
 
-    // _type == (FULL or INDENTED)
-    if (!this->valid_cache) {
-        if (this->cube_type == CubeType::FULL) {
-            this->polygons_cache = this->full_polygons();
-        } else {
-            this->polygons_cache = this->indented_polygons();
+    Indentation::Indentation() = default;
+
+    Indentation::Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z) {
+        assert(x <= MAX_INDENTATION && y <= MAX_INDENTATION && z <= MAX_INDENTATION);
+        this->x_level = x;
+        this->y_level = y;
+        this->z_level = z;
+    }
+
+    Indentation::Indentation(const Indentation &indentation) : Indentation(indentation.x_level, indentation.y_level,
+                                                                           indentation.z_level) {}
+
+    Indentation::Indentation(Indentation &&indentation) noexcept: Indentation(indentation.x_level, indentation.y_level,
+                                                                              indentation.z_level) {}
+
+    glm::tvec3<std::uint8_t> Indentation::vec() const {
+        return {this->x_level, this->y_level, this->z_level};
+    }
+
+    Indentation &Indentation::operator=(const Indentation &rhs) {
+        if (this->copy_values(rhs)) {
+            this->on_change(this);
         }
-        this->valid_cache = true;
+        return *this;
     }
 
-    // TODO: Let polygons return std::array of pointers to cache instead of copying the value.
-    for (const auto polygon : this->polygons_cache) {
-        *polygons = polygon;
-        polygons++;
+    bool Indentation::equal_values(const glm::tvec3<uint8_t> &other) const {
+        return this->x_level != other.x && this->y_level != other.y && this->z_level != other.z;
     }
-}
 
-std::uint64_t Cube::leaves() {
-    switch (this->cube_type) {
-        case CubeType::EMPTY:
-            return 0;
-        case CubeType::FULL:
-        case CubeType::INDENTED:
-            return 1;
-        case CubeType::OCTANT:
-            std::uint64_t i = 0;
-            for (const auto &octant : this->octants.value()) {
-                i += octant->leaves();
+    bool Indentation::equal_values(const Indentation &other) const {
+        return this->x_level == other.x_level && this->y_level == other.y_level && this->z_level == other.z_level;
+    }
+
+    void Indentation::change() {
+        this->on_change(this);
+    }
+
+    bool Indentation::copy_values(const Indentation &indentation) {
+        if (this != &indentation && !this->equal_values(indentation)) {
+            this->x_level = indentation.x_level;
+            this->y_level = indentation.y_level;
+            this->z_level = indentation.z_level;
+            return true;
+        }
+        return false;
+    }
+
+    Indentation &Indentation::operator=(const glm::tvec3<uint8_t> &rhs) {
+        assert(rhs.x >= 0 && rhs.x <= MAX_INDENTATION);
+        assert(rhs.y >= 0 && rhs.y <= MAX_INDENTATION);
+        assert(rhs.z >= 0 && rhs.z <= MAX_INDENTATION);
+        if (!this->equal_values(rhs)) {
+            this->x_level = rhs.x;
+            this->y_level = rhs.y;
+            this->z_level = rhs.z;
+            this->on_change(this);
+        }
+        return *this;
+    }
+
+    Indentation &Indentation::operator=(Indentation &&lhs) noexcept {
+        if (this->copy_values(lhs)) {
+            this->on_change(this);
+        }
+        return *this;
+    }
+
+    Indentation &Indentation::operator+=(const glm::tvec3<int8_t> &other) {
+        if (other.x != 0 || other.y != 0 || other.z != 0) {
+            this->x_level = std::clamp(this->x_level + other.x, 0, static_cast<int>(MAX_INDENTATION));
+            this->y_level = std::clamp(this->y_level + other.y, 0, static_cast<int>(MAX_INDENTATION));
+            this->z_level = std::clamp(this->z_level + other.z, 0, static_cast<int>(MAX_INDENTATION));
+            this->on_change(this);
+        }
+        return *this;
+    }
+
+    Indentation &Indentation::operator-=(const glm::tvec3<int8_t> &other) {
+        return (*this += {-other.x, -other.y, -other.z});
+    }
+
+
+    Cube::Cube(CubeType type, float size, const glm::vec3 &position,
+               const std::optional<std::array<Indentation, 8>> &indentations,
+               std::optional<std::array<std::shared_ptr<Cube>, 8>> octants) {
+        this->cube_type = type;
+        this->cube_size = size;
+        this->cube_position = position;
+        this->indentations = indentations;
+        this->octants = std::move(octants);
+    }
+
+    Cube::Cube(CubeType type, float size, const glm::vec3 &position) {
+        this->cube_type = type;
+        this->cube_size = size;
+        this->cube_position = position;
+    }
+
+    Cube::Cube(std::array<Indentation, 8> &indentations, float size, const glm::vec3 &position) : Cube(
+        CubeType::INDENTED, size, position) {
+        // Parse indentations to std::optional<...>
+        this->indentations = {indentations};
+    }
+
+    Cube::Cube(std::array<std::shared_ptr<Cube>, 8> &octants, float size, const glm::vec3 &position) : Cube(
+        CubeType::OCTANT, size, position) {
+        // Parse octants to std::optional<...>
+        this->octants = {static_cast<std::array<std::shared_ptr<Cube>, 8> &&>(octants)};
+    }
+
+    Cube::Cube(const Cube &cube) : Cube(cube.cube_type, cube.cube_size, cube.cube_position, cube.indentations,
+                                        cube.octants) {}
+
+    Cube::Cube(Cube &&cube) noexcept: Cube(cube.cube_type, cube.cube_size, cube.cube_position, cube.indentations,
+                                           cube.octants) {}
+
+    Cube &Cube::operator=(Cube &&lhs) noexcept {
+        if (this->copy_values(lhs)) {
+            this->on_change(this);
+        }
+        return *this;
+    }
+
+    Cube &Cube::operator=(const Cube &rhs) {
+        if (this->copy_values(rhs)) {
+            this->on_change(this);
+        }
+        return *this;
+    }
+
+    bool Cube::copy_values(const Cube &cube) {
+        if (this != &cube) {
+            this->cube_position = cube.cube_position;
+            this->cube_size = cube.cube_size;
+            this->cube_type = cube.cube_type;
+            this->octants = cube.octants;
+            this->indentations = cube.indentations;
+            return true;
+        }
+        return false;
+    }
+
+    void Cube::make_reactive(bool force) {
+        if (!force && this->is_reactive) {
+            return;
+        }
+        if (this->indentations) {
+            for (auto &indentation : this->indentations.value()) {
+                indentation.on_change.connect([this](Indentation *i) {
+                    this->change(i);
+                });
             }
-            return i;
-    }
-    assert(false); // This point should never be reached, as we handled all types already.
-    return 0;
-}
-
-std::array<std::array<glm::vec3, 3>, 12> Cube::full_polygons(std::array<glm::vec3, 8> &v) {
-    return {{
-                {{v[0], v[2], v[1]}}, // x = 0
-                {{v[1], v[2], v[3]}}, // x = 0
-
-                {{v[4], v[5], v[6]}}, // x = 1
-                {{v[5], v[7], v[6]}}, // x = 1
-
-                {{v[0], v[1], v[4]}}, // y = 0
-                {{v[1], v[5], v[4]}}, // y = 0
-
-                {{v[2], v[6], v[3]}}, // y = 1
-                {{v[3], v[6], v[7]}}, // y = 1
-
-                {{v[0], v[4], v[2]}}, // z = 0
-                {{v[2], v[4], v[6]}}, // z = 0
-
-                {{v[1], v[3], v[5]}}, // z = 1
-                {{v[3], v[7], v[5]}}, // z = 1
-            }};
-}
-
-std::array<std::array<glm::vec3, 3>, 12> Cube::full_polygons() {
-    assert(this->cube_type == CubeType::FULL);
-
-    std::array<glm::vec3, 8> v = this->vertices();
-    return this->full_polygons(v);
-}
-
-std::array<std::array<glm::vec3, 3>, 12> Cube::indented_polygons() {
-    assert(this->cube_type == CubeType::INDENTED);
-
-    std::array<glm::vec3, 8> v = this->vertices();
-
-    std::array<std::array<glm::vec3, 3>, 12> vertices = this->full_polygons(v);
-    std::array<glm::tvec3<std::uint8_t>, 8> in = this->indentation_levels();
-
-    // Check for each side if the side is convex, rotate the hypotenuse so it becomes convex!
-    // x = 0
-    if (in[0].x + in[3].x < in[1].x + in[2].x) {
-        vertices[0] = {{v[0], v[2], v[3]}};
-        vertices[1] = {{v[0], v[3], v[1]}};
+        }
+        if (this->octants) {
+            for (auto &octant : this->octants.value()) {
+                octant->make_reactive(force);
+                octant->on_change.connect([this](Cube *o) {
+                    this->change();
+                });
+            }
+        }
     }
 
-    // x = 1
-    if (in[4].x + in[7].x < in[5].x + in[6].x) {
-        vertices[2] = {{v[4], v[7], v[6]}};
-        vertices[3] = {{v[4], v[5], v[7]}};
+    Cube Cube::parse(std::vector<unsigned char> &data) {
+        BitStream stream = BitStream(data.data(), data.size());
+        return Cube::parse(stream);
     }
 
-    // y = 0
-    if (in[0].y + in[5].y < in[1].y + in[4].y) {
-        vertices[4] = {{v[0], v[1], v[5]}};
-        vertices[5] = {{v[0], v[5], v[4]}};
+    Cube Cube::parse(BitStream &stream) {
+        return Cube::parse(stream, DEFAULT_CUBE_SIZE, DEFAULT_CUBE_POSITION);
     }
 
-    // y = 1
-    if (in[2].y + in[7].y < in[3].y + in[6].y) {
-        vertices[6] = {{v[2], v[7], v[3]}};
-        vertices[7] = {{v[2], v[6], v[7]}};
+    Cube Cube::parse(BitStream &stream, float size, const glm::vec3 &position) {
+        CubeType type = static_cast<CubeType>(stream.get(2).value());
+        if (type == CubeType::EMPTY || type == CubeType::FULL) {
+            return Cube(type, size, position);
+        }
+        if (type == CubeType::INDENTED) {
+            // Parse indentations
+            std::array<Indentation, 8> indentations;
+            for (std::uint8_t i = 0; i < 8; i++) {
+                indentations[i] = Indentation::parse(stream);
+            }
+            return Cube(indentations, size, position);
+        }
+
+        assert(type == CubeType::OCTANT);
+        // Parse the octants.
+        const float half = size / 2;
+        const float x = position.x;
+        const float y = position.y;
+        const float z = position.z;
+        const float xh = x + half;
+        const float yh = y + half;
+        const float zh = z + half;
+        std::array<std::shared_ptr<Cube>, 8> octants = {
+            std::make_shared<Cube>(Cube::parse(stream, half, {x , y , z })),
+            std::make_shared<Cube>(Cube::parse(stream, half, {x , y , zh})),
+            std::make_shared<Cube>(Cube::parse(stream, half, {x , yh, z })),
+            std::make_shared<Cube>(Cube::parse(stream, half, {x , yh, zh})),
+            std::make_shared<Cube>(Cube::parse(stream, half, {xh, y , z })),
+            std::make_shared<Cube>(Cube::parse(stream, half, {xh, y , zh})),
+            std::make_shared<Cube>(Cube::parse(stream, half, {xh, yh, z })),
+            std::make_shared<Cube>(Cube::parse(stream, half, {xh, yh, zh}))};
+        return Cube(octants, size, position);
     }
 
-    // z = 0
-    if (in[0].z + in[6].z < in[2].z + in[4].z) {
-        vertices[8] = {{v[0], v[4], v[6]}};
-        vertices[9] = {{v[0], v[6], v[2]}};
+    CubeType Cube::type() {
+        return this->cube_type;
     }
 
-    // z = 1
-    if (in[1].z + in[7].z < in[3].z + in[6].z) {
-        vertices[10] = {{v[1], v[3], v[7]}};
-        vertices[11] = {{v[1], v[7], v[5]}};
+    std::vector<std::array<glm::vec3, 3>> Cube::polygons() {
+        std::vector<std::array<glm::vec3, 3>> polygons;
+
+        std::uint64_t i = 0;
+
+        polygons.resize(this->leaves() * 12);
+
+        auto polygons_pointer = polygons.data();
+        this->all_polygons(polygons_pointer);
+        return polygons;
     }
-    return vertices;
-}
 
-std::array<glm::vec3, 8> Cube::vertices() {
-    assert(this->cube_type == CubeType::FULL || this->cube_type == CubeType::INDENTED);
-    glm::vec3 &p = this->cube_position;
+    void Cube::all_polygons(std::array<glm::vec3, 3> *&polygons) {
+        if (this->cube_type == CubeType::EMPTY) {
+            return;
+        }
+        if (this->cube_type == CubeType::OCTANT) {
+            for (const auto &octant : this->octants.value()) {
+                octant->all_polygons(polygons);
+            }
+            return;
+        }
 
-    // Most distant corner of a "full" cube (from p)
-    glm::vec3 f = {p.x + this->cube_size, p.y + this->cube_size, p.z + this->cube_size};
+        // _type == (FULL or INDENTED)
+        if (!this->valid_cache) {
+            if (this->cube_type == CubeType::FULL) {
+                this->polygons_cache = this->full_polygons();
+            } else {
+                this->polygons_cache = this->indented_polygons();
+            }
+            this->valid_cache = true;
+        }
 
-    if (this->cube_type == CubeType::FULL) {
-        return std::array<glm::vec3, 8>{
-            {{p.x, p.y, p.z}, {p.x, p.y, f.z}, {p.x, f.y, p.z}, {p.x, f.y, f.z}, {f.x, p.y, p.z}, {f.x, p.y, f.z}, {f.x, f.y, p.z}, {f.x, f.y, f.z}}};
+        // TODO: Let polygons return std::array of pointers to cache instead of copying the value.
+        for (const auto polygon : this->polygons_cache) {
+            *polygons = polygon;
+            polygons++;
+        }
     }
-    assert(this->cube_type == CubeType::INDENTED);
-    const float step = this->cube_size / MAX_INDENTATION;
 
-    std::array<glm::tvec3<std::uint8_t>, 8> in = this->indentation_levels();
-
-    // Calculate the vertex-positions with respect to the indentation level.
-    return std::array<glm::vec3, 8>{{{p.x + step * in[0].x, p.y + step * in[0].y, p.z + step * in[0].z},
-                                        {p.x + step * in[1].x, p.y + step * in[1].y, f.z - step * in[1].z},
-                                        {p.x + step * in[2].x, f.y - step * in[2].y, p.z + step * in[2].z},
-                                        {p.x + step * in[3].x, f.y - step * in[3].y, f.z - step * in[3].z},
-                                        {f.x - step * in[4].x, p.y + step * in[4].y, p.z + step * in[4].z},
-                                        {f.x - step * in[5].x, p.y + step * in[5].y, f.z - step * in[5].z},
-                                        {f.x - step * in[6].x, f.y - step * in[6].y, p.z + step * in[6].z},
-                                        {f.x - step * in[7].x, f.y - step * in[7].y, f.z - step * in[7].z}}};
-}
-
-void Cube::invalidate_cache() {
-    this->valid_cache = false;
-}
-
-void Cube::change() {
-    this->invalidate_cache();
-    this->on_change(this);
-}
-
-void Cube::change(Indentation *indentation) {
-    this->change();
-}
-
-std::array<glm::tvec3<std::uint8_t>, 8> Cube::indentation_levels() {
-    std::array<glm::tvec3<std::uint8_t>, 8> in;
-    auto &indents = this->indentations.value();
-    for (std::size_t i = 0; i < in.size(); i++) {
-        in[i] = indents[i].vec();
+    std::uint64_t Cube::leaves() {
+        switch (this->cube_type) {
+            case CubeType::EMPTY:
+                return 0;
+            case CubeType::FULL:
+            case CubeType::INDENTED:
+                return 1;
+            case CubeType::OCTANT:
+                std::uint64_t i = 0;
+                for (const auto &octant : this->octants.value()) {
+                    i += octant->leaves();
+                }
+                return i;
+        }
+        assert(false); // This point should never be reached, as we handled all types already.
+        return 0;
     }
-    return in;
-}
+
+    std::array<std::array<glm::vec3, 3>, 12> Cube::full_polygons(std::array<glm::vec3, 8> &v) {
+        return {{
+                    {{v[0], v[2], v[1]}}, // x = 0
+                    {{v[1], v[2], v[3]}}, // x = 0
+
+                    {{v[4], v[5], v[6]}}, // x = 1
+                    {{v[5], v[7], v[6]}}, // x = 1
+
+                    {{v[0], v[1], v[4]}}, // y = 0
+                    {{v[1], v[5], v[4]}}, // y = 0
+
+                    {{v[2], v[6], v[3]}}, // y = 1
+                    {{v[3], v[6], v[7]}}, // y = 1
+
+                    {{v[0], v[4], v[2]}}, // z = 0
+                    {{v[2], v[4], v[6]}}, // z = 0
+
+                    {{v[1], v[3], v[5]}}, // z = 1
+                    {{v[3], v[7], v[5]}}, // z = 1
+                }};
+    }
+
+    std::array<std::array<glm::vec3, 3>, 12> Cube::full_polygons() {
+        assert(this->cube_type == CubeType::FULL);
+
+        std::array<glm::vec3, 8> v = this->vertices();
+        return this->full_polygons(v);
+    }
+
+    std::array<std::array<glm::vec3, 3>, 12> Cube::indented_polygons() {
+        assert(this->cube_type == CubeType::INDENTED);
+
+        std::array<glm::vec3, 8> v = this->vertices();
+
+        std::array<std::array<glm::vec3, 3>, 12> vertices = this->full_polygons(v);
+        std::array<glm::tvec3<std::uint8_t>, 8> in = this->indentation_levels();
+
+        // Check for each side if the side is convex, rotate the hypotenuse so it becomes convex!
+        // x = 0
+        if (in[0].x + in[3].x < in[1].x + in[2].x) {
+            vertices[0] = {{v[0], v[2], v[3]}};
+            vertices[1] = {{v[0], v[3], v[1]}};
+        }
+
+        // x = 1
+        if (in[4].x + in[7].x < in[5].x + in[6].x) {
+            vertices[2] = {{v[4], v[7], v[6]}};
+            vertices[3] = {{v[4], v[5], v[7]}};
+        }
+
+        // y = 0
+        if (in[0].y + in[5].y < in[1].y + in[4].y) {
+            vertices[4] = {{v[0], v[1], v[5]}};
+            vertices[5] = {{v[0], v[5], v[4]}};
+        }
+
+        // y = 1
+        if (in[2].y + in[7].y < in[3].y + in[6].y) {
+            vertices[6] = {{v[2], v[7], v[3]}};
+            vertices[7] = {{v[2], v[6], v[7]}};
+        }
+
+        // z = 0
+        if (in[0].z + in[6].z < in[2].z + in[4].z) {
+            vertices[8] = {{v[0], v[4], v[6]}};
+            vertices[9] = {{v[0], v[6], v[2]}};
+        }
+
+        // z = 1
+        if (in[1].z + in[7].z < in[3].z + in[6].z) {
+            vertices[10] = {{v[1], v[3], v[7]}};
+            vertices[11] = {{v[1], v[7], v[5]}};
+        }
+        return vertices;
+    }
+
+    std::array<glm::vec3, 8> Cube::vertices() {
+        assert(this->cube_type == CubeType::FULL || this->cube_type == CubeType::INDENTED);
+        glm::vec3 &p = this->cube_position;
+
+        // Most distant corner of a "full" cube (from p)
+        glm::vec3 f = {p.x + this->cube_size, p.y + this->cube_size, p.z + this->cube_size};
+
+        if (this->cube_type == CubeType::FULL) {
+            return std::array<glm::vec3, 8>{
+                {{p.x, p.y, p.z},
+                 {p.x, p.y, f.z},
+                 {p.x, f.y, p.z},
+                 {p.x, f.y, f.z},
+                 {f.x, p.y, p.z},
+                 {f.x, p.y, f.z},
+                 {f.x, f.y, p.z},
+                 {f.x, f.y, f.z}}};
+        }
+        assert(this->cube_type == CubeType::INDENTED);
+        const float step = this->cube_size / MAX_INDENTATION;
+
+        std::array<glm::tvec3<std::uint8_t>, 8> in = this->indentation_levels();
+
+        // Calculate the vertex-positions with respect to the indentation level.
+        return std::array<glm::vec3, 8>{{{p.x + step * in[0].x, p.y + step * in[0].y, p.z + step * in[0].z},
+                                            {p.x + step * in[1].x, p.y + step * in[1].y, f.z - step * in[1].z},
+                                            {p.x + step * in[2].x, f.y - step * in[2].y, p.z + step * in[2].z},
+                                            {p.x + step * in[3].x, f.y - step * in[3].y, f.z - step * in[3].z},
+                                            {f.x - step * in[4].x, p.y + step * in[4].y, p.z + step * in[4].z},
+                                            {f.x - step * in[5].x, p.y + step * in[5].y, f.z - step * in[5].z},
+                                            {f.x - step * in[6].x, f.y - step * in[6].y, p.z + step * in[6].z},
+                                            {f.x - step * in[7].x, f.y - step * in[7].y, f.z - step * in[7].z}}};
+    }
+
+    void Cube::invalidate_cache() {
+        this->valid_cache = false;
+    }
+
+    void Cube::change() {
+        this->invalidate_cache();
+        this->on_change(this);
+    }
+
+    void Cube::change(Indentation *indentation) {
+        this->change();
+    }
+
+    std::array<glm::tvec3<std::uint8_t>, 8> Cube::indentation_levels() {
+        std::array<glm::tvec3<std::uint8_t>, 8> in;
+        auto &indents = this->indentations.value();
+        for (std::size_t i = 0; i < in.size(); i++) {
+            in[i] = indents[i].vec();
+        }
+        return in;
+    }
 } // namespace inexor::vulkan_renderer::world

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -454,4 +454,4 @@ std::array<glm::tvec3<std::uint8_t>, 8> Cube::indentation_levels() {
     }
     return in;
 }
-} // namespace inexor::vulkan_render::world
+} // namespace inexor::vulkan_renderer::world

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -55,7 +55,9 @@ Indentation::Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z) {
 std::uint8_t Indentation::parse_one(BitStream &stream) {
     bool indented = stream.get(1).value();
     if (indented) {
-        return stream.get(3).value();;
+        // If it is indented it cannot be 0.
+        // Thus the format saves the real value - 1.
+        return stream.get(3).value() + 1;
     }
     return 0;
 }

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -55,7 +55,7 @@ Indentation::Indentation(std::uint8_t x, std::uint8_t y, std::uint8_t z) {
 std::uint8_t Indentation::parse_one(BitStream &stream) {
     bool indented = stream.get(1).value();
     if (indented) {
-        return static_cast<std::uint8_t>(stream.get(3).value());
+        return stream.get(3).value();;
     }
     return 0;
 }

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -75,6 +75,69 @@ void Indentation::change() {
     this->on_change(this);
 }
 
+Indentation& Indentation::operator=(const Indentation& rhs) {
+    if (!this->equal_values(rhs)) {
+        this->x_level = rhs.x_level;
+        this->y_level = rhs.y_level;
+        this->z_level = rhs.z_level;
+        this->on_change(this);
+    }
+    return *this;
+}
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cppcoreguidelines-pro-type-union-access"
+bool Indentation::equal_values(const glm::tvec3<uint8_t> &other) const {
+    return this->x_level != other.x && this->y_level != other.y && this->z_level != other.z;
+}
+
+bool Indentation::equal_values(const Indentation &other) const {
+    return this->x_level == other.x_level && this->y_level == other.y_level && this->z_level == other.z_level;
+}
+
+Indentation& Indentation::operator=(const glm::tvec3<uint8_t>& rhs) {
+    assert(rhs.x >= 0 && rhs.x <= MAX_INDENTATION);
+    assert(rhs.y >= 0 && rhs.y <= MAX_INDENTATION);
+    assert(rhs.z >= 0 && rhs.z <= MAX_INDENTATION);
+    if (!this->equal_values(rhs)) {
+        this->x_level = rhs.x;
+        this->y_level = rhs.y;
+        this->z_level = rhs.z;
+        this->on_change(this);
+    }
+    return *this;
+}
+
+Indentation &Indentation::operator+=(const glm::tvec3<int8_t> &other) {
+    if (other.x != 0 || other.y != 0 || other.z != 0) {
+        this->x_level = std::clamp(this->x_level + other.x, 0, static_cast<int>(MAX_INDENTATION));
+        this->y_level = std::clamp(this->y_level + other.y, 0, static_cast<int>(MAX_INDENTATION));
+        this->z_level = std::clamp(this->z_level + other.z, 0, static_cast<int>(MAX_INDENTATION));
+        this->on_change(this);
+    }
+    return *this;
+}
+
+Indentation &Indentation::operator-=(const glm::tvec3<int8_t> &other) {
+    return (*this += {-other.x, -other.y, -other.z});
+}
+
+Indentation &Indentation::operator=(Indentation&& lhs) noexcept {
+    bool s1 = this != &lhs;
+    bool equal = this->equal_values(lhs);
+    if (this != &lhs && !this->equal_values(lhs)) {
+        this->x_level = lhs.x_level;
+        this->y_level = lhs.y_level;
+        this->z_level = lhs.z_level;
+        this->on_change(this);
+    }
+    return *this;
+}
+Indentation::Indentation(Indentation& indentation): Indentation(indentation.x_level, indentation.y_level, indentation.z_level) {}
+Indentation::Indentation(Indentation&& indentation) noexcept : Indentation(indentation.x_level, indentation.y_level, indentation.z_level) {}
+
+#pragma clang diagnostic pop
+
 Cube::Cube(CubeType type, float size, const glm::vec3 &position) {
     this->cube_type = type;
     this->cube_size = size;
@@ -83,7 +146,7 @@ Cube::Cube(CubeType type, float size, const glm::vec3 &position) {
 
 Cube::Cube(std::array<Indentation, 8> &indentations, float size, const glm::vec3 &position) : Cube(CubeType::INDENTED, size, position) {
     // Parse indentations to std::optional<...>
-    this->indentations = {static_cast<std::array<Indentation, 8> &&>(indentations)};
+    this->indentations = {indentations};
 }
 
 void Cube::make_reactive(bool force) {


### PR DESCRIPTION
This PR aims at adding overloading `=` for the `Cube`-class and overloading the `=`, `-=`, and `+=` for the `Indentation` class.

As I'm fairly new to C++, I would love to see a review considering the following question on the aspect of overloading ([this commit](https://github.com/inexorgame/vulkan-renderer/commit/348725dbf61b431ef68bf625d28ef3365bc5646f#diff-6512ac26a57b9dab0cfd3b6edfeacc41) and [this commit](https://github.com/inexorgame/vulkan-renderer/commit/1c27f8c9cab842cbc597d76e4964c13f1fce7b3f#diff-6512ac26a57b9dab0cfd3b6edfeacc41)):
Does it work as one would expect (i.e., does it follow the C++ best practices)? Are the copy-constructors and the lhs & rhs overloads correctly implemented?
