### PR TITLE
[*] Cleanup includes

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,5 +1,7 @@
 ﻿#include "inexor/vulkan-renderer/application.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -1,18 +1,15 @@
 ﻿#pragma once
 
-#include "inexor/vulkan-renderer/camera.hpp"
-#include "inexor/vulkan-renderer/debug_callback.hpp"
-#include "inexor/vulkan-renderer/error_handling.hpp"
-#include "inexor/vulkan-renderer/mesh_buffer.hpp"
 #include "inexor/vulkan-renderer/renderer.hpp"
-#include "inexor/vulkan-renderer/standard_ubo.hpp"
 #include "inexor/vulkan-renderer/thread_pool.hpp"
-#include "inexor/vulkan-renderer/tools/cla_parser.hpp"
-#include "inexor/vulkan-renderer/world/cube.hpp"
 
 #include <GLFW/glfw3.h>
-#include <spdlog/spdlog.h>
-#include <toml11/toml.hpp>
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/availability_checks.hpp
+++ b/include/inexor/vulkan-renderer/availability_checks.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/error_handling.hpp"
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
-#include <optional>
-#include <shared_mutex>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/quaternion.hpp>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/debug_callback.hpp
+++ b/include/inexor/vulkan-renderer/debug_callback.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
+
+#include <string>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/debug_marker_manager.hpp
+++ b/include/inexor/vulkan-renderer/debug_marker_manager.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
 #include <glm/glm.hpp>
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
-#include <vector>
+#include <string>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/descriptor.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <cassert>
+#include <vulkan/vulkan_core.h>
+
+#include <cstdint>
 #include <string>
 #include <vector>
-
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/error_handling.hpp
+++ b/include/inexor/vulkan-renderer/error_handling.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 

