### PR TITLE
Vulkan pipeline RAII wrapper refactoring.

### DIFF
--- a/include/inexor/vulkan-renderer/octree_vertex.hpp
+++ b/include/inexor/vulkan-renderer/octree_vertex.hpp
@@ -3,7 +3,7 @@
 #include <glm/glm.hpp>
 #include <vulkan/vulkan_core.h>
 
-#include <array>
+#include <vector>
 
 namespace inexor::vulkan_renderer {
 
@@ -17,7 +17,7 @@ struct OctreeVertex {
 
     /// @note You should use the format where the amount of color channels matches the number of components in the shader data type.
     /// It is allowed to use more channels than the number of components in the shader, but they will be silently discarded.
-    [[nodiscard]] static std::array<VkVertexInputAttributeDescription, 3> get_attribute_binding_description();
+    [[nodiscard]] static std::vector<VkVertexInputAttributeDescription> get_attribute_binding_description();
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -2,8 +2,8 @@
 
 #include "inexor/vulkan-renderer/availability_checks.hpp"
 #include "inexor/vulkan-renderer/camera.hpp"
-#include "inexor/vulkan-renderer/descriptor.hpp"
 #include "inexor/vulkan-renderer/debug_marker_manager.hpp"
+#include "inexor/vulkan-renderer/descriptor.hpp"
 #include "inexor/vulkan-renderer/fps_counter.hpp"
 #include "inexor/vulkan-renderer/gpu_info.hpp"
 #include "inexor/vulkan-renderer/mesh_buffer.hpp"
@@ -21,8 +21,11 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/fence.hpp"
 #include "inexor/vulkan-renderer/wrapper/glfw_context.hpp"
+#include "inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp"
 #include "inexor/vulkan-renderer/wrapper/image.hpp"
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
+#include "inexor/vulkan-renderer/wrapper/pipeline_layout.hpp"
+#include "inexor/vulkan-renderer/wrapper/renderpass.hpp"
 #include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 #include "inexor/vulkan-renderer/wrapper/vma.hpp"
@@ -60,13 +63,7 @@ protected:
 
     VkPresentInfoKHR present_info = {};
 
-    VkPipelineLayout pipeline_layout = {};
-
     std::vector<VkPipelineShaderStageCreateInfo> shader_stages;
-
-    VkRenderPass render_pass = VK_NULL_HANDLE;
-
-    VkPipeline pipeline = VK_NULL_HANDLE;
 
     std::vector<VkFramebuffer> frame_buffers;
 
@@ -146,6 +143,12 @@ protected:
     std::unique_ptr<wrapper::Image> depth_buffer;
 
     std::unique_ptr<wrapper::Image> depth_stencil;
+
+    std::unique_ptr<wrapper::PipelineLayout> pipeline_layout;
+
+    std::unique_ptr<wrapper::GraphicsPipeline> graphics_pipeline;
+
+    std::unique_ptr<wrapper::RenderPass> renderpass;
 
     /// @brief Create a physical device handle.
     /// @param graphics_card The regarded graphics card.

--- a/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <string>
+#include <vector>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+class GraphicsPipeline {
+private:
+    VkDevice device;
+    VkPipeline graphics_pipeline;
+    VkPipelineCache pipeline_cache;
+    std::string name;
+
+public:
+    /// Delete the copy constructor so graphics pipelines are move-only objects.
+    GraphicsPipeline(const GraphicsPipeline &) = delete;
+    GraphicsPipeline(GraphicsPipeline &&other) noexcept;
+
+    /// Delete the copy assignment operator so graphics pipelines are move-only objects.
+    GraphicsPipeline &operator=(const GraphicsPipeline &) = delete;
+    GraphicsPipeline &operator=(GraphicsPipeline &&) noexcept = default;
+
+    /// @brief Creates a graphics pipeline.
+    /// @param device [in] The Vulkan device.
+    /// @param pipeline_layout [in] The pipeline layout.
+    /// @param render_pass [in] The associated renderpass.
+    /// @param shader_stages [in] The shaders and the stages they are used in.
+    /// @param vertex_binding [in] The vertex binding description.
+    /// @param attribute_binding [in] The vertex attribute binding description.
+    /// @param window_width [in] The width of the window.
+    /// @param window_height [in] The height of the window.
+    /// @param multisampling_enabled [in] True if multisampling is enabled, false otherwise.
+    /// @note For now, The engines uses 4 samples for MSAA by default. This might change in the future.
+    /// @param name [in] The internal name of the graphics pipeline.
+    GraphicsPipeline(const VkDevice device, const VkPipelineLayout pipeline_layout, const VkRenderPass render_pass,
+                     const std::vector<VkPipelineShaderStageCreateInfo> &shader_stages, const VkVertexInputBindingDescription vertex_binding,
+                     const std::vector<VkVertexInputAttributeDescription> &attribute_binding, const std::uint32_t window_width,
+                     const std::uint32_t window_height, const bool multisampling_enabled, const std::string &name);
+
+    ~GraphicsPipeline();
+
+    [[nodiscard]] VkPipeline get() const {
+        return graphics_pipeline;
+    }
+};
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <string>
+#include <vector>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+class PipelineLayout {
+private:
+    VkDevice device;
+    VkPipelineLayout pipeline_layout;
+    std::string name;
+
+public:
+    /// Delete the copy constructor so pipeline layouts are move-only objects.
+    PipelineLayout(const PipelineLayout &) = delete;
+    PipelineLayout(PipelineLayout &&other) noexcept;
+
+    /// Delete the move-assignment operator so pipeline-layouts are move-only objects.
+    PipelineLayout &operator=(const PipelineLayout &) = delete;
+    PipelineLayout &operator=(PipelineLayout &&other) noexcept = default;
+
+    /// @brief Creates a pipeline layout
+    /// @param device [in] The Vulkan device.
+    /// @param descriptor_set_layouts [in] The descriptor set layouts for the pipeline layout.
+    /// @param name [in] The internal name of the pipeline layout.
+    PipelineLayout(const VkDevice device, const std::vector<VkDescriptorSetLayout> &descriptor_set_layouts, const std::string &name);
+
+    ~PipelineLayout();
+
+    [[nodiscard]] VkPipelineLayout get() const {
+        return pipeline_layout;
+    }
+};
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
@@ -22,10 +22,12 @@ public:
     RenderPass &operator=(const RenderPass &) = delete;
     RenderPass &operator=(RenderPass &&) noexcept = default;
 
