### PR TITLE
Cleanup command line parser

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -24,10 +24,7 @@ int main(int argc, char *argv[]) {
     spdlog::debug("Parsing command line arguments.");
 
     Application renderer;
-    // We use some simple command line argument parser we wrote ourselves.
-    renderer.parse_command_line_arguments(argc, argv);
-
-    VkResult result = renderer.init();
+    VkResult result = renderer.init(argc, argv);
 
     if (VK_SUCCESS == result) {
         renderer.run();

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -16,7 +16,7 @@
 
 namespace inexor::vulkan_renderer {
 
-class Application : public VulkanRenderer, public tools::CommandLineArgumentParser {
+class Application : public VulkanRenderer {
 public:
     Application() = default;
 
@@ -85,7 +85,7 @@ private:
     double cursor_x, cursor_y;
 
 public:
-    VkResult init();
+    VkResult init(int argc, char **argv);
 
     /// @brief Keyboard input callback.
     /// @param window [in] The glfw window.

--- a/src/vulkan-renderer/tools/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/cla_parser.cpp
@@ -1,174 +1,72 @@
 ﻿#include "inexor/vulkan-renderer/tools/cla_parser.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <stdexcept>
+
 namespace inexor::vulkan_renderer::tools {
-CommandLineArgumentTemplate::CommandLineArgumentTemplate(CommandLineArgumentType param_type, std::string param_name) : argument_type(param_type), argument_name(param_name) {
 
+template <>
+int CommandLineArgumentValue::as() const {
+    return std::stoi(value);
 }
 
-bool CommandLineArgumentParser::does_command_line_argument_template_exist(const std::string argument_name) {
-    for (const auto &accepted_argument : list_of_accepted_command_line_arguments) {
-        if (0 == accepted_argument.argument_name.compare(argument_name)) {
-            // Yes, this argument is known to the application.
-            return true;
-        }
-    }
-
-    return false;
-}
-
-std::optional<bool> CommandLineArgumentParser::is_command_line_argument_specified(const std::string argument_name) {
-    if (!does_command_line_argument_template_exist(argument_name)) {
-        return std::nullopt;
-    }
-
-    std::unordered_map<std::string, CommandLineArgumentValue>::const_iterator argument_specified = parsed_command_line_arguments.find(argument_name);
-
-    if (argument_specified == parsed_command_line_arguments.end()) {
+template <>
+bool CommandLineArgumentValue::as() const {
+    if (value == "false") {
         return false;
-    } else {
+    }
+
+    if (value == "true") {
         return true;
     }
 
-    return std::nullopt;
+    return static_cast<bool>(as<int>());
 }
 
-const std::optional<CommandLineArgumentType> CommandLineArgumentParser::get_argument_template_type(const std::string &argument_name) {
-    if (does_command_line_argument_template_exist(argument_name)) {
-        for (const auto &argument_template : list_of_accepted_command_line_arguments) {
-            if (0 == argument_template.argument_name.compare(argument_name)) {
-                return argument_template.argument_type;
-            }
-        }
+template <>
+std::uint32_t CommandLineArgumentValue::as() const {
+    return static_cast<std::uint32_t>(as<int>());
+}
+
+std::optional<CommandLineArgumentTemplate> CommandLineArgumentParser::get_arg_template(const std::string &argument_name) const {
+    // clang-format off
+    auto it = std::find_if(accepted_args.begin(), accepted_args.end(), [&](const auto &accepted_arg) {
+        return argument_name == accepted_arg.get_argument();
+    });
+    // clang-format on
+
+    if (it == accepted_args.end()) {
+        return std::nullopt;
     }
 
-    return std::nullopt;
+    return *it;
 }
 
-void CommandLineArgumentParser::parse_command_line_arguments(std::size_t argument_count, char *arguments[]) {
-    // Start the loop with 1, since index 0 is the path to the application itself + the applications name.
-    for (std::size_t i = 0; i < argument_count; i++) {
-        std::string argument_name = arguments[i];
+void CommandLineArgumentParser::parse_args(int argc, char **argv) {
+    for (int i = 1; i < argc; i++) {
+        // NOLINTNEXTLINE
+        std::string arg_name = {argv[i]};
+        auto arg_template = get_arg_template(arg_name);
 
-        // Check if the argument specified is even wated by the application.
-        if (does_command_line_argument_template_exist(argument_name)) {
-            CommandLineArgumentValue new_parsed_value;
-
-            auto command_line_type = get_argument_template_type(argument_name).value();
-
-            if (CommandLineArgumentType::NONE == command_line_type) {
-                // No follow-up argument required.
-                new_parsed_value.type = CommandLineArgumentType::NONE;
-            } else {
-                // Check if the next argument can be accepted as index for the value.
-                if ((i + 1) < argument_count) {
-                    std::string argument_value = arguments[1 + i];
-
-                    // Yes, this is an argument that the application supports.
-                    // Now let's try to parse the argument.
-                    switch (command_line_type) {
-                    case CommandLineArgumentType::STRING: {
-                        new_parsed_value.type = CommandLineArgumentType::STRING;
-                        new_parsed_value.value_str = std::string(argument_value);
-                        break;
-                    }
-                    case CommandLineArgumentType::UINT32: {
-                        new_parsed_value.type = CommandLineArgumentType::UINT32;
-                        new_parsed_value.value_uint32 = static_cast<std::uint32_t>(std::stoi(argument_value));
-                        break;
-                    }
-                    case CommandLineArgumentType::INT64: {
-                        new_parsed_value.type = CommandLineArgumentType::INT64;
-                        new_parsed_value.value_int64 = static_cast<std::int64_t>(std::stoi(argument_value));
-                        break;
-                    }
-                    case CommandLineArgumentType::BOOL: {
-                        new_parsed_value.type = CommandLineArgumentType::BOOL;
-
-                        if (std::stoi(argument_value) > 0) {
-                            new_parsed_value.value_bool = true;
-                        } else {
-                            new_parsed_value.value_bool = false;
-                        }
-
-                        break;
-                    }
-                    }
-                } else {
-                    spdlog::error("Argument {} is accepted but no value specified!", arguments[i]);
-                }
-            }
-
-            // Add the new parsed command line argument to the buffer.
-            parsed_command_line_arguments[argument_name] = new_parsed_value;
-
-            number_of_parsed_command_line_arguments++;
-
-            // This was the parameter value for the argument, therefore move on!
-            if (CommandLineArgumentType::NONE != new_parsed_value.type) {
-                i++;
-            }
-        } else {
-            if (i > 0) {
-                // The user specified a command line argument which is not known to the application!
-                spdlog::warn("Warning: Unknown command line argument {}", arguments[i]);
-            }
+        if (!arg_template) {
+            spdlog::warn("Unknown command line argument {}!", arg_name);
+            continue;
         }
+
+        if (!arg_template->does_take_values()) {
+            parsed_arguments.insert(std::make_pair(arg_name, ""));
+            continue;
+        }
+
+        if (i + 1 >= argc) {
+            throw std::runtime_error("No value specified for argument " + arg_name);
+        }
+
+        // NOLINTNEXTLINE
+        std::string arg_value = {argv[++i]};
+        parsed_arguments.insert(std::make_pair(arg_name, arg_value));
     }
 }
 
-const std::int64_t CommandLineArgumentParser::get_number_of_parsed_command_line_arguments() {
-    return number_of_parsed_command_line_arguments;
-}
-
-const std::optional<bool> CommandLineArgumentParser::get_command_line_argument_bool(const std::string &argument_name) {
-    if (does_command_line_argument_template_exist(argument_name)) {
-        if (is_command_line_argument_specified(argument_name)) {
-            auto return_value = parsed_command_line_arguments[argument_name];
-            if (CommandLineArgumentType::BOOL == return_value.type) {
-                return return_value.value_bool;
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-const std::optional<std::string> CommandLineArgumentParser::get_command_line_argument_string(const std::string &argument_name) {
-    if (does_command_line_argument_template_exist(argument_name)) {
-        if (is_command_line_argument_specified(argument_name)) {
-            auto return_value = parsed_command_line_arguments[argument_name];
-            if (CommandLineArgumentType::STRING == return_value.type) {
-                return return_value.value_str;
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-const std::optional<std::int64_t> CommandLineArgumentParser::get_command_line_argument_int64(const std::string &argument_name) {
-    if (does_command_line_argument_template_exist(argument_name)) {
-        if (is_command_line_argument_specified(argument_name)) {
-            auto return_value = parsed_command_line_arguments[argument_name];
-            if (CommandLineArgumentType::INT64 == return_value.type) {
-                return return_value.value_int64;
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-const std::optional<std::uint32_t> CommandLineArgumentParser::get_command_line_argument_uint32(const std::string &argument_name) {
-    if (does_command_line_argument_template_exist(argument_name)) {
-        if (is_command_line_argument_specified(argument_name)) {
-            auto return_value = parsed_command_line_arguments[argument_name];
-            if (CommandLineArgumentType::UINT32 == return_value.type) {
-                return return_value.value_uint32;
-            }
-        }
-    }
-
-    return std::nullopt;
-}
 } // namespace inexor::vulkan_renderer::tools


### PR DESCRIPTION
- Refactored `CommandLineArgumentValue` by making a templated `as` function
  - Also removed `CommnandLineArgumentType`
- Refactored `CommandLineArgumentParser`
  - Shortened names
  -  Rewrote `parse_args` function
- Made the parser a member of `Application` rather than inheriting from it
- Made command line arguments follow more of a posix/gnu style