### PR TITLE
Moved spdlog trace messages to RAII destructors.

### DIFF
--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -195,11 +195,7 @@ VkResult VulkanRenderer::cleanup_swapchain() {
 
     spdlog::debug("Device is idle.");
 
-    spdlog::debug("Destroying frame buffer.");
-
     framebuffer.reset();
-
-    spdlog::debug("Destroying depth buffer image view.");
 
     depth_buffer.reset();
 
@@ -210,25 +206,13 @@ VkResult VulkanRenderer::cleanup_swapchain() {
         msaa_target_buffer.depth.reset();
     }
 
-    spdlog::debug("Destroying command buffers.");
-
     command_buffers.clear();
-
-    spdlog::debug("Destroying pipeline.");
 
     graphics_pipeline.reset();
 
-    spdlog::debug("Destroying pipeline layout.");
-
     pipeline_layout.reset();
 
-    spdlog::debug("Destroying render pass.");
-
     renderpass.reset();
-
-    spdlog::debug("Destroying image views.");
-
-    spdlog::debug("Destroying descriptor sets and layouts.");
 
     return VK_SUCCESS;
 }
@@ -258,8 +242,6 @@ VkResult VulkanRenderer::recreate_swapchain() {
 
     swapchain->recreate(window_width, window_height);
 
-    spdlog::debug("Destroying depth buffer image view.");
-
     depth_buffer.reset();
 
     depth_stencil.reset();
@@ -268,9 +250,6 @@ VkResult VulkanRenderer::recreate_swapchain() {
         msaa_target_buffer.color.reset();
         msaa_target_buffer.depth.reset();
     }
-
-    // TODO: Create methods for destroying resources as well!
-    spdlog::debug("Destroying frame buffer.");
 
     framebuffer.reset();
 
@@ -679,11 +658,9 @@ VkResult VulkanRenderer::shutdown_vulkan() {
     mesh_buffers.clear();
     descriptors.clear();
 
-    spdlog::debug("Destroying semaphores.");
     image_available_semaphores.clear();
     rendering_finished_semaphores.clear();
 
-    spdlog::debug("Destroying fences.");
     in_flight_fences.clear();
 
     vma.reset();

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -30,6 +30,7 @@ Fence::Fence(const VkDevice device, const std::string &name, const bool in_signa
 }
 
 Fence::~Fence() {
+    spdlog::trace("Destroying fences {}.", name);
     vkDestroyFence(device, fence, nullptr);
 }
 

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -56,7 +56,7 @@ Framebuffer::Framebuffer(const VkDevice device, const VkRenderPass renderpass,
 }
 
 Framebuffer::~Framebuffer() {
-    spdlog::trace("Destroying frame buffer.");
+    spdlog::trace("Destroying frame buffer {}.", name);
 
     for (auto *frame : frames) {
         vkDestroyFramebuffer(device, frame, nullptr);

--- a/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
+++ b/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
@@ -173,7 +173,10 @@ GraphicsPipeline::GraphicsPipeline(const VkDevice device, const VkPipelineLayout
 }
 
 GraphicsPipeline::~GraphicsPipeline() {
+    spdlog::trace("Destroying pipeline cache {}.", name);
     vkDestroyPipelineCache(device, pipeline_cache, nullptr);
+
+    spdlog::trace("Destroying pipeline {}.", name);
     vkDestroyPipeline(device, graphics_pipeline, nullptr);
 }
 

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -71,7 +71,10 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
 }
 
 Image::~Image() {
+    spdlog::trace("Destroying image view {} .", name);
     vkDestroyImageView(device, image_view, nullptr);
+
+    spdlog::trace("Destroying image {} .", name);
     vmaDestroyImage(vma_allocator, image, allocation);
 }
 

--- a/src/vulkan-renderer/wrapper/pipeline_layout.cpp
+++ b/src/vulkan-renderer/wrapper/pipeline_layout.cpp
@@ -34,6 +34,7 @@ PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescri
 }
 
 PipelineLayout::~PipelineLayout() {
+    spdlog::trace("Destroying pipeline layout {}.", name);
     vkDestroyPipelineLayout(device, pipeline_layout, nullptr);
 }
 

--- a/src/vulkan-renderer/wrapper/renderpass.cpp
+++ b/src/vulkan-renderer/wrapper/renderpass.cpp
@@ -31,6 +31,7 @@ RenderPass::RenderPass(const VkDevice device, const std::vector<VkAttachmentDesc
 }
 
 RenderPass::~RenderPass() {
+    spdlog::trace("Destroying render pass {}.", name);
     vkDestroyRenderPass(device, renderpass, nullptr);
 }
 

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -31,6 +31,7 @@ Semaphore::Semaphore(const VkDevice device, const std::string &name) : device(de
 }
 
 Semaphore::~Semaphore() {
+    spdlog::trace("Destroying semaphore {}.", name);
     vkDestroySemaphore(device, semaphore, nullptr);
 }
 


### PR DESCRIPTION
This small pull request moves spdlog trace messages to the corresponding destructor.