### PR TITLE
[ci] Add clang format check

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,0 +1,34 @@
+name: Code Style
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clang-format:
+    name: Clang Format
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Update environment
+        shell: bash
+        run: |
+          # Update package lists
+          apt update -qq
+
+          # Install tools
+          apt install -y \
+            clang-format \
+            git
+
+      - name: Style check
+        shell: bash
+        run: |
+          git-clang-format origin/master
+          git diff | tee format-diff
+          if [ -s format-diff ]; then exit 1; fi


### PR DESCRIPTION
- Run clang-format on diff of PR
- Only works on PRs were the base branch is master, I couldn't figure out a way to get the current branch in actions
- Doesn't change any code, only fails if the code hasn't been formatted properly.