### PR TITLE
[*] Prefer auto *

### DIFF
--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -23,7 +23,7 @@ static void frame_buffer_resize_callback(GLFWwindow *window, int width, int heig
     spdlog::debug("Frame buffer resize callback called. window width: {}, height: {}", width, height);
 
     // This is actually the way it is handled by the official Vulkan samples.
-    auto app = reinterpret_cast<VulkanRenderer *>(glfwGetWindowUserPointer(window));
+    auto *app = reinterpret_cast<VulkanRenderer *>(glfwGetWindowUserPointer(window));
     app->frame_buffer_resized = true;
 }
 

--- a/src/vulkan-renderer/gpu_info.cpp
+++ b/src/vulkan-renderer/gpu_info.cpp
@@ -685,7 +685,7 @@ void VulkanGraphicsCardInfoViewer::print_all_physical_devices(const VkInstance &
         vulkan_error_check(result);
 
         // Loop through all graphics cards and print information about them.
-        for (auto graphics_card : available_graphics_cards) {
+        for (auto *graphics_card : available_graphics_cards) {
             print_device_layers(graphics_card);
             print_device_extensions(graphics_card);
             print_graphics_card_info(graphics_card);

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -282,7 +282,7 @@ VkResult VulkanRenderer::cleanup_swapchain() {
     spdlog::debug("Destroying frame buffer.");
 
     if (frame_buffers.size() > 0) {
-        for (auto frame_buffer : frame_buffers) {
+        for (auto *frame_buffer : frame_buffers) {
             if (VK_NULL_HANDLE != frame_buffer) {
                 vkDestroyFramebuffer(vkdevice->get_device(), frame_buffer, nullptr);
                 frame_buffer = VK_NULL_HANDLE;
@@ -483,7 +483,7 @@ VkResult VulkanRenderer::recreate_swapchain() {
     spdlog::debug("Destroying frame buffer.");
 
     if (frame_buffers.size() > 0) {
-        for (auto frame_buffer : frame_buffers) {
+        for (auto *frame_buffer : frame_buffers) {
             if (VK_NULL_HANDLE != frame_buffer) {
                 vkDestroyFramebuffer(vkdevice->get_device(), frame_buffer, nullptr);
                 frame_buffer = VK_NULL_HANDLE;

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -265,7 +265,7 @@ std::vector<std::array<glm::vec3, 3>> Cube::polygons() {
 
     polygons.resize(this->leaves() * 12);
 
-    auto polygons_pointer = polygons.data();
+    auto *polygons_pointer = polygons.data();
     this->all_polygons(polygons_pointer);
     return polygons;
 }

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -48,7 +48,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     std::uint32_t glfw_extension_count = 0;
 
     // Because this requires some dynamic libraries to be loaded, this may take even up to some seconds!
-    auto glfw_extensions = glfwGetRequiredInstanceExtensions(&glfw_extension_count);
+    auto *glfw_extensions = glfwGetRequiredInstanceExtensions(&glfw_extension_count);
 
     if (glfw_extension_count == 0) {
         throw std::runtime_error("Error: glfwGetRequiredInstanceExtensions results 0 as number of required instance extensions!");

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -137,7 +137,7 @@ void Swapchain::recreate(std::uint32_t window_width, std::uint32_t window_height
 
     // Unlike swapchain images, the image views were created by us directly.
     // It is our job to destroy them again.
-    for (const auto image_view : swapchain_image_views) {
+    for (auto *image_view : swapchain_image_views) {
         vkDestroyImageView(device, image_view, nullptr);
     }
 
@@ -152,7 +152,7 @@ Swapchain::~Swapchain() {
     vkDestroySwapchainKHR(device, swapchain, nullptr);
     swapchain = VK_NULL_HANDLE;
 
-    for (const auto image_view : swapchain_image_views) {
+    for (auto *image_view : swapchain_image_views) {
         vkDestroyImageView(device, image_view, nullptr);
     }
 }


### PR DESCRIPTION
Prefer `auto *` to `auto` for types where the right hand side is a pointer. This makes it clear that the deduced type is a pointer and that the right hand side isn't being copied.