### PR TITLE
[cmake] Bump minimum version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.9)
 project(inexor-vulkan-renderer)
 
 # Stop in source builds


### PR DESCRIPTION
This allows us to use link time optimization through cmake, as the `INTERPROCEDURAL_OPTIMIZATION` target property was ignored in versions before 3.9.