-    ///
-    ///
-    ///
-    ///
+    /// @brief Creates a renderpass.
+    /// @param device [in] The Vulkan device.
+    /// @param attachments [in] The renderpass attachments.
+    /// @param dependencies [in] The subpass dependencies.
+    /// @param subpass_description [in] The subpass description.
+    /// @param name [in] The internal name of this renderpass.
     RenderPass(const VkDevice device, const std::vector<VkAttachmentDescription> &attachments, const std::vector<VkSubpassDependency> &dependencies,
                const VkSubpassDescription subpass_description, const std::string &name);
 

--- a/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <string>
+#include <vector>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+class RenderPass {
+private:
+    VkDevice device;
+    VkRenderPass renderpass;
+    std::string name;
+
+public:
+    /// Delete the copy constructor so renderpasses are move-only objects.
+    RenderPass(const RenderPass &) = delete;
+    RenderPass(RenderPass &&other) noexcept;
+
+    /// Delete the copy assignment operator so renderpasses are move-only objects.
+    RenderPass &operator=(const RenderPass &) = delete;
+    RenderPass &operator=(RenderPass &&) noexcept = default;
+
+    ///
+    ///
+    ///
+    ///
+    RenderPass(const VkDevice device, const std::vector<VkAttachmentDescription> &attachments, const std::vector<VkSubpassDependency> &dependencies,
+               const VkSubpassDescription subpass_description, const std::string &name);
+
+    ~RenderPass();
+
+    [[nodiscard]] VkRenderPass get() const {
+        return renderpass;
+    }
+};
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(
     vulkan-renderer/wrapper/glfw_context.cpp
     vulkan-renderer/wrapper/image.cpp
     vulkan-renderer/wrapper/instance.cpp
+    vulkan-renderer/wrapper/pipeline_layout.cpp
     vulkan-renderer/wrapper/semaphore.cpp
     vulkan-renderer/wrapper/swapchain.cpp
     vulkan-renderer/wrapper/vma.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
     vulkan-renderer/wrapper/image.cpp
     vulkan-renderer/wrapper/instance.cpp
     vulkan-renderer/wrapper/pipeline_layout.cpp
+    vulkan-renderer/wrapper/renderpass.cpp
     vulkan-renderer/wrapper/semaphore.cpp
     vulkan-renderer/wrapper/swapchain.cpp
     vulkan-renderer/wrapper/vma.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
     vulkan-renderer/wrapper/device.cpp
     vulkan-renderer/wrapper/fence.cpp
     vulkan-renderer/wrapper/glfw_context.cpp
+    vulkan-renderer/wrapper/graphics_pipeline.cpp
     vulkan-renderer/wrapper/image.cpp
     vulkan-renderer/wrapper/instance.cpp
     vulkan-renderer/wrapper/pipeline_layout.cpp

--- a/src/vulkan-renderer/octree_vertex.cpp
+++ b/src/vulkan-renderer/octree_vertex.cpp
@@ -11,8 +11,8 @@ VkVertexInputBindingDescription OctreeVertex::get_vertex_binding_description() {
     return vertex_input_binding_description;
 }
 
-std::array<VkVertexInputAttributeDescription, 3> OctreeVertex::get_attribute_binding_description() {
-    std::array<VkVertexInputAttributeDescription, 3> vertex_input_attribute_description = {};
+std::vector<VkVertexInputAttributeDescription> OctreeVertex::get_attribute_binding_description() {
+    std::vector<VkVertexInputAttributeDescription> vertex_input_attribute_description(3);
 
     vertex_input_attribute_description[0].location = 0;
     vertex_input_attribute_description[0].binding = 0;

--- a/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
+++ b/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
@@ -1,0 +1,176 @@
+#include "inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+GraphicsPipeline::GraphicsPipeline(GraphicsPipeline &&other) noexcept
+    : device(other.device), graphics_pipeline(std::exchange(other.graphics_pipeline, nullptr)), pipeline_cache(std::exchange(other.pipeline_cache, nullptr)),
+      name(std::move(other.name)) {}
+
+GraphicsPipeline::GraphicsPipeline(const VkDevice device, const VkPipelineLayout pipeline_layout, const VkRenderPass render_pass,
+                                   const std::vector<VkPipelineShaderStageCreateInfo> &shader_stages, const VkVertexInputBindingDescription vertex_binding,
+                                   const std::vector<VkVertexInputAttributeDescription> &attribute_binding, const std::uint32_t window_width,
+                                   const std::uint32_t window_height, const bool multisampling_enabled, const std::string &name)
+    : device(device), name(name) {
+
+    assert(device);
+    assert(pipeline_layout);
+    assert(render_pass);
+    assert(!shader_stages.empty());
+    assert(!attribute_binding.empty());
+    assert(window_width > 0);
+    assert(window_height > 0);
+    assert(!name.empty());
+
+    VkPipelineVertexInputStateCreateInfo vertex_input_ci = {};
+    vertex_input_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertex_input_ci.vertexBindingDescriptionCount = 1;
+    vertex_input_ci.pVertexBindingDescriptions = &vertex_binding;
+    vertex_input_ci.vertexAttributeDescriptionCount = static_cast<std::uint32_t>(attribute_binding.size());
+    vertex_input_ci.pVertexAttributeDescriptions = attribute_binding.data();
+
+    // TODO: Change topology to support wireframe.
+    VkPipelineInputAssemblyStateCreateInfo input_assembly_ci = {};
+    input_assembly_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    input_assembly_ci.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    input_assembly_ci.primitiveRestartEnable = VK_FALSE;
+
+    // TODO: Make viewport a parameter.
+    VkViewport view_port = {};
+    view_port.x = 0.0f;
+    view_port.y = 0.0f;
+    view_port.width = static_cast<float>(window_width);
+    view_port.height = static_cast<float>(window_height);
+    view_port.minDepth = 0.0f;
+    view_port.maxDepth = 1.0f;
+
+    // TODO: Make scissor a parameter.
+    VkRect2D scissor = {};
+    scissor.offset = {0, 0};
+    scissor.extent = {window_width, window_height};
+
+    // TODO: Examine how creating multiple viewports and scissors at once could be useful.
+    VkPipelineViewportStateCreateInfo viewport_state_ci = {};
+    viewport_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewport_state_ci.viewportCount = 1;
+    viewport_state_ci.pViewports = &view_port;
+    viewport_state_ci.scissorCount = 1;
+    viewport_state_ci.pScissors = &scissor;
+
+    // TODO: Improve multisampling parameters: support other than 4 samples.
+    VkPipelineMultisampleStateCreateInfo multisample_state_ci = {};
+    multisample_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisample_state_ci.sampleShadingEnable = VK_FALSE;
+    multisample_state_ci.minSampleShading = 1.0f;
+    multisample_state_ci.pSampleMask = nullptr;
+    multisample_state_ci.alphaToCoverageEnable = VK_FALSE;
+    multisample_state_ci.alphaToOneEnable = VK_FALSE;
+    multisample_state_ci.rasterizationSamples = multisampling_enabled ? VK_SAMPLE_COUNT_4_BIT : VK_SAMPLE_COUNT_1_BIT;
+
+    // TODO: Support wireframe.
+    VkPipelineRasterizationStateCreateInfo rasterization_state_ci = {};
+    rasterization_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterization_state_ci.depthClampEnable = VK_FALSE;
+    rasterization_state_ci.rasterizerDiscardEnable = VK_FALSE;
+    rasterization_state_ci.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterization_state_ci.cullMode = VK_CULL_MODE_BACK_BIT;
+    rasterization_state_ci.frontFace = VK_FRONT_FACE_CLOCKWISE;
+    rasterization_state_ci.depthBiasEnable = VK_FALSE;
+    rasterization_state_ci.depthBiasConstantFactor = 0.0f;
+    rasterization_state_ci.depthBiasClamp = 0.0f;
+    rasterization_state_ci.depthBiasSlopeFactor = 0.0f;
+    rasterization_state_ci.lineWidth = 1.0f;
+
+    // TODO: Make compare function a parameter.
+    VkPipelineDepthStencilStateCreateInfo depth_stencil = {};
+    depth_stencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    depth_stencil.depthTestEnable = VK_TRUE;
+    depth_stencil.depthWriteEnable = VK_TRUE;
+    depth_stencil.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depth_stencil.depthBoundsTestEnable = VK_FALSE;
+    depth_stencil.stencilTestEnable = VK_FALSE;
+
+    // TODO: Examine how this could be parameterized.
+    VkPipelineColorBlendAttachmentState color_blend_attachment = {};
+    color_blend_attachment.blendEnable = VK_TRUE;
+    color_blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    color_blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
+    color_blend_attachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    color_blend_attachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
+    color_blend_attachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    // TODO: Examine how this could be parameterized.
+    VkPipelineColorBlendStateCreateInfo color_blend_state_ci = {};
+    color_blend_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    color_blend_state_ci.logicOpEnable = VK_FALSE;
+    color_blend_state_ci.logicOp = VK_LOGIC_OP_NO_OP;
+    color_blend_state_ci.attachmentCount = 1;
+    color_blend_state_ci.pAttachments = &color_blend_attachment;
+    color_blend_state_ci.blendConstants[0] = 0.0f;
+    color_blend_state_ci.blendConstants[1] = 0.0f;
+    color_blend_state_ci.blendConstants[2] = 0.0f;
+    color_blend_state_ci.blendConstants[3] = 0.0f;
+
+    // TODO: Parameterize this.
+    // Tell Vulkan that we want to change viewport and scissor during runtime so it's a dynamic state.
+    const std::vector<VkDynamicState> enabled_dynamic_states = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+
+    VkPipelineDynamicStateCreateInfo dynamic_state_ci = {};
+    dynamic_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamic_state_ci.pDynamicStates = enabled_dynamic_states.data();
+    dynamic_state_ci.dynamicStateCount = static_cast<std::uint32_t>(enabled_dynamic_states.size());
+
+    // TODO: Support tesselation stage in the future.
+    // TODO: Examine in how far sub-passes should be used?
+    VkGraphicsPipelineCreateInfo pipeline_ci = {};
+    pipeline_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipeline_ci.stageCount = static_cast<std::uint32_t>(shader_stages.size());
+    pipeline_ci.pStages = shader_stages.data();
+    pipeline_ci.pVertexInputState = &vertex_input_ci;
+    pipeline_ci.pInputAssemblyState = &input_assembly_ci;
+    pipeline_ci.pTessellationState = nullptr;
+    pipeline_ci.pViewportState = &viewport_state_ci;
+    pipeline_ci.pRasterizationState = &rasterization_state_ci;
+    pipeline_ci.pMultisampleState = &multisample_state_ci;
+    pipeline_ci.pDepthStencilState = &depth_stencil;
+    pipeline_ci.pColorBlendState = &color_blend_state_ci;
+    pipeline_ci.pDynamicState = &dynamic_state_ci;
+    pipeline_ci.layout = pipeline_layout;
+    pipeline_ci.renderPass = render_pass;
+    pipeline_ci.subpass = 0;
+    pipeline_ci.basePipelineHandle = VK_NULL_HANDLE;
+    pipeline_ci.basePipelineIndex = -1;
+
+    spdlog::debug("Creating cache for graphics pipeline.");
+
+    VkPipelineCacheCreateInfo cache_ci = {};
+    cache_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+
+    if (vkCreatePipelineCache(device, &cache_ci, nullptr, &pipeline_cache) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreatePipelineCache failed for " + name + " !");
+    }
+
+    // TODO: Assign an internal name to this pipeline cache using Vulkan debug markers!
+
+    spdlog::debug("Creating graphics pipeline.");
+
+    if (vkCreateGraphicsPipelines(device, pipeline_cache, 1, &pipeline_ci, nullptr, &graphics_pipeline) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreateGraphicsPipelines failed for " + name + " !");
+    }
+
+    // TODO: Assign an internal name to this graphics pipeline using Vulkan debug markers!
+
+    spdlog::debug("Created graphics pipeline and cache successfully.");
+}
+
+GraphicsPipeline::~GraphicsPipeline() {
+    vkDestroyPipelineCache(device, pipeline_cache, nullptr);
+    vkDestroyPipeline(device, graphics_pipeline, nullptr);
+}
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/pipeline_layout.cpp
+++ b/src/vulkan-renderer/wrapper/pipeline_layout.cpp
@@ -1,0 +1,38 @@
+#include "inexor/vulkan-renderer/wrapper/pipeline_layout.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <cassert>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+PipelineLayout::PipelineLayout(PipelineLayout &&other) noexcept
+    : device(other.device), pipeline_layout(std::exchange(other.pipeline_layout, nullptr)), name(std::move(other.name)) {}
+
+PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescriptorSetLayout> &descriptor_set_layouts, const std::string &name)
+    : device(device), name(name) {
+    assert(device);
+    assert(!descriptor_set_layouts.empty());
+    assert(!name.empty());
+
+    VkPipelineLayoutCreateInfo create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    create_info.setLayoutCount = static_cast<std::uint32_t>(descriptor_set_layouts.size());
+    create_info.pSetLayouts = descriptor_set_layouts.data();
+
+    spdlog::debug("Creating pipeline layout {}.", name);
+
+    if (vkCreatePipelineLayout(device, &create_info, nullptr, &pipeline_layout)) {
+        throw std::runtime_error("Error: vkCreatePipelineLayout failed for " + name + " !");
+    }
+
+    // TODO: Assign an internal name to this pipeline layout using Vulkan debug markers.
+
+    spdlog::debug("Created pipeline layout successfully.");
+}
+
+PipelineLayout::~PipelineLayout() {
+    vkDestroyPipelineLayout(device, pipeline_layout, nullptr);
+}
+
+} // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/renderpass.cpp
+++ b/src/vulkan-renderer/wrapper/renderpass.cpp
@@ -1,0 +1,35 @@
+#include "inexor/vulkan-renderer/wrapper/renderpass.hpp"
+
+#include <spdlog/spdlog.h>
+
+namespace inexor::vulkan_renderer::wrapper {
+
+RenderPass::RenderPass(RenderPass &&other) noexcept : device(other.device), renderpass(std::exchange(other.renderpass, nullptr)), name(std::move(other.name)) {}
+
+RenderPass::RenderPass(const VkDevice device, const std::vector<VkAttachmentDescription> &attachments, const std::vector<VkSubpassDependency> &dependencies,
+                       const VkSubpassDescription subpass_description, const std::string &name)
+    : device(device), name(name) {
+
+    VkRenderPassCreateInfo renderpass_ci = {};
+    renderpass_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    renderpass_ci.attachmentCount = static_cast<std::uint32_t>(attachments.size());
+    renderpass_ci.pAttachments = attachments.data();
+    renderpass_ci.subpassCount = 1;
+    renderpass_ci.pSubpasses = &subpass_description;
+    renderpass_ci.dependencyCount = 2;
+    renderpass_ci.pDependencies = dependencies.data();
+
+    spdlog::debug("Creating renderpass {}.", name);
+
+    if (vkCreateRenderPass(device, &renderpass_ci, nullptr, &renderpass) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreateRenderPass failed for " + name + " !");
+    }
+
+    spdlog::debug("Created renderpass successfully.");
+}
+
+RenderPass::~RenderPass() {
+    vkDestroyRenderPass(device, renderpass, nullptr);
+}
+
+} // namespace inexor::vulkan_renderer::wrapper


### PR DESCRIPTION
In this RAII refactoring, I encapsulate:

* `VkPipelineLayout`
* `VkRenderPass`
* `VkPipeline` and `VkPipelineCache` (one wrapper)
 
This is the refactoring where we have the most parameters in our constructors.
I think most of it needs to be extended in the future again (especially renderpasses), as mentioned in the TODOs.

But for now, this really simplifies the code and further decreases the size of `renderer.cpp`.