### PR TITLE
[clang-tidy] Disable cppcoreguidelines-pro-bounds-array-to-pointer-decay

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,clang-analyzer-*,clang-diagnostics-*,cppcoreguidelines-*,google-*,llvm-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-llvm-header-guard'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,clang-analyzer-*,clang-diagnostics-*,cppcoreguidelines-*,google-*,llvm-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-modernize-use-trailing-return-type,-llvm-header-guard,-cppcoreguidelines-pro-bounds-array-to-pointer-decay'
 WarningsAsErrors: ''
 HeaderFilterRegex: 'inexor/*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
Was giving this warning `Do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast instead` on every `assert`.