--- a/include/inexor/vulkan-renderer/fence_manager.hpp
+++ b/include/inexor/vulkan-renderer/fence_manager.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "inexor/vulkan-renderer/debug_marker_manager.hpp"
-#include "inexor/vulkan-renderer/error_handling.hpp"
 #include "inexor/vulkan-renderer/manager_template.hpp"
 
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <string>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/fps_counter.hpp
+++ b/include/inexor/vulkan-renderer/fps_counter.hpp
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <optional>
 
 namespace inexor::vulkan_renderer {

--- a/include/inexor/vulkan-renderer/gpu_info.hpp
+++ b/include/inexor/vulkan-renderer/gpu_info.hpp
@@ -1,14 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/error_handling.hpp"
-#include "inexor/vulkan-renderer/surface_formats.hpp"
-
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
-
-#include <cassert>
-#include <unordered_map>
-#include <vector>
+#include <vulkan/vulkan_core.h>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/gpu_memory_buffer.hpp
@@ -1,8 +1,7 @@
 ﻿#pragma once
 
-#include <spdlog/spdlog.h>
 #include <vma/vk_mem_alloc.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 

--- a/include/inexor/vulkan-renderer/image_buffer.hpp
+++ b/include/inexor/vulkan-renderer/image_buffer.hpp
@@ -2,8 +2,6 @@
 
 #include <vma/vma_usage.h>
 
-#include <optional>
-
 namespace inexor::vulkan_renderer {
 
 struct ImageBuffer {

--- a/include/inexor/vulkan-renderer/manager_template.hpp
+++ b/include/inexor/vulkan-renderer/manager_template.hpp
@@ -1,7 +1,10 @@
 ﻿#pragma once
 
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/mesh_buffer.hpp
@@ -1,13 +1,14 @@
 ﻿#pragma once
 
 #include "inexor/vulkan-renderer/gpu_memory_buffer.hpp"
-#include "inexor/vulkan-renderer/once_command_buffer.hpp"
-#include "inexor/vulkan-renderer/staging_buffer.hpp"
 
 #include <vma/vma_usage.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
+#include <cassert>
+#include <cstdint>
 #include <optional>
+#include <string>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/octree_vertex.hpp
+++ b/include/inexor/vulkan-renderer/octree_vertex.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <glm/glm.hpp>
-
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
 #include <array>
 

--- a/include/inexor/vulkan-renderer/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/once_command_buffer.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include "wrapper/command_pool.hpp"
+#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
-#include <stdexcept>
+#include <cstdint>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -1,26 +1,20 @@
 ﻿#pragma once
 
-#include "availability_checks.hpp"
+#include "inexor/vulkan-renderer/availability_checks.hpp"
 #include "inexor/vulkan-renderer/camera.hpp"
-#include "inexor/vulkan-renderer/debug_marker_manager.hpp"
 #include "inexor/vulkan-renderer/descriptor.hpp"
-#include "inexor/vulkan-renderer/error_handling.hpp"
 #include "inexor/vulkan-renderer/fence_manager.hpp"
 #include "inexor/vulkan-renderer/fps_counter.hpp"
 #include "inexor/vulkan-renderer/gpu_info.hpp"
 #include "inexor/vulkan-renderer/image_buffer.hpp"
 #include "inexor/vulkan-renderer/mesh_buffer.hpp"
 #include "inexor/vulkan-renderer/msaa_target.hpp"
-#include "inexor/vulkan-renderer/octree_vertex.hpp"
 #include "inexor/vulkan-renderer/semaphore_manager.hpp"
 #include "inexor/vulkan-renderer/settings_decision_maker.hpp"
-#include "inexor/vulkan-renderer/standard_ubo.hpp"
+#include "inexor/vulkan-renderer/shader.hpp"
 #include "inexor/vulkan-renderer/texture.hpp"
 #include "inexor/vulkan-renderer/time_step.hpp"
 #include "inexor/vulkan-renderer/uniform_buffer.hpp"
-
-// Those components have been refactored to fulfill RAII idioms.
-#include "inexor/vulkan-renderer/shader.hpp"
 #include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/glfw_context.hpp"
@@ -30,16 +24,10 @@
 #include "inexor/vulkan-renderer/wrapper/window.hpp"
 #include "inexor/vulkan-renderer/wrapper/window_surface.hpp"
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/mat4x4.hpp>
-#include <glm/vec4.hpp>
-#include <spdlog/spdlog.h>
+#include <vulkan/vulkan_core.h>
 
-#include <chrono>
-#include <fstream>
-#include <iostream>
-#include <string>
+#include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace inexor::vulkan_renderer {

--- a/include/inexor/vulkan-renderer/semaphore_manager.hpp
+++ b/include/inexor/vulkan-renderer/semaphore_manager.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
 #include "inexor/vulkan-renderer/debug_marker_manager.hpp"
-#include "inexor/vulkan-renderer/error_handling.hpp"
 #include "inexor/vulkan-renderer/manager_template.hpp"
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
+#include <memory>
 #include <mutex>
 
 namespace inexor::vulkan_renderer {

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -1,14 +1,8 @@
 ﻿#pragma once
 
-#include "inexor/vulkan-renderer/error_handling.hpp"
+#include <vulkan/vulkan_core.h>
 
-#include <vulkan/vulkan.h>
-
-#include <algorithm>
-#include <cassert>
 #include <cstdint>
-#include <iostream>
-#include <map>
 #include <optional>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/shader.hpp
+++ b/include/inexor/vulkan-renderer/shader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 #include <vector>

--- a/include/inexor/vulkan-renderer/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/staging_buffer.hpp
@@ -3,9 +3,7 @@
 #include "inexor/vulkan-renderer/gpu_memory_buffer.hpp"
 #include "inexor/vulkan-renderer/once_command_buffer.hpp"
 
-#include <vulkan/vulkan.h>
-
-#include <cassert>
+#include <vulkan/vulkan_core.h>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/texture.hpp
+++ b/include/inexor/vulkan-renderer/texture.hpp
@@ -2,19 +2,11 @@
 
 #include "inexor/vulkan-renderer/gpu_memory_buffer.hpp"
 #include "inexor/vulkan-renderer/once_command_buffer.hpp"
-#include "inexor/vulkan-renderer/staging_buffer.hpp"
 
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <cassert>
+#include <cstdint>
 #include <string>
-
-#include <nlohmann/json.hpp>
-#include <spdlog/spdlog.h>
-#include <vma/vma_usage.h>
-#include <vulkan/vulkan.h>
-#define TINYGLTF_NO_INCLUDE_JSON
-#include <tiny_gltf/tiny_gltf.h>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-
-#include <cassert>
-#include <fstream>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/uniform_buffer.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "gpu_memory_buffer.hpp"
+#include "inexor/vulkan-renderer/gpu_memory_buffer.hpp"
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <shared_mutex>
 #include <string>
 
 namespace inexor::vulkan_renderer {

--- a/include/inexor/vulkan-renderer/world/bit_stream.hpp
+++ b/include/inexor/vulkan-renderer/world/bit_stream.hpp
@@ -2,12 +2,9 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include <cassert>
+#include <array>
 #include <cstdint>
-#include <fstream>
-#include <iostream>
 #include <optional>
-#include <vector>
 
 namespace inexor::vulkan_renderer::world {
 constexpr std::array<std::uint8_t, 9> KEEP_FIRST_N_BITS{0b0000'0000, 0b1000'0000, 0b1100'0000, 0b1110'0000, 0b1111'0000,

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -6,8 +6,8 @@
 #include <boost/signals2.hpp>
 #include <glm/vec3.hpp>
 
-#include <functional>
-#include <iostream>
+#include <array>
+#include <cstdint>
 #include <optional>
 
 namespace inexor::vulkan_renderer::world {

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -1,16 +1,10 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/availability_checks.hpp"
-#include "inexor/vulkan-renderer/settings_decision_maker.hpp"
-
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
 #include <cassert>
-#include <memory>
+#include <cstdint>
 #include <optional>
-#include <string>
-#include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
 

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -2,14 +2,10 @@
 
 #include "inexor/vulkan-renderer/availability_checks.hpp"
 
-#include <fmt/ranges.h>
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
 
-#include <array>
-#include <cassert>
-#include <memory>
 #include <string>
+#include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
 

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/availability_checks.hpp"
-#include "inexor/vulkan-renderer/settings_decision_maker.hpp"
+#include <vulkan/vulkan_core.h>
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
-
-#include <cassert>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/include/inexor/vulkan-renderer/wrapper/vma.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/vma.hpp
@@ -2,12 +2,6 @@
 
 #include <vma/vk_mem_alloc.h>
 
-#include <spdlog/spdlog.h>
-#include <vulkan/vulkan.h>
-
-#include <cassert>
-#include <fstream>
-
 namespace inexor::vulkan_renderer::wrapper {
 class VulkanMemoryAllocator {
 private:

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -1,5 +1,15 @@
 #include "inexor/vulkan-renderer/application.hpp"
+
 #include "inexor/vulkan-renderer/debug_callback.hpp"
+#include "inexor/vulkan-renderer/error_handling.hpp"
+#include "inexor/vulkan-renderer/octree_vertex.hpp"
+#include "inexor/vulkan-renderer/standard_ubo.hpp"
+#include "inexor/vulkan-renderer/tools/cla_parser.hpp"
+#include "inexor/vulkan-renderer/world/cube.hpp"
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <spdlog/spdlog.h>
+#include <toml11/toml.hpp>
 
 namespace inexor::vulkan_renderer {
 

--- a/src/vulkan-renderer/availability_checks.cpp
+++ b/src/vulkan-renderer/availability_checks.cpp
@@ -1,5 +1,10 @@
 #include "inexor/vulkan-renderer/availability_checks.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+
+#include <cassert>
+#include <cstring>
+
 namespace inexor::vulkan_renderer {
 
 VkResult AvailabilityChecksManager::create_instance_extensions_cache() {

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -1,5 +1,7 @@
 #include "inexor/vulkan-renderer/camera.hpp"
 
+#include <glm/gtc/matrix_transform.hpp>
+
 namespace inexor::vulkan_renderer {
 void Camera::update_view_matrix() {
     glm::mat4 rot_m = glm::mat4(1.0f);

--- a/src/vulkan-renderer/debug_callback.cpp
+++ b/src/vulkan-renderer/debug_callback.cpp
@@ -1,5 +1,7 @@
 #include "inexor/vulkan-renderer/debug_callback.hpp"
 
+#include <spdlog/spdlog.h>
+
 namespace inexor::vulkan_renderer {
 VKAPI_ATTR VkBool32 VKAPI_CALL vulkan_debug_message_callback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT object_type, std::uint64_t object,
                                                              std::size_t location, std::int32_t message_code, const char *layer_prefix, const char *message,

--- a/src/vulkan-renderer/debug_marker_manager.cpp
+++ b/src/vulkan-renderer/debug_marker_manager.cpp
@@ -1,5 +1,9 @@
 #include "inexor/vulkan-renderer/debug_marker_manager.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <vector>
+
 namespace inexor::vulkan_renderer {
 
 void VulkanDebugMarkerManager::init(const VkDevice &device, const VkPhysicalDevice &graphics_card, bool enable_debug_markers) {

--- a/src/vulkan-renderer/descriptor.cpp
+++ b/src/vulkan-renderer/descriptor.cpp
@@ -1,5 +1,10 @@
 #include "inexor/vulkan-renderer/descriptor.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <stdexcept>
+
 namespace inexor::vulkan_renderer {
 
 Descriptor::Descriptor(Descriptor &&other) noexcept

--- a/src/vulkan-renderer/error_handling.cpp
+++ b/src/vulkan-renderer/error_handling.cpp
@@ -1,5 +1,7 @@
 #include "inexor/vulkan-renderer/error_handling.hpp"
 
+#include <spdlog/spdlog.h>
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif

--- a/src/vulkan-renderer/fence_manager.cpp
+++ b/src/vulkan-renderer/fence_manager.cpp
@@ -1,5 +1,11 @@
 #include "inexor/vulkan-renderer/fence_manager.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
 namespace inexor::vulkan_renderer {
 
 VkResult VulkanFenceManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {

--- a/src/vulkan-renderer/gpu_info.cpp
+++ b/src/vulkan-renderer/gpu_info.cpp
@@ -1,6 +1,13 @@
 #include "inexor/vulkan-renderer/gpu_info.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+#include "inexor/vulkan-renderer/surface_formats.hpp"
+
+#include <spdlog/spdlog.h>
+
 #include <array>
+#include <cassert>
+#include <cstdint>
 
 namespace inexor::vulkan_renderer {
 

--- a/src/vulkan-renderer/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/gpu_memory_buffer.cpp
@@ -1,5 +1,9 @@
 #include "inexor/vulkan-renderer/gpu_memory_buffer.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
 namespace inexor::vulkan_renderer {
 
 GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept

--- a/src/vulkan-renderer/mesh_buffer.cpp
+++ b/src/vulkan-renderer/mesh_buffer.cpp
@@ -1,5 +1,9 @@
 #include "inexor/vulkan-renderer/mesh_buffer.hpp"
 
+#include "inexor/vulkan-renderer/staging_buffer.hpp"
+
+#include <spdlog/spdlog.h>
+
 namespace inexor::vulkan_renderer {
 MeshBuffer::MeshBuffer(MeshBuffer &&other) noexcept
     : name(std::move(other.name)), vertex_buffer(std::move(other.vertex_buffer)), index_buffer(std::move(other.index_buffer)),

--- a/src/vulkan-renderer/once_command_buffer.cpp
+++ b/src/vulkan-renderer/once_command_buffer.cpp
@@ -1,5 +1,11 @@
 #include "inexor/vulkan-renderer/once_command_buffer.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <stdexcept>
+#include <utility>
+
 namespace inexor::vulkan_renderer {
 
 OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -1,5 +1,13 @@
 ﻿#include "inexor/vulkan-renderer/renderer.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+#include "inexor/vulkan-renderer/octree_vertex.hpp"
+#include "inexor/vulkan-renderer/standard_ubo.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <fstream>
+
 namespace inexor::vulkan_renderer {
 
 VkResult VulkanRenderer::initialise_debug_marker_manager(const bool enable_debug_markers) {

--- a/src/vulkan-renderer/semaphore_manager.cpp
+++ b/src/vulkan-renderer/semaphore_manager.cpp
@@ -1,5 +1,9 @@
 #include "inexor/vulkan-renderer/semaphore_manager.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+
+#include <spdlog/spdlog.h>
+
 namespace inexor::vulkan_renderer {
 
 VkResult VulkanSemaphoreManager::init(const VkDevice &device, const std::shared_ptr<VulkanDebugMarkerManager> debug_marker_manager) {

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -1,5 +1,12 @@
 ﻿#include "inexor/vulkan-renderer/settings_decision_maker.hpp"
 
+#include "inexor/vulkan-renderer/error_handling.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <map>
+
 namespace inexor::vulkan_renderer {
 
 std::uint32_t VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface) {

--- a/src/vulkan-renderer/staging_buffer.cpp
+++ b/src/vulkan-renderer/staging_buffer.cpp
@@ -1,5 +1,7 @@
 ﻿#include "inexor/vulkan-renderer/staging_buffer.hpp"
 
+#include <spdlog/spdlog.h>
+
 namespace inexor::vulkan_renderer {
 
 StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept

--- a/src/vulkan-renderer/texture.cpp
+++ b/src/vulkan-renderer/texture.cpp
@@ -1,8 +1,11 @@
 #include "inexor/vulkan-renderer/texture.hpp"
 
-// stb single-file public domain libraries for C/C++
+#include "inexor/vulkan-renderer/staging_buffer.hpp"
+
 #define STB_IMAGE_IMPLEMENTATION
+#include <spdlog/spdlog.h>
 #include <stb_image.h>
+#include <vma/vk_mem_alloc.h>
 
 namespace inexor::vulkan_renderer {
 

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -1,5 +1,10 @@
 #include "inexor/vulkan-renderer/tools/file.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+#include <fstream>
+
 namespace inexor::vulkan_renderer::tools {
 
 const std::size_t File::get_file_size() const {

--- a/src/vulkan-renderer/uniform_buffer.cpp
+++ b/src/vulkan-renderer/uniform_buffer.cpp
@@ -1,5 +1,8 @@
 #include "inexor/vulkan-renderer/uniform_buffer.hpp"
 
+#include <cassert>
+#include <cstring>
+
 namespace inexor::vulkan_renderer {
 
 // TODO: Fix move constructor!

--- a/src/vulkan-renderer/world/bit_stream.cpp
+++ b/src/vulkan-renderer/world/bit_stream.cpp
@@ -1,4 +1,4 @@
-#include <inexor/vulkan-renderer/world/bit_stream.hpp>
+#include "inexor/vulkan-renderer/world/bit_stream.hpp"
 
 namespace inexor::vulkan_renderer::world {
 BitStream::BitStream(unsigned char *data, std::size_t size) {

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -1,4 +1,5 @@
-#include <inexor/vulkan-renderer/world/cube.hpp>
+#include "inexor/vulkan-renderer/world/cube.hpp"
+
 #include <utility>
 
 namespace inexor::vulkan_renderer::world {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -1,5 +1,12 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 
+#include "inexor/vulkan-renderer/availability_checks.hpp"
+#include "inexor/vulkan-renderer/settings_decision_maker.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <stdexcept>
+
 namespace {
 // TODO: Make proper use of queue priorities in the future.
 constexpr float default_queue_priority = 1.0f;

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -1,6 +1,10 @@
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
 
 #include <GLFW/glfw3.h>
+#include <fmt/ranges.h>
+#include <spdlog/spdlog.h>
+
+#include <cassert>
 
 namespace inexor::vulkan_renderer::wrapper {
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -1,5 +1,11 @@
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 
+#include "inexor/vulkan-renderer/settings_decision_maker.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <optional>
+
 namespace inexor::vulkan_renderer::wrapper {
 
 Swapchain::Swapchain(Swapchain &&other) noexcept

--- a/src/vulkan-renderer/wrapper/vma.cpp
+++ b/src/vulkan-renderer/wrapper/vma.cpp
@@ -13,7 +13,10 @@
 // Enable validation of contents of the margins.
 #define VMA_DEBUG_DETECT_CORRUPTION 1
 
+#include <spdlog/spdlog.h>
 #include <vma/vk_mem_alloc.h>
+
+#include <fstream>
 
 namespace inexor::vulkan_renderer::wrapper {
 


### PR DESCRIPTION
- Add some missing includes
- Move some includes from header to source file
- Remove unused includes
- Replace all `#include <vulkan/vulkan.h>` with `#include <vulkan/vulkan_core.h>`

Overall this gave about a 13% compilation speed increase. This PR doesn't add any forward declaration, however I think we should consider forward declaring some symbols as it would give a huge compilation speed benefit, especially since the standard library has started making forward declaration headers (such as `iosfwd`).