### PR TITLE
VkCommandPool RAII wrapper refactoring.

### DIFF
--- a/include/inexor/vulkan-renderer/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/once_command_buffer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "wrapper/command_pool.hpp"
+
 #include <spdlog/spdlog.h>
 #include <vulkan/vulkan.h>
 
@@ -11,14 +13,13 @@ namespace inexor::vulkan_renderer {
 /// @brief A OnceCommandBuffer is a command buffer which is being used only once.
 class OnceCommandBuffer {
 private:
-    VkDevice device = VK_NULL_HANDLE;
-    VkCommandPool command_pool = VK_NULL_HANDLE;
-    VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-    VkQueue data_transfer_queue = VK_NULL_HANDLE;
-    std::uint32_t data_transfer_queue_family_index = 0;
+    VkDevice device;
+    wrapper::CommandPool command_pool;
+    VkCommandBuffer command_buffer;
+    VkQueue data_transfer_queue;
 
-    bool command_buffer_created = false;
-    bool recording_started = false;
+    bool command_buffer_created;
+    bool recording_started;
 
 public:
     // Delete the copy constructor so once command buffers are move-only objects.

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -21,6 +21,7 @@
 
 // Those components have been refactored to fulfill RAII idioms.
 #include "inexor/vulkan-renderer/shader.hpp"
+#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/glfw_context.hpp"
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
@@ -79,8 +80,6 @@ protected:
     VkPipeline pipeline = VK_NULL_HANDLE;
 
     std::vector<VkFramebuffer> frame_buffers;
-
-    VkCommandPool command_pool = VK_NULL_HANDLE;
 
     std::vector<VkCommandBuffer> command_buffers;
 
@@ -157,6 +156,9 @@ protected:
 
     /// RAII wrapper for glfw contexts.
     std::unique_ptr<wrapper::GLFWContext> glfw_context = nullptr;
+
+    /// RAII wrapper for command pools.
+    std::unique_ptr<wrapper::CommandPool> command_pool = nullptr;
 
     /// @brief Create a physical device handle.
     /// @param graphics_card The regarded graphics card.

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <spdlog/spdlog.h>
+#include <vulkan/vulkan_core.h>
+
+#include <cassert>
+
+namespace inexor::vulkan_renderer::wrapper {
+class CommandPool {
+private:
+    VkDevice device;
+    VkCommandPool command_pool;
+
+public:
+    /// Delete the copy constructor so Vulkan command pools are move-only objects.
+    CommandPool(const CommandPool &) = delete;
+    CommandPool(CommandPool &&other) noexcept;
+
+    /// Delete the copy assignment operator so Vulkan command pools are move-only objects.
+    CommandPool &operator=(const CommandPool &) = delete;
+    CommandPool &operator=(CommandPool &&) noexcept = default;
+
+    /// @brief Creates a Vulkan command pool.
+    /// @param device [in] The Vulkan device.
+    /// @param queue_family_index [in] The queue family index for the command pool.
+    CommandPool(const VkDevice device, const std::uint32_t queue_family_index);
+
+    ~CommandPool();
+
+    [[nodiscard]] VkCommandPool get() const {
+        return command_pool;
+    }
+};
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     vulkan-renderer/tools/cla_parser.cpp
     vulkan-renderer/tools/file.cpp
 
+    vulkan-renderer/wrapper/command_pool.cpp
     vulkan-renderer/wrapper/device.cpp
     vulkan-renderer/wrapper/glfw_context.cpp
     vulkan-renderer/wrapper/instance.cpp

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -515,8 +515,7 @@ VkResult Application::init(int argc, char **argv) {
     result = create_frame_buffers();
     vulkan_error_check(result);
 
-    result = create_command_pool();
-    vulkan_error_check(result);
+    command_pool = std::make_unique<wrapper::CommandPool>(vkdevice->get_device(), vkdevice->get_graphics_queue_family_index());
 
     result = create_uniform_buffers();
     vulkan_error_check(result);

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -1,0 +1,28 @@
+#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
+
+namespace inexor::vulkan_renderer::wrapper {
+
+CommandPool::CommandPool(CommandPool &&other) noexcept : device(other.device), command_pool(std::exchange(other.command_pool, nullptr)) {}
+
+CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family_index) : device(device) {
+    assert(device);
+
+    VkCommandPoolCreateInfo create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    create_info.queueFamilyIndex = queue_family_index;
+
+    if (vkCreateCommandPool(device, &create_info, nullptr, &command_pool) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreateCommandPool failed!");
+    }
+
+    // TODO: Assign an internal name to this command pool using Vulkan debug markers.
+
+    spdlog::debug("Created command pool successfully.");
+}
+
+CommandPool::~CommandPool() {
+    vkDestroyCommandPool(device, command_pool, nullptr);
+}
+
+} // namespace inexor::vulkan_renderer::wrapper


### PR DESCRIPTION
In this pull request, I added a RAII wrapper for `VkCommandPool` and replaced the command pool of the renderer and the once command buffer class with the wrapper.