### PR TITLE
Small code style cleanup

### DIFF
--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -15,13 +15,13 @@ namespace inexor::vulkan_renderer {
 
 class Application : public VulkanRenderer {
 private:
-    std::string m_application_name = "";
+    std::string m_application_name;
 
-    std::string m_engine_name = "";
+    std::string m_engine_name;
 
-    std::uint32_t m_application_version = 0;
+    std::uint32_t m_application_version{};
 
-    std::uint32_t m_engine_version = 0;
+    std::uint32_t m_engine_version{};
 
     // The core concept of paralellization in Inexor is to use a
     // C++17 threadpool implementation which spawns worker threads.

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -15,19 +15,19 @@ namespace inexor::vulkan_renderer {
 
 class Application : public VulkanRenderer {
 private:
-    std::string application_name = "";
+    std::string m_application_name = "";
 
-    std::string engine_name = "";
+    std::string m_engine_name = "";
 
-    std::uint32_t application_version = 0;
+    std::uint32_t m_application_version = 0;
 
-    std::uint32_t engine_version = 0;
+    std::uint32_t m_engine_version = 0;
 
     // The core concept of paralellization in Inexor is to use a
     // C++17 threadpool implementation which spawns worker threads.
     // A task system is used to distribute work over worker threads.
     // Call thread_pool->execute(); to order new tasks to be worked on.
-    std::shared_ptr<ThreadPool> thread_pool;
+    std::shared_ptr<ThreadPool> m_thread_pool;
 
     // TODO: Refactor into a manger class.
     struct ShaderSetup {
@@ -35,15 +35,15 @@ private:
         std::string shader_file_name;
     };
 
-    std::vector<std::string> vertex_shader_files;
+    std::vector<std::string> m_vertex_shader_files;
 
-    std::vector<std::string> fragment_shader_files;
+    std::vector<std::string> m_fragment_shader_files;
 
-    std::vector<std::string> texture_files;
+    std::vector<std::string> m_texture_files;
 
-    std::vector<std::string> shader_files;
+    std::vector<std::string> m_shader_files;
 
-    std::vector<std::string> gltf_model_files;
+    std::vector<std::string> m_gltf_model_files;
 
 private:
     /// @brief Loads the configuration of the renderer from a TOML configuration file.
@@ -66,7 +66,7 @@ private:
     VkResult update_mouse_input();
 
     // TODO: Refactor!
-    double cursor_x, cursor_y;
+    double m_cursor_x, m_cursor_y;
 
 public:
     Application(int argc, char **argv);

--- a/include/inexor/vulkan-renderer/availability_checks.hpp
+++ b/include/inexor/vulkan-renderer/availability_checks.hpp
@@ -10,21 +10,21 @@ namespace inexor::vulkan_renderer {
 
 class AvailabilityChecksManager {
 private:
-    std::uint32_t available_instance_extensions = 0;
+    std::uint32_t m_available_instance_extensions = 0;
 
-    std::uint32_t available_instance_layers = 0;
+    std::uint32_t m_available_instance_layers = 0;
 
-    std::uint32_t available_device_layers = 0;
+    std::uint32_t m_available_device_layers = 0;
 
-    std::uint32_t available_device_extensions = 0;
+    std::uint32_t m_available_device_extensions = 0;
 
-    std::vector<VkExtensionProperties> instance_extensions_cache;
+    std::vector<VkExtensionProperties> m_instance_extensions_cache;
 
-    std::vector<VkLayerProperties> instance_layers_cache;
+    std::vector<VkLayerProperties> m_instance_layers_cache;
 
-    std::vector<VkLayerProperties> device_layer_properties_cache;
+    std::vector<VkLayerProperties> m_device_layer_properties_cache;
 
-    std::vector<VkExtensionProperties> device_extensions_cache;
+    std::vector<VkExtensionProperties> m_device_extensions_cache;
 
     VkResult create_instance_layers_cache();
 

--- a/include/inexor/vulkan-renderer/availability_checks.hpp
+++ b/include/inexor/vulkan-renderer/availability_checks.hpp
@@ -10,13 +10,13 @@ namespace inexor::vulkan_renderer {
 
 class AvailabilityChecksManager {
 private:
-    std::uint32_t m_available_instance_extensions = 0;
+    std::uint32_t m_available_instance_extensions{0};
 
-    std::uint32_t m_available_instance_layers = 0;
+    std::uint32_t m_available_instance_layers{0};
 
-    std::uint32_t m_available_device_layers = 0;
+    std::uint32_t m_available_device_layers{0};
 
-    std::uint32_t m_available_device_extensions = 0;
+    std::uint32_t m_available_device_extensions{0};
 
     std::vector<VkExtensionProperties> m_instance_extensions_cache;
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -60,13 +60,13 @@ struct BezierOutputPoint : public BezierInputPoint {
 /// @brief This struct bundles describes everything about the bezier curve.
 /// It contains both the input points and the generated output points.
 class BezierCurve {
-    bool curve_generated;
+    bool m_curve_generated;
 
-    float curve_precision;
+    float m_curve_precision;
 
-    std::vector<BezierInputPoint> input_points;
+    std::vector<BezierInputPoint> m_input_points;
 
-    std::vector<BezierOutputPoint> output_points;
+    std::vector<BezierOutputPoint> m_output_points;
 
     uint32_t binomial_coefficient(uint32_t n, const uint32_t k);
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -85,7 +85,7 @@ public:
 
     void calculate_bezier_curve(const float curve_precision);
 
-    [[nodiscard]] std::vector<BezierOutputPoint> get_output_points();
+    [[nodiscard]] std::vector<BezierOutputPoint> output_points();
 
     void clear_output();
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -43,18 +43,18 @@ namespace inexor::vulkan_renderer {
 /// Every bezier curve will be generated from a list of BezierInputPoint.
 /// Every input point can have a custom weight coefficient.
 struct BezierInputPoint {
-    glm::vec3 pos = glm::vec3(0.0f, 0.0f, 0.0f);
+    glm::vec3 pos{0.0f, 0.0f, 0.0f};
 
-    float weight = 1.0f;
+    float weight{1.0f};
 };
 
 /// @brief Those are the points which will be generated from the bezier curve generator.
 /// How many BezierOutputPoint points will be generated depends on the required precision.
 /// The higher the requested precision, the more points will be
 struct BezierOutputPoint : public BezierInputPoint {
-    glm::vec3 normal = glm::vec3(0.0f, 0.0f, 0.0f);
+    glm::vec3 normal{0.0f, 0.0f, 0.0f};
 
-    glm::vec3 tangent = glm::vec3(0.0f, 0.0f, 0.0f);
+    glm::vec3 tangent{0.0f, 0.0f, 0.0f};
 };
 
 /// @brief This struct bundles describes everything about the bezier curve.

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -7,34 +7,34 @@ namespace inexor::vulkan_renderer {
 // TODO: Refactor method naming!
 class Camera {
 private:
-    float fov;
-    float z_near, z_far;
+    float m_fov;
+    float m_z_near, m_z_far;
 
     void update_view_matrix();
 
 public:
     enum CameraType { LOOKAT, FIRSTPERSON };
-    CameraType type = CameraType::LOOKAT;
+    CameraType m_type = CameraType::LOOKAT;
 
-    glm::vec3 rotation = glm::vec3();
-    glm::vec3 position = glm::vec3();
+    glm::vec3 m_rotation = glm::vec3();
+    glm::vec3 m_position = glm::vec3();
 
-    float rotation_speed = 1.0f;
-    float movement_speed = 1.0f;
+    float m_rotation_speed = 1.0f;
+    float m_movement_speed = 1.0f;
 
-    bool updated = false;
+    bool m_updated = false;
 
     struct {
         glm::mat4 perspective;
         glm::mat4 view;
-    } matrices;
+    } m_matrices;
 
     struct {
         bool left = false;
         bool right = false;
         bool up = false;
         bool down = false;
-    } keys;
+    } m_keys;
 
     bool moving();
 

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -14,15 +14,15 @@ private:
 
 public:
     enum CameraType { LOOKAT, FIRSTPERSON };
-    CameraType m_type = CameraType::LOOKAT;
+    CameraType m_type{CameraType::LOOKAT};
 
-    glm::vec3 m_rotation = glm::vec3();
-    glm::vec3 m_position = glm::vec3();
+    glm::vec3 m_rotation{};
+    glm::vec3 m_position{};
 
-    float m_rotation_speed = 1.0f;
-    float m_movement_speed = 1.0f;
+    float m_rotation_speed{1.0f};
+    float m_movement_speed{1.0f};
 
-    bool m_updated = false;
+    bool m_updated{false};
 
     struct {
         glm::mat4 perspective;
@@ -30,10 +30,10 @@ public:
     } m_matrices;
 
     struct {
-        bool left = false;
-        bool right = false;
-        bool up = false;
-        bool down = false;
+        bool left{false};
+        bool right{false};
+        bool up{false};
+        bool down{false};
     } m_keys;
 
     bool moving();

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -38,9 +38,9 @@ public:
 
     bool moving();
 
-    float get_near_clip();
+    float near_clip();
 
-    float get_far_clip();
+    float far_clip();
 
     void set_perspective(float fov, float aspect, float z_near, float z_far);
 

--- a/include/inexor/vulkan-renderer/error_handling.hpp
+++ b/include/inexor/vulkan-renderer/error_handling.hpp
@@ -11,7 +11,7 @@ namespace inexor::vulkan_renderer {
 // @brief Returns an error text.
 // @param result_code The result code.
 // @return A string which describes the error.
-[[nodiscard]] std::string get_error_description_text(const VkResult &result_code);
+[[nodiscard]] std::string error_description_text(const VkResult &result_code);
 
 // @brief Displays an error message as a message.
 // @param error_message The error message.

--- a/include/inexor/vulkan-renderer/fps_counter.hpp
+++ b/include/inexor/vulkan-renderer/fps_counter.hpp
@@ -8,11 +8,11 @@ namespace inexor::vulkan_renderer {
 
 class FPSCounter {
 private:
-    std::size_t frames = 0;
+    std::size_t m_frames = 0;
 
-    std::chrono::time_point<std::chrono::high_resolution_clock> last_time;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_last_time;
 
-    float fps_update_interval = 1.0f;
+    float m_fps_update_interval = 1.0f;
 
 public:
     FPSCounter() = default;

--- a/include/inexor/vulkan-renderer/msaa_target.hpp
+++ b/include/inexor/vulkan-renderer/msaa_target.hpp
@@ -8,10 +8,10 @@ namespace inexor::vulkan_renderer {
 
 struct MSAATarget {
     // The color buffer.
-    std::unique_ptr<wrapper::Image> color;
+    std::unique_ptr<wrapper::Image> m_color;
 
     // The depth buffer.
-    std::unique_ptr<wrapper::Image> depth;
+    std::unique_ptr<wrapper::Image> m_depth;
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -74,25 +74,25 @@ protected:
     Camera m_game_camera;
 
     // RAII wrapper for glfw contexts.
-    std::unique_ptr<wrapper::GLFWContext> m_glfw_context = nullptr;
+    std::unique_ptr<wrapper::GLFWContext> m_glfw_context;
 
     // RAII wrapper for glfw windows.
-    std::unique_ptr<wrapper::Window> m_window = nullptr;
+    std::unique_ptr<wrapper::Window> m_window;
 
     // RAII wrapper for VkInstance.
-    std::unique_ptr<wrapper::Instance> m_vkinstance = nullptr;
+    std::unique_ptr<wrapper::Instance> m_vkinstance;
 
     // RAII wrapper for VkDevice, VkPhysicalDevice and VkQueues.
-    std::unique_ptr<wrapper::Device> m_vkdevice = nullptr;
+    std::unique_ptr<wrapper::Device> m_vkdevice;
 
     // RAII wrapper for glfw compatible Vulkan surfaces.
-    std::unique_ptr<wrapper::WindowSurface> m_surface = nullptr;
+    std::unique_ptr<wrapper::WindowSurface> m_surface;
 
     // RAII wrapper for Swapchain.
-    std::unique_ptr<wrapper::Swapchain> m_swapchain = nullptr;
+    std::unique_ptr<wrapper::Swapchain> m_swapchain;
 
     // RAII wrapper for command pools.
-    std::unique_ptr<wrapper::CommandPool> m_command_pool = nullptr;
+    std::unique_ptr<wrapper::CommandPool> m_command_pool;
 
     std::unique_ptr<wrapper::Semaphore> m_image_available_semaphore;
     std::unique_ptr<wrapper::Semaphore> m_rendering_finished_semaphore;

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -42,66 +42,66 @@ protected:
     // We try to avoid inheritance here and prefer a composition pattern.
     // TODO: VulkanSwapchainManager, VulkanPipelineManager, VulkanRenderPassManager?
 
-    std::shared_ptr<VulkanGraphicsCardInfoViewer> gpu_info_manager = std::make_shared<VulkanGraphicsCardInfoViewer>();
+    std::shared_ptr<VulkanGraphicsCardInfoViewer> m_gpu_info_manager = std::make_shared<VulkanGraphicsCardInfoViewer>();
 
-    std::shared_ptr<AvailabilityChecksManager> availability_checks_manager =
+    std::shared_ptr<AvailabilityChecksManager> m_availability_checks_manager =
         std::make_shared<AvailabilityChecksManager>();
 
-    std::shared_ptr<VulkanSettingsDecisionMaker> settings_decision_maker =
+    std::shared_ptr<VulkanSettingsDecisionMaker> m_settings_decision_maker =
         std::make_shared<VulkanSettingsDecisionMaker>();
 
-    std::vector<VkPipelineShaderStageCreateInfo> shader_stages;
+    std::vector<VkPipelineShaderStageCreateInfo> m_shader_stages;
 
-    VkDebugReportCallbackEXT debug_report_callback{};
+    VkDebugReportCallbackEXT m_debug_report_callback{};
 
-    bool debug_report_callback_initialised = false;
+    bool m_debug_report_callback_initialised = false;
 
-    TimeStep time_step;
+    TimeStep m_time_step;
 
-    std::uint32_t window_width = 0;
+    std::uint32_t m_window_width = 0;
 
-    std::uint32_t window_height = 0;
+    std::uint32_t m_window_height = 0;
 
-    std::string window_title = "";
+    std::string m_window_title = "";
 
-    FPSCounter fps_counter;
+    FPSCounter m_fps_counter;
 
     // TODO: Refactor this!
-    VkDescriptorBufferInfo uniform_buffer_info{};
+    VkDescriptorBufferInfo m_uniform_buffer_info{};
 
-    bool vsync_enabled = false;
+    bool m_vsync_enabled = false;
 
-    Camera game_camera;
+    Camera m_game_camera;
 
     // RAII wrapper for glfw contexts.
-    std::unique_ptr<wrapper::GLFWContext> glfw_context = nullptr;
+    std::unique_ptr<wrapper::GLFWContext> m_glfw_context = nullptr;
 
     // RAII wrapper for glfw windows.
-    std::unique_ptr<wrapper::Window> window = nullptr;
+    std::unique_ptr<wrapper::Window> m_window = nullptr;
 
     // RAII wrapper for VkInstance.
-    std::unique_ptr<wrapper::Instance> vkinstance = nullptr;
+    std::unique_ptr<wrapper::Instance> m_vkinstance = nullptr;
 
     // RAII wrapper for VkDevice, VkPhysicalDevice and VkQueues.
-    std::unique_ptr<wrapper::Device> vkdevice = nullptr;
+    std::unique_ptr<wrapper::Device> m_vkdevice = nullptr;
 
     // RAII wrapper for glfw compatible Vulkan surfaces.
-    std::unique_ptr<wrapper::WindowSurface> surface = nullptr;
+    std::unique_ptr<wrapper::WindowSurface> m_surface = nullptr;
 
     // RAII wrapper for Swapchain.
-    std::unique_ptr<wrapper::Swapchain> swapchain = nullptr;
+    std::unique_ptr<wrapper::Swapchain> m_swapchain = nullptr;
 
     // RAII wrapper for command pools.
-    std::unique_ptr<wrapper::CommandPool> command_pool = nullptr;
+    std::unique_ptr<wrapper::CommandPool> m_command_pool = nullptr;
 
-    std::unique_ptr<wrapper::Semaphore> image_available_semaphore;
-    std::unique_ptr<wrapper::Semaphore> rendering_finished_semaphore;
+    std::unique_ptr<wrapper::Semaphore> m_image_available_semaphore;
+    std::unique_ptr<wrapper::Semaphore> m_rendering_finished_semaphore;
 
-    std::vector<wrapper::Shader> shaders;
-    std::vector<wrapper::Texture> textures;
-    std::vector<wrapper::UniformBuffer> uniform_buffers;
-    std::vector<wrapper::MeshBuffer> mesh_buffers;
-    std::vector<wrapper::Descriptor> descriptors;
+    std::vector<wrapper::Shader> m_shaders;
+    std::vector<wrapper::Texture> m_textures;
+    std::vector<wrapper::UniformBuffer> m_uniform_buffers;
+    std::vector<wrapper::MeshBuffer> m_mesh_buffers;
+    std::vector<wrapper::Descriptor> m_descriptors;
 
     // NOTE: We use unique_ptr for easy frame graph recreation during swapchain invalidation
     std::unique_ptr<FrameGraph> m_frame_graph;
@@ -126,13 +126,13 @@ public:
     /// @brief Run Vulkan memory allocator's memory statistics
     void calculate_memory_budget();
 
-    bool window_resized = false;
+    bool m_window_resized = false;
 
     /// Neccesary for taking into account the relative speed of the system's CPU.
-    float time_passed = 0.0f;
+    float m_time_passed = 0.0f;
 
     //
-    TimeStep stopwatch;
+    TimeStep m_stopwatch;
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -42,34 +42,32 @@ protected:
     // We try to avoid inheritance here and prefer a composition pattern.
     // TODO: VulkanSwapchainManager, VulkanPipelineManager, VulkanRenderPassManager?
 
-    std::shared_ptr<VulkanGraphicsCardInfoViewer> m_gpu_info_manager = std::make_shared<VulkanGraphicsCardInfoViewer>();
+    std::shared_ptr<VulkanGraphicsCardInfoViewer> m_gpu_info_manager{new VulkanGraphicsCardInfoViewer};
 
-    std::shared_ptr<AvailabilityChecksManager> m_availability_checks_manager =
-        std::make_shared<AvailabilityChecksManager>();
+    std::shared_ptr<AvailabilityChecksManager> m_availability_checks_manager{new AvailabilityChecksManager};
 
-    std::shared_ptr<VulkanSettingsDecisionMaker> m_settings_decision_maker =
-        std::make_shared<VulkanSettingsDecisionMaker>();
+    std::shared_ptr<VulkanSettingsDecisionMaker> m_settings_decision_maker{new VulkanSettingsDecisionMaker};
 
     std::vector<VkPipelineShaderStageCreateInfo> m_shader_stages;
 
     VkDebugReportCallbackEXT m_debug_report_callback{};
 
-    bool m_debug_report_callback_initialised = false;
+    bool m_debug_report_callback_initialised{false};
 
     TimeStep m_time_step;
 
-    std::uint32_t m_window_width = 0;
+    std::uint32_t m_window_width{0};
 
-    std::uint32_t m_window_height = 0;
+    std::uint32_t m_window_height{0};
 
-    std::string m_window_title = "";
+    std::string m_window_title;
 
     FPSCounter m_fps_counter;
 
     // TODO: Refactor this!
     VkDescriptorBufferInfo m_uniform_buffer_info{};
 
-    bool m_vsync_enabled = false;
+    bool m_vsync_enabled{false};
 
     Camera m_game_camera;
 
@@ -126,10 +124,10 @@ public:
     /// @brief Run Vulkan memory allocator's memory statistics
     void calculate_memory_budget();
 
-    bool m_window_resized = false;
+    bool m_window_resized{false};
 
     /// Neccesary for taking into account the relative speed of the system's CPU.
-    float m_time_passed = 0.0f;
+    float m_time_passed{0.0f};
 
     //
     TimeStep m_stopwatch;

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -41,7 +41,7 @@ public:
     /// @brief Gets the VkPhysicalDeviceType of a graphics card.
     /// @param graphics_card The graphics card.
     /// @return The graphics_card of the graphics card.
-    [[nodiscard]] VkPhysicalDeviceType get_graphics_card_type(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] VkPhysicalDeviceType graphics_card_type(const VkPhysicalDevice &graphics_card);
 
     /// @brief Automatically selects the best graphics card considering all available ones.
     /// @note If there is only one graphics card available, we can't choose and must use it obviously.

--- a/include/inexor/vulkan-renderer/thread_pool.hpp
+++ b/include/inexor/vulkan-renderer/thread_pool.hpp
@@ -117,7 +117,7 @@ private:
 
     std::condition_variable m_tasklist_cv;
 
-    std::atomic<bool> m_stop_threads = false;
+    std::atomic<bool> m_stop_threads{false};
 };
 
 template <typename F, typename... Args, typename>

--- a/include/inexor/vulkan-renderer/time_step.hpp
+++ b/include/inexor/vulkan-renderer/time_step.hpp
@@ -10,10 +10,10 @@ namespace inexor::vulkan_renderer {
 class TimeStep {
 private:
     // The time point of the last render call.
-    std::chrono::time_point<std::chrono::high_resolution_clock> last_time;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_last_time;
 
     // The time point of initialisation.
-    std::chrono::time_point<std::chrono::high_resolution_clock> initialisation_time;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_initialisation_time;
 
 public:
     TimeStep();

--- a/include/inexor/vulkan-renderer/time_step.hpp
+++ b/include/inexor/vulkan-renderer/time_step.hpp
@@ -22,11 +22,11 @@ public:
 
     /// @brief Returns a scaling factor which corresponds to the
     /// time which has passed since last render call and now.
-    [[nodiscard]] float get_time_step();
+    [[nodiscard]] float time_step();
 
     /// @brief Returns a scaling factor which corresponds to the
     /// time which has passed since initialisation and now.
-    [[nodiscard]] float get_time_step_since_initialisation();
+    [[nodiscard]] float time_step_since_initialisation();
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/tools/cla_parser.hpp
+++ b/include/inexor/vulkan-renderer/tools/cla_parser.hpp
@@ -11,30 +11,30 @@ namespace inexor::vulkan_renderer::tools {
 
 /// @brief Template class for creating arguments
 class CommandLineArgumentTemplate {
-    const std::string argument;
-    const bool takes_values;
+    const std::string m_argument;
+    const bool m_takes_values;
 
 public:
     /// @param argument The argument to be passed on the command line (e.g --vsync)
     /// @param takes_args Whether this argument can take values (e.g --gpu 1)
     /// @note Only arguments that take zero or one values are supported
     CommandLineArgumentTemplate(std::string argument, bool takes_args)
-        : argument(std::move(argument)), takes_values(takes_args) {}
+        : m_argument(std::move(argument)), m_takes_values(takes_args) {}
 
     [[nodiscard]] const std::string &get_argument() const {
-        return argument;
+        return m_argument;
     }
 
     [[nodiscard]] bool does_take_values() const {
-        return takes_values;
+        return m_takes_values;
     }
 };
 
 class CommandLineArgumentValue {
-    const std::string value;
+    const std::string m_value;
 
 public:
-    explicit CommandLineArgumentValue(std::string value) : value(std::move(value)) {}
+    explicit CommandLineArgumentValue(std::string value) : m_value(std::move(value)) {}
 
     template <typename T>
     T as() const;
@@ -47,7 +47,7 @@ public:
 /// @todo Support short arguments with stacking (e.g -abc)
 class CommandLineArgumentParser {
     /// @todo Allow runtime addition of accepted parameters
-    const std::vector<CommandLineArgumentTemplate> accepted_args = {
+    const std::vector<CommandLineArgumentTemplate> m_accepted_args = {
         // Defines which GPU to use (by array index).
         {"--gpu", true},
 
@@ -69,7 +69,7 @@ class CommandLineArgumentParser {
         // Disable debug markers (even if -renderdoc is specified)
         {"--no-vk-debug-markers", false}};
 
-    std::unordered_map<std::string, CommandLineArgumentValue> parsed_arguments;
+    std::unordered_map<std::string, CommandLineArgumentValue> m_parsed_arguments;
 
     std::optional<CommandLineArgumentTemplate> get_arg_template(const std::string &argument_name) const;
 
@@ -84,8 +84,8 @@ public:
             return std::nullopt;
         }
 
-        auto it = parsed_arguments.find(name);
-        if (it == parsed_arguments.end()) {
+        auto it = m_parsed_arguments.find(name);
+        if (it == m_parsed_arguments.end()) {
             return std::nullopt;
         }
 
@@ -98,7 +98,7 @@ public:
 
     /// @brief Returns the number of command line arguments.
     [[nodiscard]] std::size_t get_parsed_arg_count() const {
-        return parsed_arguments.size();
+        return m_parsed_arguments.size();
     }
 };
 

--- a/include/inexor/vulkan-renderer/tools/cla_parser.hpp
+++ b/include/inexor/vulkan-renderer/tools/cla_parser.hpp
@@ -21,11 +21,11 @@ public:
     CommandLineArgumentTemplate(std::string argument, bool takes_args)
         : m_argument(std::move(argument)), m_takes_values(takes_args) {}
 
-    [[nodiscard]] const std::string &get_argument() const {
+    [[nodiscard]] const std::string &argument() const {
         return m_argument;
     }
 
-    [[nodiscard]] bool does_take_values() const {
+    [[nodiscard]] bool takes_values() const {
         return m_takes_values;
     }
 };
@@ -71,15 +71,15 @@ class CommandLineArgumentParser {
 
     std::unordered_map<std::string, CommandLineArgumentValue> m_parsed_arguments;
 
-    std::optional<CommandLineArgumentTemplate> get_arg_template(const std::string &argument_name) const;
+    std::optional<CommandLineArgumentTemplate> make_arg_template(const std::string &argument_name) const;
 
 public:
     /// @brief Parses the command line arguments
     void parse_args(int argc, char **argv);
 
     template <typename T>
-    std::optional<T> get_arg(const std::string &name) const {
-        auto arg_template = get_arg_template(name);
+    std::optional<T> arg(const std::string &name) const {
+        auto arg_template = make_arg_template(name);
         if (!arg_template) {
             return std::nullopt;
         }
@@ -89,7 +89,7 @@ public:
             return std::nullopt;
         }
 
-        if (!arg_template->does_take_values()) {
+        if (!arg_template->takes_values()) {
             return true;
         }
 
@@ -97,7 +97,7 @@ public:
     }
 
     /// @brief Returns the number of command line arguments.
-    [[nodiscard]] std::size_t get_parsed_arg_count() const {
+    [[nodiscard]] std::size_t parsed_arg_count() const {
         return m_parsed_arguments.size();
     }
 };

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -10,10 +10,10 @@ namespace inexor::vulkan_renderer::tools {
 class File {
 private:
     /// The file data.
-    std::vector<char> file_data;
+    std::vector<char> m_file_data;
 
     /// The size of the file.
-    std::size_t file_size;
+    std::size_t m_file_size;
 
 public:
     File() = default;

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -21,10 +21,10 @@ public:
     ~File() = default;
 
     /// @brief Returns the size of the file.
-    [[nodiscard]] const std::size_t get_file_size() const;
+    [[nodiscard]] const std::size_t file_size() const;
 
     /// @brief Returns the file's data.
-    [[nodiscard]] const std::vector<char> &get_file_data() const;
+    [[nodiscard]] const std::vector<char> &file_data() const;
 
     /// @brief Loads the entire file into memory.
     /// @param file_name The name of the file.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -45,20 +45,20 @@ public:
     enum class Type { EMPTY = 0b00U, SOLID = 0b01U, NORMAL = 0b10U, OCTANT = 0b11U };
 
 private:
-    Type m_type = Type::SOLID;
-    float m_size = 32;
+    Type m_type{Type::SOLID};
+    float m_size{32};
     glm::vec3 m_position{0.0F, 0.0F, 0.0F};
 
     /// Root cube points to itself.
-    std::weak_ptr<Cube> m_parent = this->weak_from_this();
+    std::weak_ptr<Cube> m_parent{weak_from_this()};
 
     /// Indentations, should only be used if it is a geometry cube.
     std::array<Indentation, Cube::EDGES> m_indentations{};
     std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> m_childs{};
 
     /// Only geometry cube (Type::SOLID and Type::Normal) have a polygon cache.
-    mutable PolygonCache m_polygon_cache = nullptr;
-    mutable bool m_polygon_cache_valid = false;
+    mutable PolygonCache m_polygon_cache{nullptr};
+    mutable bool m_polygon_cache_valid{false};
 
     /// Removes all childs recursive.
     void remove_childs();

--- a/include/inexor/vulkan-renderer/world/indentation.hpp
+++ b/include/inexor/vulkan-renderer/world/indentation.hpp
@@ -9,8 +9,8 @@ public:
     static constexpr std::uint8_t MAX = 8;
 
 private:
-    std::uint8_t m_start = 0;
-    std::uint8_t m_end = Indentation::MAX;
+    std::uint8_t m_start{0};
+    std::uint8_t m_end{Indentation::MAX};
 
 public:
     Indentation() = default;

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -41,7 +41,7 @@ public:
         return m_command_buffer;
     }
 
-    [[nodiscard]] const VkCommandBuffer *get_ptr() const {
+    [[nodiscard]] const VkCommandBuffer *ptr() const {
         return &m_command_buffer;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -9,8 +9,8 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class CommandPool {
 private:
-    VkDevice device;
-    VkCommandPool command_pool;
+    VkDevice m_device;
+    VkCommandPool m_command_pool;
 
 public:
     /// Delete the copy constructor so Vulkan command pools are move-only objects.
@@ -29,11 +29,11 @@ public:
     ~CommandPool();
 
     [[nodiscard]] VkCommandPool get() const {
-        return command_pool;
+        return m_command_pool;
     }
 
     [[nodiscard]] const VkCommandPool *get_ptr() const {
-        return &command_pool;
+        return &m_command_pool;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -13,20 +13,16 @@ private:
     VkCommandPool m_command_pool;
 
 public:
-    /// Delete the copy constructor so Vulkan command pools are move-only objects.
-    CommandPool(const CommandPool &) = delete;
-    CommandPool(CommandPool &&other) noexcept;
-
-    /// Delete the copy assignment operator so Vulkan command pools are move-only objects.
-    CommandPool &operator=(const CommandPool &) = delete;
-    CommandPool &operator=(CommandPool &&) noexcept = default;
-
     /// @brief Creates a Vulkan command pool.
     /// @param device [in] The Vulkan device.
     /// @param queue_family_index [in] The queue family index for the command pool.
     CommandPool(const VkDevice device, const std::uint32_t queue_family_index);
-
+    CommandPool(const CommandPool &) = delete;
+    CommandPool(CommandPool &&) noexcept;
     ~CommandPool();
+
+    CommandPool &operator=(const CommandPool &) = delete;
+    CommandPool &operator=(CommandPool &&) = default;
 
     [[nodiscard]] VkCommandPool get() const {
         return m_command_pool;

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -32,7 +32,7 @@ public:
         return m_command_pool;
     }
 
-    [[nodiscard]] const VkCommandPool *get_ptr() const {
+    [[nodiscard]] const VkCommandPool *ptr() const {
         return &m_command_pool;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
@@ -11,16 +11,16 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief TODO
 class Descriptor {
 protected:
-    std::string name = "";
-    std::uint32_t number_of_images_in_swapchain = 0;
+    std::string m_name = "";
+    std::uint32_t m_number_of_images_in_swapchain = 0;
 
-    std::vector<VkDescriptorSet> descriptor_sets{};
-    std::vector<VkWriteDescriptorSet> write_descriptor_sets{};
-    std::vector<VkDescriptorSetLayoutBinding> descriptor_set_layout_bindings{};
+    std::vector<VkDescriptorSet> m_descriptor_sets{};
+    std::vector<VkWriteDescriptorSet> m_write_descriptor_sets{};
+    std::vector<VkDescriptorSetLayoutBinding> m_descriptor_set_layout_bindings{};
 
-    VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
-    VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
-    VkDevice device = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_descriptor_set_layout = VK_NULL_HANDLE;
+    VkDescriptorPool m_descriptor_pool = VK_NULL_HANDLE;
+    VkDevice m_device = VK_NULL_HANDLE;
 
 public:
     /// Delete the copy constructor so descriptors are move-only objects.
@@ -50,11 +50,11 @@ public:
     void reset(const bool clear_descriptor_layout_bindings = false);
 
     const auto get_descriptor_sets_data() const {
-        return descriptor_sets.data();
+        return m_descriptor_sets.data();
     }
 
     const auto get_descriptor_set_layout() const {
-        return descriptor_set_layout;
+        return m_descriptor_set_layout;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
@@ -23,19 +23,15 @@ protected:
     VkDevice m_device = VK_NULL_HANDLE;
 
 public:
-    /// Delete the copy constructor so descriptors are move-only objects.
-    Descriptor(const Descriptor &) = delete;
-    Descriptor(Descriptor &&other) noexcept;
-
-    /// Delete the copy assignment operator so descriptors are move-only objects.
-    Descriptor &operator=(const Descriptor &) = delete;
-    Descriptor &operator=(Descriptor &&) noexcept = default;
-
     /// @param device [in] The Vulkan device.
     /// @param number_of_images_in_swapchain [in] The number of images in the swapchain, usually 3 (triple buffering).
     Descriptor(VkDevice device, std::uint32_t number_of_images_in_swapchain, const std::string &name);
-
+    Descriptor(const Descriptor &) = delete;
+    Descriptor(Descriptor &&) noexcept;
     ~Descriptor();
+
+    Descriptor &operator=(const Descriptor &) = delete;
+    Descriptor &operator=(Descriptor &&) = default;
 
     void create_descriptor_pool(const std::initializer_list<VkDescriptorType> pool_types);
 

--- a/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
@@ -11,16 +11,16 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief TODO
 class Descriptor {
 protected:
-    std::string m_name = "";
-    std::uint32_t m_number_of_images_in_swapchain = 0;
+    std::string m_name;
+    std::uint32_t m_number_of_images_in_swapchain{0};
 
     std::vector<VkDescriptorSet> m_descriptor_sets{};
     std::vector<VkWriteDescriptorSet> m_write_descriptor_sets{};
     std::vector<VkDescriptorSetLayoutBinding> m_descriptor_set_layout_bindings{};
 
-    VkDescriptorSetLayout m_descriptor_set_layout = VK_NULL_HANDLE;
-    VkDescriptorPool m_descriptor_pool = VK_NULL_HANDLE;
-    VkDevice m_device = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_descriptor_set_layout{VK_NULL_HANDLE};
+    VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
+    VkDevice m_device{VK_NULL_HANDLE};
 
 public:
     /// @param device [in] The Vulkan device.

--- a/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
@@ -49,11 +49,11 @@ public:
     /// @note This will be called when swapchain needs to be recreated.
     void reset(const bool clear_descriptor_layout_bindings = false);
 
-    const auto get_descriptor_sets_data() const {
+    const auto descriptor_sets_data() const {
         return m_descriptor_sets.data();
     }
 
-    const auto get_descriptor_set_layout() const {
+    const auto descriptor_set_layout() const {
         return m_descriptor_set_layout;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -55,12 +55,12 @@ public:
 
     ~Device();
 
-    [[nodiscard]] const VkDevice get_device() const {
+    [[nodiscard]] const VkDevice device() const {
         assert(m_device);
         return m_device;
     }
 
-    [[nodiscard]] const VkPhysicalDevice get_physical_device() const {
+    [[nodiscard]] const VkPhysicalDevice physical_device() const {
         assert(m_graphics_card);
         return m_graphics_card;
     }
@@ -69,12 +69,12 @@ public:
         return m_allocator;
     }
 
-    [[nodiscard]] const VkQueue get_graphics_queue() const {
+    [[nodiscard]] const VkQueue graphics_queue() const {
         assert(m_graphics_queue);
         return m_graphics_queue;
     }
 
-    [[nodiscard]] const VkQueue get_present_queue() const {
+    [[nodiscard]] const VkQueue present_queue() const {
         assert(m_present_queue);
         return m_present_queue;
     }
@@ -82,20 +82,20 @@ public:
     /// @note Transfer queues are the fastest way to copy data across the PCIe bus.
     /// They are heavily underutilized even in modern games.
     /// Transfer queues can be used asynchronously to graphics queuey.
-    [[nodiscard]] const VkQueue get_transfer_queue() const {
+    [[nodiscard]] const VkQueue transfer_queue() const {
         assert(m_transfer_queue);
         return m_transfer_queue;
     }
 
-    [[nodiscard]] std::uint32_t get_graphics_queue_family_index() const {
+    [[nodiscard]] std::uint32_t graphics_queue_family_index() const {
         return m_graphics_queue_family_index;
     }
 
-    [[nodiscard]] std::uint32_t get_present_queue_family_index() const {
+    [[nodiscard]] std::uint32_t present_queue_family_index() const {
         return m_present_queue_family_index;
     }
 
-    [[nodiscard]] std::uint32_t get_transfer_queue_family_index() const {
+    [[nodiscard]] std::uint32_t transfer_queue_family_index() const {
         return m_transfer_queue_family_index;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -13,28 +13,28 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief A RAII wrapper for VkDevice, VkPhysicalDevice and VkQueues.
 class Device {
 private:
-    VkDevice device;
-    VkPhysicalDevice graphics_card;
+    VkDevice m_device;
+    VkPhysicalDevice m_graphics_card;
     VmaAllocator m_allocator;
 
     // TODO(): Create a queue wrapper
-    VkQueue graphics_queue;
-    VkQueue present_queue;
-    VkQueue transfer_queue;
-    VkSurfaceKHR surface;
+    VkQueue m_graphics_queue;
+    VkQueue m_present_queue;
+    VkQueue m_transfer_queue;
+    VkSurfaceKHR m_surface;
 
-    std::uint32_t present_queue_family_index;
-    std::uint32_t graphics_queue_family_index;
-    std::uint32_t transfer_queue_family_index;
+    std::uint32_t m_present_queue_family_index;
+    std::uint32_t m_graphics_queue_family_index;
+    std::uint32_t m_transfer_queue_family_index;
 
     // The debug marker extension is not part of the core,
     // so function pointers need to be loaded manually.
-    PFN_vkDebugMarkerSetObjectTagEXT vk_debug_marker_set_object_tag;
-    PFN_vkDebugMarkerSetObjectNameEXT vk_debug_marker_set_object_name;
-    PFN_vkCmdDebugMarkerBeginEXT vk_cmd_debug_marker_begin;
-    PFN_vkCmdDebugMarkerEndEXT vk_cmd_debug_marker_end;
-    PFN_vkCmdDebugMarkerInsertEXT vk_cmd_debug_marker_insert;
-    PFN_vkSetDebugUtilsObjectNameEXT vk_set_debug_utils_object_name;
+    PFN_vkDebugMarkerSetObjectTagEXT m_vk_debug_marker_set_object_tag;
+    PFN_vkDebugMarkerSetObjectNameEXT m_vk_debug_marker_set_object_name;
+    PFN_vkCmdDebugMarkerBeginEXT m_vk_cmd_debug_marker_begin;
+    PFN_vkCmdDebugMarkerEndEXT m_vk_cmd_debug_marker_end;
+    PFN_vkCmdDebugMarkerInsertEXT m_vk_cmd_debug_marker_insert;
+    PFN_vkSetDebugUtilsObjectNameEXT m_vk_set_debug_utils_object_name;
 
 public:
     /// Delete the copy constructor so shaders are move-only objects.
@@ -56,13 +56,13 @@ public:
     ~Device();
 
     [[nodiscard]] const VkDevice get_device() const {
-        assert(device);
-        return device;
+        assert(m_device);
+        return m_device;
     }
 
     [[nodiscard]] const VkPhysicalDevice get_physical_device() const {
-        assert(graphics_card);
-        return graphics_card;
+        assert(m_graphics_card);
+        return m_graphics_card;
     }
 
     [[nodiscard]] VmaAllocator allocator() const {
@@ -70,33 +70,33 @@ public:
     }
 
     [[nodiscard]] const VkQueue get_graphics_queue() const {
-        assert(graphics_queue);
-        return graphics_queue;
+        assert(m_graphics_queue);
+        return m_graphics_queue;
     }
 
     [[nodiscard]] const VkQueue get_present_queue() const {
-        assert(present_queue);
-        return present_queue;
+        assert(m_present_queue);
+        return m_present_queue;
     }
 
     /// @note Transfer queues are the fastest way to copy data across the PCIe bus.
     /// They are heavily underutilized even in modern games.
     /// Transfer queues can be used asynchronously to graphics queuey.
     [[nodiscard]] const VkQueue get_transfer_queue() const {
-        assert(transfer_queue);
-        return transfer_queue;
+        assert(m_transfer_queue);
+        return m_transfer_queue;
     }
 
     [[nodiscard]] std::uint32_t get_graphics_queue_family_index() const {
-        return graphics_queue_family_index;
+        return m_graphics_queue_family_index;
     }
 
     [[nodiscard]] std::uint32_t get_present_queue_family_index() const {
-        return present_queue_family_index;
+        return m_present_queue_family_index;
     }
 
     [[nodiscard]] std::uint32_t get_transfer_queue_family_index() const {
-        return transfer_queue_family_index;
+        return m_transfer_queue_family_index;
     }
 
 #ifndef NDEBUG

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -37,23 +37,19 @@ private:
     PFN_vkSetDebugUtilsObjectNameEXT m_vk_set_debug_utils_object_name;
 
 public:
-    /// Delete the copy constructor so shaders are move-only objects.
-    Device(const Device &) = delete;
-    Device(Device &&other) noexcept;
-
-    /// Delete the copy assignment operator so shaders are move-only objects.
-    Device &operator=(const Device &) = delete;
-    Device &operator=(Device &&) noexcept = default;
-
     /// @brief Creates a graphics card interface.
     /// @param preferred_gpu_index [in] The index of the preferred physical device to use.
     Device(const VkInstance instance, const VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
            bool prefer_distinct_transfer_queue,
            const std::optional<std::uint32_t> preferred_physical_device_index = std::nullopt);
+    Device(const Device &) = delete;
+    Device(Device &&) noexcept;
+    ~Device();
 
     // TODO: Add overloaded constructors for VkPhysicalDeviceFeatures and requested device extensions in the future!
 
-    ~Device();
+    Device &operator=(const Device &) = delete;
+    Device &operator=(Device &&) = default;
 
     [[nodiscard]] const VkDevice device() const {
         assert(m_device);

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -10,9 +10,9 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Fence {
 private:
-    VkFence fence;
-    VkDevice device;
-    std::string name;
+    VkFence m_fence;
+    VkDevice m_device;
+    std::string m_name;
 
 public:
     Fence(const Fence &) = default;
@@ -30,8 +30,8 @@ public:
     ~Fence();
 
     [[nodiscard]] VkFence get() const {
-        assert(fence);
-        return fence;
+        assert(m_fence);
+        return m_fence;
     }
 
     ///

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -15,19 +15,17 @@ private:
     std::string m_name;
 
 public:
-    Fence(const Fence &) = default;
-    Fence(Fence &&other) noexcept;
-
-    Fence &operator=(const Fence &other) = default;
-    Fence &operator=(Fence &&other) noexcept = default;
-
     /// @brief Creates a new fence.
     /// @param device [in] The Vulkan device.
     /// @param name [in] The internal name of the fence.
     /// @param in_signaled_state [in] If true, the fence will be created in signaled state.
     Fence(const VkDevice device, const std::string &name, const bool in_signaled_state);
-
+    Fence(const Fence &) = delete;
+    Fence(Fence &&) noexcept;
     ~Fence();
+
+    Fence &operator=(const Fence &) = delete;
+    Fence &operator=(Fence &&) = default;
 
     [[nodiscard]] VkFence get() const {
         assert(m_fence);

--- a/include/inexor/vulkan-renderer/wrapper/glfw_context.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/glfw_context.hpp
@@ -4,17 +4,13 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class GLFWContext {
 public:
-    /// Delete the copy constructor so glfw contexts are move-only objects.
-    GLFWContext(const GLFWContext &) = delete;
-    GLFWContext(GLFWContext &&other) noexcept = default;
-
-    /// Delete the copy assignment operator so glfw contexts are move-only objects.
-    GLFWContext &operator=(const GLFWContext &) = delete;
-    GLFWContext &operator=(GLFWContext &&) noexcept = default;
-
     GLFWContext();
-
+    GLFWContext(const GLFWContext &) = delete;
+    GLFWContext(GLFWContext &&) noexcept = default;
     ~GLFWContext();
+
+    GLFWContext &operator=(const GLFWContext &) = delete;
+    GLFWContext &operator=(GLFWContext &&) = default;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -13,9 +13,9 @@ protected:
 
     VkDevice m_device;
     VmaAllocator m_vma_allocator;
-    VkBuffer m_buffer = VK_NULL_HANDLE;
-    VkDeviceSize m_buffer_size = 0;
-    VmaAllocation m_allocation = VK_NULL_HANDLE;
+    VkBuffer m_buffer{VK_NULL_HANDLE};
+    VkDeviceSize m_buffer_size{0};
+    VmaAllocation m_allocation{VK_NULL_HANDLE};
     VmaAllocationInfo m_allocation_info{};
     VmaAllocationCreateInfo m_allocation_ci{};
 

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -54,23 +54,23 @@ public:
 
     virtual ~GPUMemoryBuffer();
 
-    [[nodiscard]] const std::string &get_name() const {
+    [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 
-    [[nodiscard]] const VkBuffer get_buffer() const {
+    [[nodiscard]] const VkBuffer buffer() const {
         return m_buffer;
     }
 
-    [[nodiscard]] const VmaAllocation get_allocation() const {
+    [[nodiscard]] const VmaAllocation allocation() const {
         return m_allocation;
     }
 
-    [[nodiscard]] const VmaAllocationInfo get_allocation_info() const {
+    [[nodiscard]] const VmaAllocationInfo allocation_info() const {
         return m_allocation_info;
     }
 
-    [[nodiscard]] const VmaAllocationCreateInfo get_allocation_create_info() const {
+    [[nodiscard]] const VmaAllocationCreateInfo allocation_create_info() const {
         return m_allocation_ci;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -9,15 +9,15 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class GPUMemoryBuffer {
 protected:
-    std::string name;
+    std::string m_name;
 
-    VkDevice device;
-    VmaAllocator vma_allocator;
-    VkBuffer buffer = VK_NULL_HANDLE;
-    VkDeviceSize buffer_size = 0;
-    VmaAllocation allocation = VK_NULL_HANDLE;
-    VmaAllocationInfo allocation_info{};
-    VmaAllocationCreateInfo allocation_ci{};
+    VkDevice m_device;
+    VmaAllocator m_vma_allocator;
+    VkBuffer m_buffer = VK_NULL_HANDLE;
+    VkDeviceSize m_buffer_size = 0;
+    VmaAllocation m_allocation = VK_NULL_HANDLE;
+    VmaAllocationInfo m_allocation_info{};
+    VmaAllocationCreateInfo m_allocation_ci{};
 
 public:
     /// Delete the copy constructor so gpu memory buffers are move-only objects.
@@ -55,23 +55,23 @@ public:
     virtual ~GPUMemoryBuffer();
 
     [[nodiscard]] const std::string &get_name() const {
-        return name;
+        return m_name;
     }
 
     [[nodiscard]] const VkBuffer get_buffer() const {
-        return buffer;
+        return m_buffer;
     }
 
     [[nodiscard]] const VmaAllocation get_allocation() const {
-        return allocation;
+        return m_allocation;
     }
 
     [[nodiscard]] const VmaAllocationInfo get_allocation_info() const {
-        return allocation_info;
+        return m_allocation_info;
     }
 
     [[nodiscard]] const VmaAllocationCreateInfo get_allocation_create_info() const {
-        return allocation_ci;
+        return m_allocation_ci;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -20,14 +20,6 @@ protected:
     VmaAllocationCreateInfo m_allocation_ci{};
 
 public:
-    /// Delete the copy constructor so gpu memory buffers are move-only objects.
-    GPUMemoryBuffer(const GPUMemoryBuffer &) = delete;
-    GPUMemoryBuffer(GPUMemoryBuffer &&buffer) noexcept;
-
-    /// Delete the copy assignment operator so gpu memory buffers are move-only objects.
-    GPUMemoryBuffer &operator=(const GPUMemoryBuffer &) = delete;
-    GPUMemoryBuffer &operator=(GPUMemoryBuffer &&) noexcept = default;
-
     /// @brief Creates a new GPU memory buffer.
     /// @param device [in] The Vulkan device from which the buffer will be created.
     /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
@@ -51,8 +43,12 @@ public:
     GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                     const VkDeviceSize &buffer_size, void *data, const std::size_t data_size,
                     const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage);
-
+    GPUMemoryBuffer(const GPUMemoryBuffer &) = delete;
+    GPUMemoryBuffer(GPUMemoryBuffer &&) noexcept;
     virtual ~GPUMemoryBuffer();
+
+    GPUMemoryBuffer &operator=(const GPUMemoryBuffer &) = delete;
+    GPUMemoryBuffer &operator=(GPUMemoryBuffer &&) = default;
 
     [[nodiscard]] const std::string &name() const {
         return m_name;

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -44,11 +44,11 @@ public:
 
     ~Image();
 
-    [[nodiscard]] VkFormat get_image_format() const {
+    [[nodiscard]] VkFormat image_format() const {
         return m_format;
     }
 
-    [[nodiscard]] VkImageView get_image_view() const {
+    [[nodiscard]] VkImageView image_view() const {
         assert(m_image_view);
         return m_image_view;
     }

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -10,14 +10,14 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Image {
 private:
-    VkDevice device;
-    VmaAllocator vma_allocator;
-    VmaAllocation allocation;
-    VmaAllocationInfo allocation_info;
-    VkImage image;
-    VkFormat format;
-    VkImageView image_view;
-    std::string name;
+    VkDevice m_device;
+    VmaAllocator m_vma_allocator;
+    VmaAllocation m_allocation;
+    VmaAllocationInfo m_allocation_info;
+    VkImage m_image;
+    VkFormat m_format;
+    VkImageView m_image_view;
+    std::string m_name;
 
 public:
     /// Delete the copy constructor so depth stencil buffers are move-only objects.
@@ -45,17 +45,17 @@ public:
     ~Image();
 
     [[nodiscard]] VkFormat get_image_format() const {
-        return format;
+        return m_format;
     }
 
     [[nodiscard]] VkImageView get_image_view() const {
-        assert(image_view);
-        return image_view;
+        assert(m_image_view);
+        return m_image_view;
     }
 
     [[nodiscard]] VkImage get() const {
-        assert(image);
-        return image;
+        assert(m_image);
+        return m_image;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -20,14 +20,6 @@ private:
     std::string m_name;
 
 public:
-    /// Delete the copy constructor so depth stencil buffers are move-only objects.
-    Image(const Image &) = delete;
-    Image(Image &&other) noexcept;
-
-    /// Delete the copy assignment operator so depth stencil buffers are move-only objets.
-    Image &operator=(const Image &) = delete;
-    Image &operator=(Image &&) noexcept = default;
-
     /// @brief Creates an image and a corresponding image view.
     /// @param device [in] The Vulkan device.
     /// @param graphics_card [in] The graphics card.
@@ -41,8 +33,12 @@ public:
     Image(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
           const VkFormat format, const VkImageUsageFlags image_usage, const VkImageAspectFlags aspect_flags,
           const VkSampleCountFlagBits sample_count, const std::string &name, const VkExtent2D image_extent);
-
+    Image(const Image &) = delete;
+    Image(Image &&) noexcept;
     ~Image();
+
+    Image &operator=(const Image &) = delete;
+    Image &operator=(Image &&) = default;
 
     [[nodiscard]] VkFormat image_format() const {
         return m_format;

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -59,7 +59,7 @@ public:
 
     ~Instance();
 
-    [[nodiscard]] const VkInstance get_instance() const {
+    [[nodiscard]] const VkInstance instance() const {
         return m_instance;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -13,7 +13,7 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @note The instantiation of this class must be synchronized externally.
 class Instance {
 protected:
-    VkInstance m_instance = VK_NULL_HANDLE;
+    VkInstance m_instance{VK_NULL_HANDLE};
     AvailabilityChecksManager m_availability_checks;
 
 public:

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -13,8 +13,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @note The instantiation of this class must be synchronized externally.
 class Instance {
 protected:
-    VkInstance instance = VK_NULL_HANDLE;
-    AvailabilityChecksManager availability_checks;
+    VkInstance m_instance = VK_NULL_HANDLE;
+    AvailabilityChecksManager m_availability_checks;
 
 public:
     /// Delete the copy constructor so Vulkan instances are move-only objects.
@@ -60,7 +60,7 @@ public:
     ~Instance();
 
     [[nodiscard]] const VkInstance get_instance() const {
-        return instance;
+        return m_instance;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -17,14 +17,6 @@ protected:
     AvailabilityChecksManager m_availability_checks;
 
 public:
-    /// Delete the copy constructor so Vulkan instances are move-only objects.
-    Instance(const Instance &) = delete;
-    Instance(Instance &&other) noexcept;
-
-    /// Delete the copy assignment operator so Vulkan instances are move-only objects.
-    Instance &operator=(const Instance &) = delete;
-    Instance &operator=(Instance &&) noexcept = default;
-
     /// @brief Creates a VkInstance.
     /// @param application_name [in] The name of the application.
     /// @param engine_name [in] The name of the engine.
@@ -56,8 +48,12 @@ public:
     Instance(const std::string &application_name, const std::string &engine_name,
              const std::uint32_t application_version, const std::uint32_t engine_version,
              const std::uint32_t vulkan_api_version);
-
+    Instance(const Instance &) = delete;
+    Instance(Instance &&) noexcept;
     ~Instance();
+
+    Instance &operator=(const Instance &) = delete;
+    Instance &operator=(Instance &&) = default;
 
     [[nodiscard]] const VkInstance instance() const {
         return m_instance;

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -25,19 +25,19 @@ namespace inexor::vulkan_renderer::wrapper {
 class MeshBuffer {
 
 private:
-    std::string name = "";
+    std::string m_name = "";
 
-    GPUMemoryBuffer vertex_buffer;
+    GPUMemoryBuffer m_vertex_buffer;
 
     // Index buffer, if available.
-    std::optional<GPUMemoryBuffer> index_buffer;
+    std::optional<GPUMemoryBuffer> m_index_buffer;
 
-    std::uint32_t number_of_vertices = 0;
+    std::uint32_t m_number_of_vertices = 0;
 
-    std::uint32_t number_of_indices = 0;
+    std::uint32_t m_number_of_indices = 0;
 
     // Don't forget that index buffers are optional!
-    bool index_buffer_available = false;
+    bool m_index_buffer_available = false;
 
 public:
     // Delete the copy constructor so mesh buffers are move-only objects.
@@ -62,24 +62,24 @@ public:
     ~MeshBuffer();
 
     [[nodiscard]] VkBuffer get_vertex_buffer() const {
-        return vertex_buffer.get_buffer();
+        return m_vertex_buffer.get_buffer();
     }
 
     [[nodiscard]] bool has_index_buffer() const {
-        return index_buffer.has_value();
+        return m_index_buffer.has_value();
     }
 
     [[nodiscard]] std::optional<VkBuffer> get_index_buffer() const {
-        assert(index_buffer);
-        return index_buffer->get_buffer();
+        assert(m_index_buffer);
+        return m_index_buffer->get_buffer();
     }
 
     [[nodiscard]] const std::uint32_t get_vertex_count() const {
-        return number_of_vertices;
+        return m_number_of_vertices;
     }
 
     [[nodiscard]] const std::uint32_t get_index_cound() const {
-        return number_of_indices;
+        return m_number_of_indices;
     }
 
     // TODO: Update data!

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -40,14 +40,6 @@ private:
     bool m_index_buffer_available = false;
 
 public:
-    // Delete the copy constructor so mesh buffers are move-only objects.
-    MeshBuffer(const MeshBuffer &) = delete;
-    MeshBuffer(MeshBuffer &&buffer) noexcept;
-
-    // Delete the copy assignment operator so uniform buffers are move-only objects.
-    MeshBuffer &operator=(const MeshBuffer &) = delete;
-    MeshBuffer &operator=(MeshBuffer &&) noexcept = default;
-
     /// @brief Creates a new vertex buffer and an associated index buffer.
     MeshBuffer(const VkDevice device, VkQueue data_transfer_queue, const std::uint32_t data_transfer_queue_family_index,
                const VmaAllocator vma_allocator, const std::string &name, const VkDeviceSize size_of_vertex_structure,
@@ -58,8 +50,12 @@ public:
     MeshBuffer(const VkDevice device, VkQueue data_transfer_queue, const std::uint32_t data_transfer_queue_family_index,
                const VmaAllocator vma_allocator, const std::string &name, const VkDeviceSize size_of_vertex_structure,
                const std::size_t number_of_vertices, void *vertices);
-
+    MeshBuffer(const MeshBuffer &) = delete;
+    MeshBuffer(MeshBuffer &&) noexcept;
     ~MeshBuffer();
+
+    MeshBuffer &operator=(const MeshBuffer &) = delete;
+    MeshBuffer &operator=(MeshBuffer &&) = default;
 
     [[nodiscard]] VkBuffer vertex_buffer() const {
         return m_vertex_buffer.buffer();

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -61,24 +61,24 @@ public:
 
     ~MeshBuffer();
 
-    [[nodiscard]] VkBuffer get_vertex_buffer() const {
-        return m_vertex_buffer.get_buffer();
+    [[nodiscard]] VkBuffer vertex_buffer() const {
+        return m_vertex_buffer.buffer();
     }
 
     [[nodiscard]] bool has_index_buffer() const {
         return m_index_buffer.has_value();
     }
 
-    [[nodiscard]] std::optional<VkBuffer> get_index_buffer() const {
+    [[nodiscard]] std::optional<VkBuffer> index_buffer() const {
         assert(m_index_buffer);
-        return m_index_buffer->get_buffer();
+        return m_index_buffer->buffer();
     }
 
-    [[nodiscard]] const std::uint32_t get_vertex_count() const {
+    [[nodiscard]] const std::uint32_t vertex_count() const {
         return m_number_of_vertices;
     }
 
-    [[nodiscard]] const std::uint32_t get_index_cound() const {
+    [[nodiscard]] const std::uint32_t index_cound() const {
         return m_number_of_indices;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -32,9 +32,9 @@ private:
     // Index buffer, if available.
     std::optional<GPUMemoryBuffer> m_index_buffer;
 
-    std::uint32_t m_number_of_vertices = 0;
+    std::uint32_t m_number_of_vertices{0};
 
-    std::uint32_t m_number_of_indices = 0;
+    std::uint32_t m_number_of_indices{0};
 
     // Don't forget that index buffers are optional!
     bool m_index_buffer_available = false;

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -45,7 +45,7 @@ public:
 
     void end_recording_and_submit_command();
 
-    [[nodiscard]] VkCommandBuffer get_command_buffer() const {
+    [[nodiscard]] VkCommandBuffer command_buffer() const {
         return m_command_buffer->get();
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -14,13 +14,13 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief A OnceCommandBuffer is a command buffer which is being used only once.
 class OnceCommandBuffer {
 private:
-    wrapper::CommandPool command_pool;
-    std::unique_ptr<wrapper::CommandBuffer> command_buffer;
-    VkQueue data_transfer_queue;
-    VkDevice device;
+    wrapper::CommandPool m_command_pool;
+    std::unique_ptr<wrapper::CommandBuffer> m_command_buffer;
+    VkQueue m_data_transfer_queue;
+    VkDevice m_device;
 
-    bool command_buffer_created;
-    bool recording_started;
+    bool m_command_buffer_created;
+    bool m_recording_started;
 
 public:
     // Delete the copy constructor so once command buffers are move-only objects.
@@ -46,7 +46,7 @@ public:
     void end_recording_and_submit_command();
 
     [[nodiscard]] VkCommandBuffer get_command_buffer() const {
-        return command_buffer->get();
+        return m_command_buffer->get();
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -23,21 +23,17 @@ private:
     bool m_recording_started;
 
 public:
-    // Delete the copy constructor so once command buffers are move-only objects.
-    OnceCommandBuffer(const OnceCommandBuffer &) = delete;
-    OnceCommandBuffer(OnceCommandBuffer &&other) noexcept;
-
-    // Delete the copy assignment operator so shaders are move-only objects.
-    OnceCommandBuffer &operator=(const OnceCommandBuffer &) = delete;
-    OnceCommandBuffer &operator=(OnceCommandBuffer &&) noexcept = default;
-
     /// @brief Creates a new commandbuffer which is being called only once.
     /// @param device [in] The Vulkan device.
     /// @param data_transfer_queue [in] The data transfer queue.
     OnceCommandBuffer(const VkDevice device, const VkQueue data_transfer_queue,
                       const std::uint32_t data_transfer_queue_family_index);
-
+    OnceCommandBuffer(const OnceCommandBuffer &) = delete;
+    OnceCommandBuffer(OnceCommandBuffer &&) noexcept;
     ~OnceCommandBuffer();
+
+    OnceCommandBuffer &operator=(const OnceCommandBuffer &) = delete;
+    OnceCommandBuffer &operator=(OnceCommandBuffer &&) = default;
 
     void create_command_buffer();
 

--- a/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
@@ -9,9 +9,9 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class PipelineLayout {
 private:
-    VkDevice device;
-    VkPipelineLayout pipeline_layout;
-    std::string name;
+    VkDevice m_device;
+    VkPipelineLayout m_pipeline_layout;
+    std::string m_name;
 
 public:
     /// Delete the copy constructor so pipeline layouts are move-only objects.
@@ -32,7 +32,7 @@ public:
     ~PipelineLayout();
 
     [[nodiscard]] VkPipelineLayout get() const {
-        return pipeline_layout;
+        return m_pipeline_layout;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/pipeline_layout.hpp
@@ -14,22 +14,18 @@ private:
     std::string m_name;
 
 public:
-    /// Delete the copy constructor so pipeline layouts are move-only objects.
-    PipelineLayout(const PipelineLayout &) = delete;
-    PipelineLayout(PipelineLayout &&other) noexcept;
-
-    /// Delete the move-assignment operator so pipeline-layouts are move-only objects.
-    PipelineLayout &operator=(const PipelineLayout &) = delete;
-    PipelineLayout &operator=(PipelineLayout &&other) noexcept = default;
-
     /// @brief Creates a pipeline layout
     /// @param device [in] The Vulkan device.
     /// @param descriptor_set_layouts [in] The descriptor set layouts for the pipeline layout.
     /// @param name [in] The internal name of the pipeline layout.
     PipelineLayout(const VkDevice device, const std::vector<VkDescriptorSetLayout> &descriptor_set_layouts,
                    const std::string &name);
-
+    PipelineLayout(const PipelineLayout &) = delete;
+    PipelineLayout(PipelineLayout &&) noexcept;
     ~PipelineLayout();
+
+    PipelineLayout &operator=(const PipelineLayout &) = delete;
+    PipelineLayout &operator=(PipelineLayout &&) = default;
 
     [[nodiscard]] VkPipelineLayout get() const {
         return m_pipeline_layout;

--- a/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
@@ -8,9 +8,9 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Semaphore {
 private:
-    VkSemaphore semaphore;
-    VkDevice device;
-    std::string name;
+    VkSemaphore m_semaphore;
+    VkDevice m_device;
+    std::string m_name;
 
 public:
     /// Delete the copy constructor so Vulkan semaphores are move-only objects.
@@ -26,11 +26,11 @@ public:
     ~Semaphore();
 
     [[nodiscard]] VkSemaphore get() const {
-        return semaphore;
+        return m_semaphore;
     }
 
     [[nodiscard]] const VkSemaphore *get_ptr() const {
-        return &semaphore;
+        return &m_semaphore;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
@@ -29,7 +29,7 @@ public:
         return m_semaphore;
     }
 
-    [[nodiscard]] const VkSemaphore *get_ptr() const {
+    [[nodiscard]] const VkSemaphore *ptr() const {
         return &m_semaphore;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
@@ -13,17 +13,13 @@ private:
     std::string m_name;
 
 public:
-    /// Delete the copy constructor so Vulkan semaphores are move-only objects.
-    Semaphore(const Semaphore &) = delete;
-    Semaphore(Semaphore &&other) noexcept;
-
-    /// Delete the move assignment operator so Vulkan semaphores are move-only objects.
-    Semaphore &operator=(const Semaphore &) = delete;
-    Semaphore &operator=(Semaphore &&) noexcept = default;
-
     Semaphore(const VkDevice device, const std::string &name);
-
+    Semaphore(const Semaphore &) = delete;
+    Semaphore(Semaphore &&) noexcept;
     ~Semaphore();
+
+    Semaphore &operator=(const Semaphore &) = delete;
+    Semaphore &operator=(Semaphore &&) = default;
 
     [[nodiscard]] VkSemaphore get() const {
         return m_semaphore;

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -17,14 +17,6 @@ private:
     VkShaderModule m_shader_module;
 
 public:
-    /// Delete the copy constructor so shaders are move-only objects.
-    Shader(const Shader &) = delete;
-    Shader(Shader &&shader) noexcept;
-
-    /// Delete the copy assignment operator so shaders are move-only objects.
-    Shader &operator=(const Shader &) = delete;
-    Shader &operator=(Shader &&) noexcept = default;
-
     /// @brief Creates a shader from memory.
     /// @param device [in] The Vulkan device which will be used to create the shader module.
     /// @param type [in] The shader type (vertex shader, fragment shader, tesselation shader..).
@@ -42,8 +34,12 @@ public:
     /// @param entry_point [in] The entry point of the shader code, in most cases just "main".
     Shader(VkDevice device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name,
            const std::string &entry_point = "main");
-
+    Shader(const Shader &) = delete;
+    Shader(Shader &&) noexcept;
     ~Shader();
+
+    Shader &operator=(const Shader &) = delete;
+    Shader &operator=(Shader &&) = default;
 
     [[nodiscard]] const std::string &name() const {
         return m_name;

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -9,12 +9,12 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Shader {
 private:
-    VkDevice device;
-    VkShaderStageFlagBits type;
-    std::string name;
-    std::string entry_point;
+    VkDevice m_device;
+    VkShaderStageFlagBits m_type;
+    std::string m_name;
+    std::string m_entry_point;
 
-    VkShaderModule shader_module;
+    VkShaderModule m_shader_module;
 
 public:
     /// Delete the copy constructor so shaders are move-only objects.
@@ -46,19 +46,19 @@ public:
     ~Shader();
 
     [[nodiscard]] const std::string &get_name() const {
-        return name;
+        return m_name;
     }
 
     [[nodiscard]] const std::string &get_entry_point() const {
-        return entry_point;
+        return m_entry_point;
     }
 
     [[nodiscard]] VkShaderStageFlagBits get_type() const {
-        return type;
+        return m_type;
     }
 
     [[nodiscard]] VkShaderModule get_module() const {
-        return shader_module;
+        return m_shader_module;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -45,19 +45,19 @@ public:
 
     ~Shader();
 
-    [[nodiscard]] const std::string &get_name() const {
+    [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 
-    [[nodiscard]] const std::string &get_entry_point() const {
+    [[nodiscard]] const std::string &entry_point() const {
         return m_entry_point;
     }
 
-    [[nodiscard]] VkShaderStageFlagBits get_type() const {
+    [[nodiscard]] VkShaderStageFlagBits type() const {
         return m_type;
     }
 
-    [[nodiscard]] VkShaderModule get_module() const {
+    [[nodiscard]] VkShaderModule module() const {
         return m_shader_module;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -37,7 +37,7 @@ public:
                   const VkDeviceSize buffer_size, void *data, const std::size_t data_size);
 
     ///
-    void upload_data_to_gpu(const GPUMemoryBuffer &target_buffer);
+    void upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer);
 
     ~StagingBuffer() = default;
 };

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -16,14 +16,6 @@ private:
     OnceCommandBuffer m_command_buffer_for_copying;
 
 public:
-    // Delete the copy constructor so staging buffers are move-only objects.
-    StagingBuffer(const StagingBuffer &) = delete;
-    StagingBuffer(StagingBuffer &&other) noexcept;
-
-    // Delete the copy assignment operator so staging buffers are move-only objects.
-    StagingBuffer &operator=(const StagingBuffer &) = delete;
-    StagingBuffer &operator=(StagingBuffer &&) noexcept = default;
-
     /// @brief Creates a new staging buffer.
     /// @param device [in] The Vulkan device from which the buffer will be created.
     /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
@@ -35,11 +27,15 @@ public:
     StagingBuffer(const VkDevice device, const VmaAllocator vma_allocator, const VkQueue data_transfer_queue,
                   const std::uint32_t data_transfer_queueu_family_index, const std::string &name,
                   const VkDeviceSize buffer_size, void *data, const std::size_t data_size);
+    StagingBuffer(const StagingBuffer &) = delete;
+    StagingBuffer(StagingBuffer &&) noexcept;
+    ~StagingBuffer() = default;
+
+    StagingBuffer &operator=(const StagingBuffer &) = delete;
+    StagingBuffer &operator=(StagingBuffer &&) = default;
 
     ///
     void upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer);
-
-    ~StagingBuffer() = default;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -12,8 +12,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// a queue command can be executed to use a transfer queue to upload the data to the GPU memory.
 class StagingBuffer : public GPUMemoryBuffer {
 private:
-    VkQueue data_transfer_queue;
-    OnceCommandBuffer command_buffer_for_copying;
+    VkQueue m_data_transfer_queue;
+    OnceCommandBuffer m_command_buffer_for_copying;
 
 public:
     // Delete the copy constructor so staging buffers are move-only objects.

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -34,21 +34,17 @@ private:
     void setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width, std::uint32_t window_height);
 
 public:
-    /// Delete the copy constructor so swapchains are move-only objects.
-    Swapchain(const Swapchain &) = delete;
-    Swapchain(Swapchain &&other) noexcept;
-
-    /// Delete the copy assignment operator so swapchains are move-only objects.
-    Swapchain &operator=(const Swapchain &) = delete;
-    Swapchain &operator=(Swapchain &&) noexcept = delete;
-
     /// @brief
     /// @note We must pass width and height as call by reference!
     Swapchain(const VkDevice device, const VkPhysicalDevice graphics_card, const VkSurfaceKHR surface,
               std::uint32_t window_width, std::uint32_t window_height, const bool enable_vsync,
               const std::string &name);
-
+    Swapchain(const Swapchain &) = delete;
+    Swapchain(Swapchain &&) noexcept;
     ~Swapchain();
+
+    Swapchain &operator=(const Swapchain &) = delete;
+    Swapchain &operator=(Swapchain &&) = default;
 
     /// @brief Acquires the next writable image in the swapchain
     /// @param semaphore A semaphore to signal once image acquisition has completed

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -60,27 +60,27 @@ public:
     /// This happens for example when the window gets resized.
     void recreate(std::uint32_t window_width, std::uint32_t window_height);
 
-    [[nodiscard]] const VkSwapchainKHR *get_swapchain_ptr() const {
+    [[nodiscard]] const VkSwapchainKHR *swapchain_ptr() const {
         return &m_swapchain;
     }
 
-    [[nodiscard]] VkSwapchainKHR get_swapchain() const {
+    [[nodiscard]] VkSwapchainKHR swapchain() const {
         return m_swapchain;
     }
 
-    [[nodiscard]] std::uint32_t get_image_count() const {
+    [[nodiscard]] std::uint32_t image_count() const {
         return m_swapchain_image_count;
     }
 
-    [[nodiscard]] VkFormat get_image_format() const {
+    [[nodiscard]] VkFormat image_format() const {
         return m_surface_format.format;
     }
 
-    [[nodiscard]] VkExtent2D get_extent() const {
+    [[nodiscard]] VkExtent2D extent() const {
         return m_extent;
     }
 
-    [[nodiscard]] VkImageView get_image_view(std::size_t index) const {
+    [[nodiscard]] VkImageView image_view(std::size_t index) const {
         if (index >= m_swapchain_image_views.size()) {
             throw std::out_of_range("Error: swapchain_image_views has " +
                                     std::to_string(m_swapchain_image_views.size()) + " entries. Requested index " +
@@ -90,7 +90,7 @@ public:
         return m_swapchain_image_views.at(index);
     }
 
-    [[nodiscard]] std::vector<VkImageView> get_image_views() const {
+    [[nodiscard]] std::vector<VkImageView> image_views() const {
         return m_swapchain_image_views;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -13,18 +13,18 @@ class Semaphore;
 class Swapchain {
 private:
     // TODO: Move members which don't need to be members!
-    VkDevice device;
-    VkPhysicalDevice graphics_card;
-    VkSurfaceKHR surface;
-    VkSwapchainKHR swapchain;
-    VkSurfaceFormatKHR surface_format;
-    VkExtent2D extent;
+    VkDevice m_device;
+    VkPhysicalDevice m_graphics_card;
+    VkSurfaceKHR m_surface;
+    VkSwapchainKHR m_swapchain;
+    VkSurfaceFormatKHR m_surface_format;
+    VkExtent2D m_extent;
 
-    std::vector<VkImage> swapchain_images;
-    std::vector<VkImageView> swapchain_image_views;
-    std::uint32_t swapchain_image_count;
-    std::string name;
-    bool vsync_enabled;
+    std::vector<VkImage> m_swapchain_images;
+    std::vector<VkImageView> m_swapchain_image_views;
+    std::uint32_t m_swapchain_image_count;
+    std::string m_name;
+    bool m_vsync_enabled;
 
     /// @brief (Re)creates the swapchain.
     /// @param window_width [in] The requested width of the window.
@@ -61,36 +61,37 @@ public:
     void recreate(std::uint32_t window_width, std::uint32_t window_height);
 
     [[nodiscard]] const VkSwapchainKHR *get_swapchain_ptr() const {
-        return &swapchain;
+        return &m_swapchain;
     }
 
     [[nodiscard]] VkSwapchainKHR get_swapchain() const {
-        return swapchain;
+        return m_swapchain;
     }
 
     [[nodiscard]] std::uint32_t get_image_count() const {
-        return swapchain_image_count;
+        return m_swapchain_image_count;
     }
 
     [[nodiscard]] VkFormat get_image_format() const {
-        return surface_format.format;
+        return m_surface_format.format;
     }
 
     [[nodiscard]] VkExtent2D get_extent() const {
-        return extent;
+        return m_extent;
     }
 
     [[nodiscard]] VkImageView get_image_view(std::size_t index) const {
-        if (index >= swapchain_image_views.size()) {
-            throw std::out_of_range("Error: swapchain_image_views has " + std::to_string(swapchain_image_views.size()) +
-                                    " entries. Requested index " + std::to_string(index) + " is out of bounds!");
+        if (index >= m_swapchain_image_views.size()) {
+            throw std::out_of_range("Error: swapchain_image_views has " +
+                                    std::to_string(m_swapchain_image_views.size()) + " entries. Requested index " +
+                                    std::to_string(index) + " is out of bounds!");
         }
 
-        return swapchain_image_views.at(index);
+        return m_swapchain_image_views.at(index);
     }
 
     [[nodiscard]] std::vector<VkImageView> get_image_views() const {
-        return swapchain_image_views;
+        return m_swapchain_image_views;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/texture.hpp
@@ -47,14 +47,6 @@ private:
     void create_texture_sampler();
 
 public:
-    /// Delete the copy constructor so textures are move-only objects.
-    Texture(const Texture &) = delete;
-    Texture(Texture &&other) noexcept;
-
-    /// Delete the copy assignment operator so shaders are move-only objects.
-    Texture &operator=(const Texture &) = delete;
-    Texture &operator=(Texture &&) noexcept = default;
-
     /// @brief Creates a texture from a file.
     /// @param device [in] The Vulkan device from which the texture will be created.
     /// @param graphics_card [in] The graphics card.
@@ -79,8 +71,12 @@ public:
     Texture(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
             void *texture_data, const std::size_t texture_size, const std::string &name,
             const VkQueue data_transfer_queue, const std::uint32_t data_transfer_queue_family_index);
-
+    Texture(const Texture &) = delete;
+    Texture(Texture &&) noexcept;
     ~Texture();
+
+    Texture &operator=(const Texture &) = delete;
+    Texture &operator=(Texture &&) = default;
 
     [[nodiscard]] const std::string &name() const {
         return m_name;

--- a/include/inexor/vulkan-renderer/wrapper/texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/texture.hpp
@@ -82,25 +82,25 @@ public:
 
     ~Texture();
 
-    [[nodiscard]] const std::string &get_name() const {
+    [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 
-    [[nodiscard]] const std::string &get_file_name() const {
+    [[nodiscard]] const std::string &file_name() const {
         return m_file_name;
     }
 
-    [[nodiscard]] const VkImage get_image() const {
+    [[nodiscard]] const VkImage image() const {
         assert(m_texture_image);
         return m_texture_image->get();
     }
 
-    [[nodiscard]] const VkImageView get_image_view() const {
+    [[nodiscard]] const VkImageView image_view() const {
         assert(m_texture_image);
-        return m_texture_image->get_image_view();
+        return m_texture_image->image_view();
     }
 
-    [[nodiscard]] const VkSampler get_sampler() const {
+    [[nodiscard]] const VkSampler sampler() const {
         assert(m_texture_image);
         return m_sampler;
     }

--- a/include/inexor/vulkan-renderer/wrapper/texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/texture.hpp
@@ -19,12 +19,12 @@ class Texture {
 private:
     std::unique_ptr<wrapper::Image> m_texture_image;
 
-    std::string m_name = "";
-    std::string m_file_name = "";
-    int m_texture_width = 0;
-    int m_texture_height = 0;
-    int m_texture_channels = 0;
-    int m_mip_levels = 0;
+    std::string m_name;
+    std::string m_file_name;
+    int m_texture_width{0};
+    int m_texture_height{0};
+    int m_texture_channels{0};
+    int m_mip_levels{0};
 
     VkDevice m_device;
     VkSampler m_sampler;
@@ -33,7 +33,7 @@ private:
     VkPhysicalDevice m_graphics_card;
 
     std::uint32_t m_data_transfer_queue_family_index;
-    const VkFormat m_texture_image_format = VK_FORMAT_R8G8B8A8_UNORM;
+    const VkFormat m_texture_image_format{VK_FORMAT_R8G8B8A8_UNORM};
 
     OnceCommandBuffer m_copy_command_buffer;
 

--- a/include/inexor/vulkan-renderer/wrapper/texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/texture.hpp
@@ -17,25 +17,25 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Texture {
 private:
-    std::unique_ptr<wrapper::Image> texture_image;
+    std::unique_ptr<wrapper::Image> m_texture_image;
 
-    std::string name = "";
-    std::string file_name = "";
-    int texture_width = 0;
-    int texture_height = 0;
-    int texture_channels = 0;
-    int mip_levels = 0;
+    std::string m_name = "";
+    std::string m_file_name = "";
+    int m_texture_width = 0;
+    int m_texture_height = 0;
+    int m_texture_channels = 0;
+    int m_mip_levels = 0;
 
-    VkDevice device;
-    VkSampler sampler;
-    VmaAllocator vma_allocator;
-    VkQueue data_transfer_queue;
-    VkPhysicalDevice graphics_card;
+    VkDevice m_device;
+    VkSampler m_sampler;
+    VmaAllocator m_vma_allocator;
+    VkQueue m_data_transfer_queue;
+    VkPhysicalDevice m_graphics_card;
 
-    std::uint32_t data_transfer_queue_family_index;
-    const VkFormat texture_image_format = VK_FORMAT_R8G8B8A8_UNORM;
+    std::uint32_t m_data_transfer_queue_family_index;
+    const VkFormat m_texture_image_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    OnceCommandBuffer copy_command_buffer;
+    OnceCommandBuffer m_copy_command_buffer;
 
     ///
     void create_texture(void *texture_data, const std::size_t texture_size);
@@ -83,26 +83,26 @@ public:
     ~Texture();
 
     [[nodiscard]] const std::string &get_name() const {
-        return name;
+        return m_name;
     }
 
     [[nodiscard]] const std::string &get_file_name() const {
-        return file_name;
+        return m_file_name;
     }
 
     [[nodiscard]] const VkImage get_image() const {
-        assert(texture_image);
-        return texture_image->get();
+        assert(m_texture_image);
+        return m_texture_image->get();
     }
 
     [[nodiscard]] const VkImageView get_image_view() const {
-        assert(texture_image);
-        return texture_image->get_image_view();
+        assert(m_texture_image);
+        return m_texture_image->get_image_view();
     }
 
     [[nodiscard]] const VkSampler get_sampler() const {
-        assert(texture_image);
-        return sampler;
+        assert(m_texture_image);
+        return m_sampler;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
@@ -10,8 +10,8 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class UniformBuffer : public GPUMemoryBuffer {
 protected:
-    VkDescriptorBufferInfo descriptor_buffer_info{};
-    VkDescriptorSet descriptor_set{};
+    VkDescriptorBufferInfo m_descriptor_buffer_info{};
+    VkDescriptorSet m_descriptor_set{};
 
 public:
     // Delete the copy constructor so uniform buffers are move-only objects.

--- a/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
@@ -14,14 +14,6 @@ protected:
     VkDescriptorSet m_descriptor_set{};
 
 public:
-    // Delete the copy constructor so uniform buffers are move-only objects.
-    UniformBuffer(const UniformBuffer &) = delete;
-    UniformBuffer(UniformBuffer &&buffer) noexcept;
-
-    // Delete the copy assignment operator so uniform buffers are move-only objects.
-    UniformBuffer &operator=(const UniformBuffer &) = delete;
-    UniformBuffer &operator=(UniformBuffer &&) noexcept = default;
-
     /// @brief Creates a new uniform buffer.
     /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
     /// @param name [in] The internal name of the buffer.
@@ -30,8 +22,12 @@ public:
     /// @param memory_usage [in] The Vulkan Memory Allocator library's memory usage flags.
     UniformBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                   const VkDeviceSize &size);
-
+    UniformBuffer(const UniformBuffer &) = delete;
+    UniformBuffer(UniformBuffer &&) noexcept;
     ~UniformBuffer() = default;
+
+    UniformBuffer &operator=(const UniformBuffer &) = delete;
+    UniformBuffer &operator=(UniformBuffer &&) = default;
 
     /// @brief Updates the data of a uniform buffer.
     void update(void *data, const std::size_t size);

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -14,14 +14,6 @@ private:
     std::uint32_t m_height;
 
 public:
-    /// Delete the copy constructor so windows are move-only objects.
-    Window(const Window &) = delete;
-    Window(Window &&other) noexcept;
-
-    /// Delete the copy assignment operator so windows are move-only objects.
-    Window &operator=(const Window &) = delete;
-    Window &operator=(Window &&) noexcept = default;
-
     /// @brief Creates a new window using glfw library.
     /// @param instance [in] The Vulkan instance.
     /// @param title [in] The title of the window.
@@ -31,8 +23,12 @@ public:
     /// @param resizable [in] True if the window should be resizable.
     Window(const std::string &title, const std::uint32_t width, const std::uint32_t height, const bool visible,
            const bool resizable);
-
+    Window(const Window &) = delete;
+    Window(Window &&) noexcept;
     ~Window();
+
+    Window &operator=(const Window &) = delete;
+    Window &operator=(Window &&) = default;
 
     /// @brief Waits until window size is greater than 0.
     void wait_for_focus();

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -56,7 +56,7 @@ public:
     void hide();
 
     /// @brief Queries the current position of the cursor.
-    void get_cursor_pos(double &pos_x, double &pos_y);
+    void cursor_pos(double &pos_x, double &pos_y);
 
     /// @brief Checks if a button is pressed.
     /// @param button [in] The glfw button index.
@@ -72,11 +72,11 @@ public:
         return m_window;
     }
 
-    [[nodiscard]] int get_width() const {
+    [[nodiscard]] int width() const {
         return m_width;
     }
 
-    [[nodiscard]] int get_height() const {
+    [[nodiscard]] int height() const {
         return m_height;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -9,9 +9,9 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class Window {
 private:
-    GLFWwindow *window;
-    std::uint32_t width;
-    std::uint32_t height;
+    GLFWwindow *m_window;
+    std::uint32_t m_width;
+    std::uint32_t m_height;
 
 public:
     /// Delete the copy constructor so windows are move-only objects.
@@ -69,15 +69,15 @@ public:
     bool should_close();
 
     [[nodiscard]] GLFWwindow *get() const {
-        return window;
+        return m_window;
     }
 
     [[nodiscard]] int get_width() const {
-        return width;
+        return m_width;
     }
 
     [[nodiscard]] int get_height() const {
-        return height;
+        return m_height;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
@@ -10,8 +10,8 @@ namespace inexor::vulkan_renderer::wrapper {
 
 class WindowSurface {
 private:
-    VkInstance instance;
-    VkSurfaceKHR surface;
+    VkInstance m_instance;
+    VkSurfaceKHR m_surface;
 
 public:
     /// Delete the copy constructor so window surfaces are move-only objects.
@@ -30,11 +30,11 @@ public:
     ~WindowSurface();
 
     [[nodiscard]] VkSurfaceKHR get() const {
-        return surface;
+        return m_surface;
     }
 
     const VkSurfaceKHR *operator&() const {
-        return &surface;
+        return &m_surface;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
@@ -14,20 +14,16 @@ private:
     VkSurfaceKHR m_surface;
 
 public:
-    /// Delete the copy constructor so window surfaces are move-only objects.
-    WindowSurface(const WindowSurface &) = delete;
-    WindowSurface(const WindowSurface &&) noexcept;
-
-    /// Delete the copy assignment operator so windows are move-only objects.
-    WindowSurface &operator=(const WindowSurface &) = delete;
-    WindowSurface &operator=(WindowSurface &&other) noexcept = default;
-
     /// @brief Creates a new window surface.
     /// @param instance [in] The Vulkan instance.
     /// @param window [in] The glfw3 window.
     WindowSurface(const VkInstance instance, GLFWwindow *window);
-
+    WindowSurface(const WindowSurface &) = delete;
+    WindowSurface(WindowSurface &&) noexcept;
     ~WindowSurface();
+
+    WindowSurface &operator=(const WindowSurface &) = delete;
+    WindowSurface &operator=(WindowSurface &&) = default;
 
     [[nodiscard]] VkSurfaceKHR get() const {
         return m_surface;

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -295,8 +295,8 @@ Application::Application(int argc, char **argv) {
 
             if (vkCreateDebugReportCallbackEXT) {
                 // Create the debug report callback.
-                VkResult result = vkCreateDebugReportCallbackEXT(m_vkinstance->instance(), &debug_report_ci,
-                                                                 nullptr, &m_debug_report_callback);
+                VkResult result = vkCreateDebugReportCallbackEXT(m_vkinstance->instance(), &debug_report_ci, nullptr,
+                                                                 &m_debug_report_callback);
                 if (VK_SUCCESS == result) {
                     spdlog::debug("Creating Vulkan debug callback.");
                     m_debug_report_callback_initialised = true;

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -25,7 +25,7 @@ static void frame_buffer_resize_callback(GLFWwindow *window, int width, int heig
 
     // This is actually the way it is handled by the official Vulkan samples.
     auto *app = reinterpret_cast<VulkanRenderer *>(glfwGetWindowUserPointer(window));
-    app->window_resized = true;
+    app->m_window_resized = true;
 }
 
 VkResult Application::load_toml_configuration_file(const std::string &file_name) {
@@ -46,15 +46,15 @@ VkResult Application::load_toml_configuration_file(const std::string &file_name)
     auto configuration_title = toml::find<std::string>(renderer_configuration, "title");
     spdlog::debug("Title: '{}'", configuration_title);
 
-    window_width = toml::find<int>(renderer_configuration, "application", "window", "width");
-    window_height = toml::find<int>(renderer_configuration, "application", "window", "height");
-    window_title = toml::find<std::string>(renderer_configuration, "application", "window", "name");
-    spdlog::debug("Window: '{}', {} x {}", window_title, window_width, window_height);
+    m_window_width = toml::find<int>(renderer_configuration, "application", "window", "width");
+    m_window_height = toml::find<int>(renderer_configuration, "application", "window", "height");
+    m_window_title = toml::find<std::string>(renderer_configuration, "application", "window", "name");
+    spdlog::debug("Window: '{}', {} x {}", m_window_title, m_window_width, m_window_height);
 
-    application_name = toml::find<std::string>(renderer_configuration, "application", "name");
-    engine_name = toml::find<std::string>(renderer_configuration, "application", "engine", "name");
-    spdlog::debug("Application name: '{}'", application_name);
-    spdlog::debug("Engine name: '{}'", engine_name);
+    m_application_name = toml::find<std::string>(renderer_configuration, "application", "name");
+    m_engine_name = toml::find<std::string>(renderer_configuration, "application", "engine", "name");
+    spdlog::debug("Application name: '{}'", m_application_name);
+    spdlog::debug("Engine name: '{}'", m_engine_name);
 
     int application_version_major = toml::find<int>(renderer_configuration, "application", "version", "major");
     int application_version_minor = toml::find<int>(renderer_configuration, "application", "version", "minor");
@@ -63,7 +63,7 @@ VkResult Application::load_toml_configuration_file(const std::string &file_name)
                   application_version_patch);
 
     // Generate an std::uint32_t value from the major, minor and patch version info.
-    application_version =
+    m_application_version =
         VK_MAKE_VERSION(application_version_major, application_version_minor, application_version_patch);
 
     int engine_version_major = toml::find<int>(renderer_configuration, "application", "engine", "version", "major");
@@ -72,38 +72,38 @@ VkResult Application::load_toml_configuration_file(const std::string &file_name)
     spdlog::debug("Engine version {}.{}.{}", engine_version_major, engine_version_minor, engine_version_patch);
 
     // Generate an std::uint32_t value from the major, minor and patch version info.
-    engine_version = VK_MAKE_VERSION(engine_version_major, engine_version_minor, engine_version_patch);
+    m_engine_version = VK_MAKE_VERSION(engine_version_major, engine_version_minor, engine_version_patch);
 
-    texture_files = toml::find<std::vector<std::string>>(renderer_configuration, "textures", "files");
+    m_texture_files = toml::find<std::vector<std::string>>(renderer_configuration, "textures", "files");
 
     spdlog::debug("Textures:");
 
-    for (const auto &texture_file : texture_files) {
+    for (const auto &texture_file : m_texture_files) {
         spdlog::debug("{}", texture_file);
     }
 
-    gltf_model_files = toml::find<std::vector<std::string>>(renderer_configuration, "glTFmodels", "files");
+    m_gltf_model_files = toml::find<std::vector<std::string>>(renderer_configuration, "glTFmodels", "files");
 
     spdlog::debug("glTF 2.0 models:");
 
-    for (const auto &gltf_model_file : gltf_model_files) {
+    for (const auto &gltf_model_file : m_gltf_model_files) {
         spdlog::debug("{}", gltf_model_file);
     }
 
-    vertex_shader_files = toml::find<std::vector<std::string>>(renderer_configuration, "shaders", "vertex", "files");
+    m_vertex_shader_files = toml::find<std::vector<std::string>>(renderer_configuration, "shaders", "vertex", "files");
 
     spdlog::debug("Vertex shaders:");
 
-    for (const auto &vertex_shader_file : vertex_shader_files) {
+    for (const auto &vertex_shader_file : m_vertex_shader_files) {
         spdlog::debug("{}", vertex_shader_file);
     }
 
-    fragment_shader_files =
+    m_fragment_shader_files =
         toml::find<std::vector<std::string>>(renderer_configuration, "shaders", "fragment", "files");
 
     spdlog::debug("Fragment shaders:");
 
-    for (const auto &fragment_shader_file : fragment_shader_files) {
+    for (const auto &fragment_shader_file : m_fragment_shader_files) {
         spdlog::debug("{}", fragment_shader_file);
     }
 
@@ -113,9 +113,9 @@ VkResult Application::load_toml_configuration_file(const std::string &file_name)
 }
 
 VkResult Application::load_textures() {
-    assert(vkdevice->get_device());
-    assert(vkdevice->get_physical_device());
-    assert(vkdevice->allocator());
+    assert(m_vkdevice->get_device());
+    assert(m_vkdevice->get_physical_device());
+    assert(m_vkdevice->allocator());
 
     // TODO: Refactor! use key from TOML file as name!
     std::size_t texture_number = 1;
@@ -123,48 +123,48 @@ VkResult Application::load_textures() {
     // Insert the new texture into the list of textures.
     std::string texture_name = "unnamed texture";
 
-    for (const auto &texture_file : texture_files) {
-        textures.emplace_back(vkdevice->get_device(), vkdevice->get_physical_device(), vkdevice->allocator(),
-                              texture_file, texture_name, vkdevice->get_graphics_queue(),
-                              vkdevice->get_graphics_queue_family_index());
+    for (const auto &texture_file : m_texture_files) {
+        m_textures.emplace_back(m_vkdevice->get_device(), m_vkdevice->get_physical_device(), m_vkdevice->allocator(),
+                                texture_file, texture_name, m_vkdevice->get_graphics_queue(),
+                                m_vkdevice->get_graphics_queue_family_index());
     }
 
     return VK_SUCCESS;
 }
 
 VkResult Application::load_shaders() {
-    assert(vkdevice->get_device());
+    assert(m_vkdevice->get_device());
 
     spdlog::debug("Loading vertex shaders.");
 
-    if (vertex_shader_files.empty()) {
+    if (m_vertex_shader_files.empty()) {
         spdlog::error("No vertex shaders to load!");
     }
 
-    auto total_number_of_shaders = vertex_shader_files.size() + fragment_shader_files.size();
+    auto total_number_of_shaders = m_vertex_shader_files.size() + m_fragment_shader_files.size();
 
     // Loop through the list of vertex shaders and initialise all of them.
-    for (const auto &vertex_shader_file : vertex_shader_files) {
+    for (const auto &vertex_shader_file : m_vertex_shader_files) {
         spdlog::debug("Loading vertex shader file {}.", vertex_shader_file);
 
         // Insert the new shader into the list of shaders.
-        shaders.emplace_back(vkdevice->get_device(), VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader",
-                             vertex_shader_file);
+        m_shaders.emplace_back(m_vkdevice->get_device(), VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader",
+                               vertex_shader_file);
     }
 
     spdlog::debug("Loading fragment shaders.");
 
-    if (fragment_shader_files.empty()) {
+    if (m_fragment_shader_files.empty()) {
         spdlog::error("No fragment shaders to load!");
     }
 
     // Loop through the list of fragment shaders and initialise all of them.
-    for (const auto &fragment_shader_file : fragment_shader_files) {
+    for (const auto &fragment_shader_file : m_fragment_shader_files) {
         spdlog::debug("Loading fragment shader file {}.", fragment_shader_file);
 
         // Insert the new shader into the list of shaders.
-        shaders.emplace_back(vkdevice->get_device(), VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
-                             fragment_shader_file);
+        m_shaders.emplace_back(m_vkdevice->get_device(), VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
+                               fragment_shader_file);
     }
 
     spdlog::debug("Loading shaders finished.");
@@ -201,11 +201,11 @@ VkResult Application::load_octree_geometry() {
 }
 
 VkResult Application::check_application_specific_features() {
-    assert(vkdevice->get_physical_device());
+    assert(m_vkdevice->get_physical_device());
 
     VkPhysicalDeviceFeatures graphics_card_features;
 
-    vkGetPhysicalDeviceFeatures(vkdevice->get_physical_device(), &graphics_card_features);
+    vkGetPhysicalDeviceFeatures(m_vkdevice->get_physical_device(), &graphics_card_features);
 
     // Check if anisotropic filtering is available!
     if (!graphics_card_features.samplerAnisotropy) {
@@ -227,7 +227,7 @@ Application::Application(int argc, char **argv) {
     cla_parser.parse_args(argc, argv);
 
     // Initialise Inexor thread-pool.
-    thread_pool = std::make_shared<ThreadPool>();
+    m_thread_pool = std::make_shared<ThreadPool>();
 
     // Load the configuration from the TOML file.
     VkResult result = load_toml_configuration_file("configuration/renderer.toml");
@@ -260,29 +260,29 @@ Application::Application(int argc, char **argv) {
 
     spdlog::debug("Creating Vulkan instance.");
 
-    glfw_context = std::make_unique<wrapper::GLFWContext>();
+    m_glfw_context = std::make_unique<wrapper::GLFWContext>();
 
-    vkinstance = std::make_unique<wrapper::Instance>(application_name, engine_name, application_version, engine_version,
-                                                     VK_API_VERSION_1_1);
+    m_vkinstance = std::make_unique<wrapper::Instance>(m_application_name, m_engine_name, m_application_version,
+                                                       m_engine_version, VK_API_VERSION_1_1);
 
-    window = std::make_unique<wrapper::Window>(window_title, window_width, window_height, true, true);
+    m_window = std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true);
 
-    surface = std::make_unique<wrapper::WindowSurface>(vkinstance->get_instance(), window->get());
+    m_surface = std::make_unique<wrapper::WindowSurface>(m_vkinstance->get_instance(), m_window->get());
 
     spdlog::debug("Storing GLFW window user pointer.");
 
-    window->set_user_ptr(this);
+    m_window->set_user_ptr(this);
 
     spdlog::debug("Setting up framebuffer resize callback.");
 
-    window->set_resize_callback(frame_buffer_resize_callback);
+    m_window->set_resize_callback(frame_buffer_resize_callback);
 
 #ifndef NDEBUG
     // Check if validation is enabled check for availabiliy of VK_EXT_debug_utils.
     if (enable_khronos_validation_instance_layer) {
         spdlog::debug("Khronos validation layer is enabled.");
 
-        if (availability_checks_manager->has_instance_extension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME)) {
+        if (m_availability_checks_manager->has_instance_extension(VK_EXT_DEBUG_REPORT_EXTENSION_NAME)) {
             auto debug_report_ci = wrapper::make_info<VkDebugReportCallbackCreateInfoEXT>();
             debug_report_ci.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT |
                                     VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT | VK_DEBUG_REPORT_ERROR_BIT_EXT;
@@ -291,15 +291,15 @@ Application::Application(int argc, char **argv) {
             // We have to explicitly load this function.
             PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT =
                 reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-                    vkGetInstanceProcAddr(vkinstance->get_instance(), "vkCreateDebugReportCallbackEXT"));
+                    vkGetInstanceProcAddr(m_vkinstance->get_instance(), "vkCreateDebugReportCallbackEXT"));
 
             if (vkCreateDebugReportCallbackEXT) {
                 // Create the debug report callback.
-                VkResult result = vkCreateDebugReportCallbackEXT(vkinstance->get_instance(), &debug_report_ci, nullptr,
-                                                                 &debug_report_callback);
+                VkResult result = vkCreateDebugReportCallbackEXT(m_vkinstance->get_instance(), &debug_report_ci,
+                                                                 nullptr, &m_debug_report_callback);
                 if (VK_SUCCESS == result) {
                     spdlog::debug("Creating Vulkan debug callback.");
-                    debug_report_callback_initialised = true;
+                    m_debug_report_callback_initialised = true;
                 } else {
                     vulkan_error_check(result);
                 }
@@ -337,19 +337,19 @@ Application::Application(int argc, char **argv) {
     auto enable_vertical_synchronisation = cla_parser.get_arg<bool>("--vsync");
     if (enable_vertical_synchronisation.value_or(false)) {
         spdlog::debug("V-sync enabled!");
-        vsync_enabled = true;
+        m_vsync_enabled = true;
     } else {
         spdlog::debug("V-sync disabled!");
-        vsync_enabled = false;
+        m_vsync_enabled = false;
     }
 
     if (display_graphics_card_info) {
         spdlog::debug("Displaying extended information about graphics cards.");
 
         // Print general information about Vulkan.
-        gpu_info_manager->print_driver_vulkan_version();
-        gpu_info_manager->print_instance_layers();
-        gpu_info_manager->print_instance_extensions();
+        m_gpu_info_manager->print_driver_vulkan_version();
+        m_gpu_info_manager->print_instance_layers();
+        m_gpu_info_manager->print_instance_extensions();
 
         // Print all information that we can find about all graphics card available.
         // gpu_info_manager->print_all_physical_devices(vkinstance->get_instance(), surface);
@@ -381,16 +381,16 @@ Application::Application(int argc, char **argv) {
         enable_debug_marker_device_extension = false;
     }
 
-    vkdevice =
-        std::make_unique<wrapper::Device>(vkinstance->get_instance(), surface->get(),
+    m_vkdevice =
+        std::make_unique<wrapper::Device>(m_vkinstance->get_instance(), m_surface->get(),
                                           enable_debug_marker_device_extension, use_distinct_data_transfer_queue);
 
     result = check_application_specific_features();
     vulkan_error_check(result);
 
-    swapchain = std::make_unique<wrapper::Swapchain>(vkdevice->get_device(), vkdevice->get_physical_device(),
-                                                     surface->get(), window->get_width(), window->get_height(),
-                                                     vsync_enabled, "Standard swapchain.");
+    m_swapchain = std::make_unique<wrapper::Swapchain>(m_vkdevice->get_device(), m_vkdevice->get_physical_device(),
+                                                       m_surface->get(), m_window->get_width(), m_window->get_height(),
+                                                       m_vsync_enabled, "Standard swapchain.");
 
     spdlog::debug("Starting to load textures using threadpool.");
 
@@ -406,11 +406,11 @@ Application::Application(int argc, char **argv) {
     result = create_descriptor_set_layouts();
     vulkan_error_check(result);
 
-    command_pool =
-        std::make_unique<wrapper::CommandPool>(vkdevice->get_device(), vkdevice->get_graphics_queue_family_index());
+    m_command_pool =
+        std::make_unique<wrapper::CommandPool>(m_vkdevice->get_device(), m_vkdevice->get_graphics_queue_family_index());
 
-    uniform_buffers.emplace_back(vkdevice->get_device(), vkdevice->allocator(), "matrices uniform buffer",
-                                 sizeof(UniformBufferObject));
+    m_uniform_buffers.emplace_back(m_vkdevice->get_device(), m_vkdevice->allocator(), "matrices uniform buffer",
+                                   sizeof(UniformBufferObject));
 
     result = create_descriptor_writes();
     vulkan_error_check(result);
@@ -421,24 +421,24 @@ Application::Application(int argc, char **argv) {
     spdlog::debug("Vulkan initialisation finished.");
 
     spdlog::debug("Showing window.");
-    window->show();
+    m_window->show();
     recreate_swapchain();
 }
 
 VkResult Application::update_uniform_buffers() {
-    float time = time_step.get_time_step_since_initialisation();
+    float time = m_time_step.get_time_step_since_initialisation();
 
     UniformBufferObject ubo{};
 
     // Rotate the model as a function of time.
     ubo.model = glm::rotate(glm::mat4(1.0f), /*time */ glm::radians(90.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 
-    ubo.view = game_camera.matrices.view;
-    ubo.proj = game_camera.matrices.perspective;
+    ubo.view = m_game_camera.m_matrices.view;
+    ubo.proj = m_game_camera.m_matrices.perspective;
     ubo.proj[1][1] *= -1;
 
     // TODO: Don't use vector of uniform buffers.
-    uniform_buffers[0].update(&ubo, sizeof(ubo));
+    m_uniform_buffers[0].update(&ubo, sizeof(ubo));
 
     return VK_SUCCESS;
 }
@@ -448,24 +448,24 @@ VkResult Application::update_mouse_input() {
     double current_cursor_x;
     double current_cursor_y;
 
-    window->get_cursor_pos(current_cursor_x, current_cursor_y);
+    m_window->get_cursor_pos(current_cursor_x, current_cursor_y);
 
-    double cursor_delta_x = current_cursor_x - cursor_x;
-    double cursor_delta_y = current_cursor_y - cursor_y;
+    double cursor_delta_x = current_cursor_x - m_cursor_x;
+    double cursor_delta_y = current_cursor_y - m_cursor_y;
 
     int state =
 
-        window->is_button_pressed(GLFW_MOUSE_BUTTON_LEFT);
+        m_window->is_button_pressed(GLFW_MOUSE_BUTTON_LEFT);
 
     if (state == GLFW_PRESS) {
-        game_camera.rotate(
-            glm::vec3(cursor_delta_y * game_camera.rotation_speed, -cursor_delta_x * game_camera.rotation_speed, 0.0f));
+        m_game_camera.rotate(glm::vec3(cursor_delta_y * m_game_camera.m_rotation_speed,
+                                       -cursor_delta_x * m_game_camera.m_rotation_speed, 0.0f));
     }
 
-    window->is_button_pressed(GLFW_MOUSE_BUTTON_RIGHT);
+    m_window->is_button_pressed(GLFW_MOUSE_BUTTON_RIGHT);
 
-    cursor_x = current_cursor_x;
-    cursor_y = current_cursor_y;
+    m_cursor_x = current_cursor_x;
+    m_cursor_y = current_cursor_y;
 
     return VK_SUCCESS;
 }
@@ -473,17 +473,17 @@ VkResult Application::update_mouse_input() {
 void Application::run() {
     spdlog::debug("Running Application.");
 
-    while (!window->should_close()) {
-        window->poll();
+    while (!m_window->should_close()) {
+        m_window->poll();
         update_uniform_buffers();
         render_frame();
 
         // TODO: Run this in a separated thread?
         // TODO: Merge into one update_game_data() method?
         update_mouse_input();
-        game_camera.update(time_passed);
+        m_game_camera.update(m_time_passed);
 
-        time_passed = stopwatch.get_time_step();
+        m_time_passed = m_stopwatch.get_time_step();
     }
 }
 

--- a/src/vulkan-renderer/availability_checks.cpp
+++ b/src/vulkan-renderer/availability_checks.cpp
@@ -9,10 +9,10 @@ namespace inexor::vulkan_renderer {
 
 VkResult AvailabilityChecksManager::create_instance_extensions_cache() {
     // First ask Vulkan how many instance extensions are available on the system.
-    VkResult result = vkEnumerateInstanceExtensionProperties(nullptr, &available_instance_extensions, nullptr);
+    VkResult result = vkEnumerateInstanceExtensionProperties(nullptr, &m_available_instance_extensions, nullptr);
     vulkan_error_check(result);
 
-    if (available_instance_extensions == 0) {
+    if (m_available_instance_extensions == 0) {
         // It should be a very rare case that no instance extensions are available at all. Still we have to consider
         // this!
         display_error_message("Error: No Vulkan instance extensions available!");
@@ -21,11 +21,11 @@ VkResult AvailabilityChecksManager::create_instance_extensions_cache() {
         return VK_ERROR_INITIALIZATION_FAILED;
     } else {
         // Preallocate memory for extension properties.
-        instance_extensions_cache.resize(available_instance_extensions);
+        m_instance_extensions_cache.resize(m_available_instance_extensions);
 
         // Get the information about the available instance extensions.
-        result = vkEnumerateInstanceExtensionProperties(nullptr, &available_instance_extensions,
-                                                        instance_extensions_cache.data());
+        result = vkEnumerateInstanceExtensionProperties(nullptr, &m_available_instance_extensions,
+                                                        m_instance_extensions_cache.data());
         vulkan_error_check(result);
     }
 
@@ -35,12 +35,12 @@ VkResult AvailabilityChecksManager::create_instance_extensions_cache() {
 bool AvailabilityChecksManager::has_instance_extension(const std::string &instance_extension_name) {
     assert(!instance_extension_name.empty());
 
-    if (instance_extensions_cache.empty()) {
+    if (m_instance_extensions_cache.empty()) {
         create_instance_extensions_cache();
     }
 
     // Loop through all available instance extensions and search for the requested one.
-    for (const VkExtensionProperties &instance_extension : instance_extensions_cache) {
+    for (const VkExtensionProperties &instance_extension : m_instance_extensions_cache) {
         // Compare the name of the current instance extension with the requested one.
         if (strcmp(instance_extension.extensionName, instance_extension_name.c_str()) == 0) {
             // Yes, this instance extension is supported!
@@ -54,10 +54,10 @@ bool AvailabilityChecksManager::has_instance_extension(const std::string &instan
 
 VkResult AvailabilityChecksManager::create_instance_layers_cache() {
     // First ask Vulkan how many instance layers are available on the system.
-    VkResult result = vkEnumerateInstanceLayerProperties(&available_instance_layers, nullptr);
+    VkResult result = vkEnumerateInstanceLayerProperties(&m_available_instance_layers, nullptr);
     vulkan_error_check(result);
 
-    if (available_instance_layers == 0) {
+    if (m_available_instance_layers == 0) {
         // It should be a very rare case that no instance layers are available at all. Still we have to consider this!
         display_error_message("Error: No Vulkan instance layers available!");
 
@@ -65,10 +65,10 @@ VkResult AvailabilityChecksManager::create_instance_layers_cache() {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
     // Preallocate memory for layer properties.
-    instance_layers_cache.resize(available_instance_layers);
+    m_instance_layers_cache.resize(m_available_instance_layers);
 
     // Get the information about the available instance layers.
-    result = vkEnumerateInstanceLayerProperties(&available_instance_layers, instance_layers_cache.data());
+    result = vkEnumerateInstanceLayerProperties(&m_available_instance_layers, m_instance_layers_cache.data());
     vulkan_error_check(result);
 
     return VK_SUCCESS;
@@ -77,12 +77,12 @@ VkResult AvailabilityChecksManager::create_instance_layers_cache() {
 bool AvailabilityChecksManager::has_instance_layer(const std::string &instance_layer_name) {
     assert(!instance_layer_name.empty());
 
-    if (instance_layers_cache.empty()) {
+    if (m_instance_layers_cache.empty()) {
         create_instance_layers_cache();
     }
 
     // Loop through all available instance layers and search for the requested one.
-    for (const VkLayerProperties &instance_layer : instance_layers_cache) {
+    for (const VkLayerProperties &instance_layer : m_instance_layers_cache) {
         // Compare the name of the current instance extension with the requested one.
         if (strcmp(instance_layer.layerName, instance_layer_name.c_str()) == 0) {
             // Yes, this instance extension is supported!
@@ -96,10 +96,10 @@ bool AvailabilityChecksManager::has_instance_layer(const std::string &instance_l
 
 VkResult AvailabilityChecksManager::create_device_layers_cache(const VkPhysicalDevice &graphics_card) {
     // First ask Vulkan how many device layers are available on the system.
-    VkResult result = vkEnumerateDeviceLayerProperties(graphics_card, &available_device_layers, nullptr);
+    VkResult result = vkEnumerateDeviceLayerProperties(graphics_card, &m_available_device_layers, nullptr);
     vulkan_error_check(result);
 
-    if (available_device_layers == 0) {
+    if (m_available_device_layers == 0) {
         // It should be a very rare case that no device layers are available at all. Still we have to consider this!
         display_error_message("Error: No Vulkan device layers available!");
 
@@ -107,11 +107,11 @@ VkResult AvailabilityChecksManager::create_device_layers_cache(const VkPhysicalD
         return VK_ERROR_INITIALIZATION_FAILED;
     }
     // Preallocate memory for device layers.
-    device_layer_properties_cache.resize(available_device_layers);
+    m_device_layer_properties_cache.resize(m_available_device_layers);
 
     // Get the information about the available device layers.
-    result =
-        vkEnumerateDeviceLayerProperties(graphics_card, &available_device_layers, device_layer_properties_cache.data());
+    result = vkEnumerateDeviceLayerProperties(graphics_card, &m_available_device_layers,
+                                              m_device_layer_properties_cache.data());
     vulkan_error_check(result);
 
     return VK_SUCCESS;
@@ -122,12 +122,12 @@ bool AvailabilityChecksManager::has_device_layer(const VkPhysicalDevice &graphic
     assert(graphics_card);
     assert(!device_layer_name.empty());
 
-    if (device_layer_properties_cache.empty()) {
+    if (m_device_layer_properties_cache.empty()) {
         create_device_layers_cache(graphics_card);
     }
 
     // Loop through all available device layers and search for the requested one.
-    for (const VkLayerProperties &device_layer : device_layer_properties_cache) {
+    for (const VkLayerProperties &device_layer : m_device_layer_properties_cache) {
         if (0 == strcmp(device_layer.layerName, device_layer_name.c_str())) {
             // Yes, this device layer is supported!
             return true;
@@ -141,10 +141,10 @@ bool AvailabilityChecksManager::has_device_layer(const VkPhysicalDevice &graphic
 VkResult AvailabilityChecksManager::create_device_extensions_cache(const VkPhysicalDevice &graphics_card) {
     // First ask Vulkan how many device extensions are available on the system.
     VkResult result =
-        vkEnumerateDeviceExtensionProperties(graphics_card, nullptr, &available_device_extensions, nullptr);
+        vkEnumerateDeviceExtensionProperties(graphics_card, nullptr, &m_available_device_extensions, nullptr);
     vulkan_error_check(result);
 
-    if (0 == available_device_extensions) {
+    if (0 == m_available_device_extensions) {
         // It should be a very rare case that no device extension are available at all. Still we have to consider this!
         display_error_message("Error: No Vulkan device extensions available!");
 
@@ -152,11 +152,11 @@ VkResult AvailabilityChecksManager::create_device_extensions_cache(const VkPhysi
         return VK_ERROR_INITIALIZATION_FAILED;
     } else {
         // Preallocate memory for device extensions.
-        device_extensions_cache.resize(available_device_extensions);
+        m_device_extensions_cache.resize(m_available_device_extensions);
 
         // Get the information about the available device extensions.
-        result = vkEnumerateDeviceExtensionProperties(graphics_card, nullptr, &available_device_extensions,
-                                                      device_extensions_cache.data());
+        result = vkEnumerateDeviceExtensionProperties(graphics_card, nullptr, &m_available_device_extensions,
+                                                      m_device_extensions_cache.data());
         vulkan_error_check(result);
     }
 
@@ -168,12 +168,12 @@ bool AvailabilityChecksManager::has_device_extension(const VkPhysicalDevice &gra
     assert(graphics_card);
     assert(!device_extension_name.empty());
 
-    if (device_extensions_cache.empty()) {
+    if (m_device_extensions_cache.empty()) {
         create_device_extensions_cache(graphics_card);
     }
 
     // Loop through all available device extensions and search for the requested one.
-    for (const VkExtensionProperties &device_extension : device_extensions_cache) {
+    for (const VkExtensionProperties &device_extension : m_device_extensions_cache) {
         if (0 == strcmp(device_extension.extensionName, device_extension_name.c_str())) {
             // Yes, this device extension is supported!
             return true;

--- a/src/vulkan-renderer/bezier_curve.cpp
+++ b/src/vulkan-renderer/bezier_curve.cpp
@@ -38,7 +38,7 @@ bool BezierCurve::is_curve_generated() {
     return m_curve_generated;
 }
 
-std::vector<BezierOutputPoint> BezierCurve::get_output_points() {
+std::vector<BezierOutputPoint> BezierCurve::output_points() {
     assert(m_curve_generated);
     assert(m_output_points.size() > 0);
     return m_output_points;

--- a/src/vulkan-renderer/bezier_curve.cpp
+++ b/src/vulkan-renderer/bezier_curve.cpp
@@ -35,39 +35,39 @@ void BezierCurve::clear() {
 }
 
 bool BezierCurve::is_curve_generated() {
-    return curve_generated;
+    return m_curve_generated;
 }
 
 std::vector<BezierOutputPoint> BezierCurve::get_output_points() {
-    assert(curve_generated);
-    assert(output_points.size() > 0);
-    return output_points;
+    assert(m_curve_generated);
+    assert(m_output_points.size() > 0);
+    return m_output_points;
 }
 
 void BezierCurve::add_input_point(const BezierInputPoint &input_point) {
-    assert(!curve_generated);
-    input_points.push_back(input_point);
+    assert(!m_curve_generated);
+    m_input_points.push_back(input_point);
 }
 
 void BezierCurve::add_input_point(const glm::vec3 &position, const float weight) {
-    assert(!curve_generated);
+    assert(!m_curve_generated);
     assert(weight > 0.0f);
 
     BezierInputPoint input_point;
     input_point.pos = position;
     input_point.weight = weight;
 
-    input_points.push_back(input_point);
+    m_input_points.push_back(input_point);
 }
 
 BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precision) {
     BezierOutputPoint temp_output;
 
-    std::uint32_t n = static_cast<std::uint32_t>(input_points.size() - 1);
+    std::uint32_t n = static_cast<std::uint32_t>(m_input_points.size() - 1);
 
     // Calculate the coordinates of the output points of the bezier curve.
-    for (std::size_t i = 0; i < input_points.size(); i++) {
-        auto current_point = input_points[i];
+    for (std::size_t i = 0; i < m_input_points.size(); i++) {
+        auto current_point = m_input_points[i];
 
         std::uint32_t index = static_cast<std::uint32_t>(i);
 
@@ -85,8 +85,8 @@ BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precis
     // precision of the derivation depends on the curve precision!
     // With this technique, we can have precise derivations even if we have a precision of only 10.0f units!
     for (std::size_t i = 0; i < n; i++) {
-        auto current_point = input_points[i];
-        auto next_point = input_points[i + 1];
+        auto current_point = m_input_points[i];
+        auto next_point = m_input_points[i + 1];
 
         std::uint32_t index = static_cast<std::uint32_t>(i);
 
@@ -118,21 +118,21 @@ BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precis
 
 void BezierCurve::calculate_bezier_curve(const float curve_precision) {
     // We need at least 2 input points!
-    assert(input_points.size() > 2);
+    assert(m_input_points.size() > 2);
 
-    if (curve_generated) {
+    if (m_curve_generated) {
         clear();
-        curve_generated = false;
+        m_curve_generated = false;
     }
 
     float curve_precision_interval = 1.0f / curve_precision;
 
     for (float position_on_curve = 0.0f; position_on_curve <= 1.0f; position_on_curve += curve_precision_interval) {
         BezierOutputPoint temp_output = calculate_point_on_curve(position_on_curve);
-        output_points.push_back(temp_output);
+        m_output_points.push_back(temp_output);
     }
 
-    curve_generated = true;
+    m_curve_generated = true;
 }
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -27,11 +27,11 @@ bool Camera::moving() {
     return m_keys.left || m_keys.right || m_keys.up || m_keys.down;
 }
 
-float Camera::get_near_clip() {
+float Camera::near_clip() {
     return m_z_near;
 }
 
-float Camera::get_far_clip() {
+float Camera::far_clip() {
     return m_z_far;
 }
 

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -8,92 +8,92 @@ void Camera::update_view_matrix() {
     glm::mat4 rot_m = glm::mat4(1.0f);
     glm::mat4 trans_m;
 
-    rot_m = glm::rotate(rot_m, glm::radians(rotation.x), glm::vec3(1.0f, 0.0f, 0.0f));
-    rot_m = glm::rotate(rot_m, glm::radians(rotation.y), glm::vec3(0.0f, 1.0f, 0.0f));
-    rot_m = glm::rotate(rot_m, glm::radians(rotation.z), glm::vec3(0.0f, 0.0f, 1.0f));
+    rot_m = glm::rotate(rot_m, glm::radians(m_rotation.x), glm::vec3(1.0f, 0.0f, 0.0f));
+    rot_m = glm::rotate(rot_m, glm::radians(m_rotation.y), glm::vec3(0.0f, 1.0f, 0.0f));
+    rot_m = glm::rotate(rot_m, glm::radians(m_rotation.z), glm::vec3(0.0f, 0.0f, 1.0f));
 
-    trans_m = glm::translate(glm::mat4(1.0f), position * glm::vec3(1.0f, 1.0f, -1.0f));
+    trans_m = glm::translate(glm::mat4(1.0f), m_position * glm::vec3(1.0f, 1.0f, -1.0f));
 
-    if (type == CameraType::FIRSTPERSON) {
-        matrices.view = rot_m * trans_m;
+    if (m_type == CameraType::FIRSTPERSON) {
+        m_matrices.view = rot_m * trans_m;
     } else {
-        matrices.view = trans_m * rot_m;
+        m_matrices.view = trans_m * rot_m;
     }
 
-    updated = true;
+    m_updated = true;
 };
 
 bool Camera::moving() {
-    return keys.left || keys.right || keys.up || keys.down;
+    return m_keys.left || m_keys.right || m_keys.up || m_keys.down;
 }
 
 float Camera::get_near_clip() {
-    return z_near;
+    return m_z_near;
 }
 
 float Camera::get_far_clip() {
-    return z_far;
+    return m_z_far;
 }
 
 void Camera::set_perspective(float fov, float aspect, float z_near, float z_far) {
-    this->fov = fov;
-    this->z_near = z_near;
-    this->z_far = z_far;
-    matrices.perspective = glm::perspective(glm::radians(fov), aspect, z_near, z_far);
+    m_fov = fov;
+    m_z_near = z_near;
+    m_z_far = z_far;
+    m_matrices.perspective = glm::perspective(glm::radians(fov), aspect, z_near, z_far);
 }
 
 void Camera::update_aspect_ratio(float aspect) {
-    matrices.perspective = glm::perspective(glm::radians(fov), aspect, z_near, z_far);
+    m_matrices.perspective = glm::perspective(glm::radians(m_fov), aspect, m_z_near, m_z_far);
 }
 
 void Camera::set_position(glm::vec3 position) {
-    this->position = position;
+    m_position = position;
     update_view_matrix();
 }
 
 void Camera::set_rotation(glm::vec3 rotation) {
-    this->rotation = rotation;
+    m_rotation = rotation;
     update_view_matrix();
 }
 
 void Camera::rotate(glm::vec3 delta) {
-    this->rotation += delta;
+    m_rotation += delta;
     update_view_matrix();
 }
 
 void Camera::set_translation(glm::vec3 translation) {
-    this->position = translation;
+    m_position = translation;
     update_view_matrix();
 }
 
 void Camera::translate(glm::vec3 delta) {
-    this->position += delta;
+    m_position += delta;
     update_view_matrix();
 }
 
 void Camera::update(float delta_time) {
     {
-        updated = false;
-        if (type == CameraType::FIRSTPERSON && moving()) {
+        m_updated = false;
+        if (m_type == CameraType::FIRSTPERSON && moving()) {
             glm::vec3 cam_front;
-            cam_front.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
-            cam_front.y = sin(glm::radians(rotation.x));
-            cam_front.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
+            cam_front.x = -cos(glm::radians(m_rotation.x)) * sin(glm::radians(m_rotation.y));
+            cam_front.y = sin(glm::radians(m_rotation.x));
+            cam_front.z = cos(glm::radians(m_rotation.x)) * cos(glm::radians(m_rotation.y));
             cam_front = glm::normalize(cam_front);
 
-            float move_speed = delta_time * movement_speed;
+            float move_speed = delta_time * m_movement_speed;
 
-            if (keys.up) {
-                position += cam_front * move_speed;
+            if (m_keys.up) {
+                m_position += cam_front * move_speed;
             }
-            if (keys.down) {
-                position -= cam_front * move_speed;
+            if (m_keys.down) {
+                m_position -= cam_front * move_speed;
             }
-            if (keys.left) {
-                position -= glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * move_speed;
+            if (m_keys.left) {
+                m_position -= glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * move_speed;
             }
-            if (keys.right) {
-                position += glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * move_speed;
+            if (m_keys.right) {
+                m_position += glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * move_speed;
             }
 
             update_view_matrix();
@@ -104,7 +104,7 @@ void Camera::update(float delta_time) {
 bool Camera::update_pad(glm::vec2 axis_left, glm::vec2 axis_right, float delta_time) {
     bool ret_val = false;
 
-    if (type == CameraType::FIRSTPERSON) {
+    if (m_type == CameraType::FIRSTPERSON) {
         // Use the common console thumbstick layout
         // Left = view, right = move
 
@@ -112,36 +112,36 @@ bool Camera::update_pad(glm::vec2 axis_left, glm::vec2 axis_right, float delta_t
         const float range = 1.0f - dead_zone;
 
         glm::vec3 cam_front;
-        cam_front.x = -cos(glm::radians(rotation.x)) * sin(glm::radians(rotation.y));
-        cam_front.y = sin(glm::radians(rotation.x));
-        cam_front.z = cos(glm::radians(rotation.x)) * cos(glm::radians(rotation.y));
+        cam_front.x = -cos(glm::radians(m_rotation.x)) * sin(glm::radians(m_rotation.y));
+        cam_front.y = sin(glm::radians(m_rotation.x));
+        cam_front.z = cos(glm::radians(m_rotation.x)) * cos(glm::radians(m_rotation.y));
         cam_front = glm::normalize(cam_front);
 
-        float move_speed = delta_time * movement_speed * 2.0f;
-        float rot_speed = delta_time * rotation_speed * 50.0f;
+        float move_speed = delta_time * m_movement_speed * 2.0f;
+        float rot_speed = delta_time * m_rotation_speed * 50.0f;
 
         // Move
         if (fabsf(axis_left.y) > dead_zone) {
             float pos = (fabsf(axis_left.y) - dead_zone) / range;
-            position -= cam_front * pos * ((axis_left.y < 0.0f) ? -1.0f : 1.0f) * move_speed;
+            m_position -= cam_front * pos * ((axis_left.y < 0.0f) ? -1.0f : 1.0f) * move_speed;
             ret_val = true;
         }
         if (fabsf(axis_left.x) > dead_zone) {
             float pos = (fabsf(axis_left.x) - dead_zone) / range;
-            position += glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * pos *
-                        ((axis_left.x < 0.0f) ? -1.0f : 1.0f) * move_speed;
+            m_position += glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * pos *
+                          ((axis_left.x < 0.0f) ? -1.0f : 1.0f) * move_speed;
             ret_val = true;
         }
 
         // Rotate
         if (fabsf(axis_right.x) > dead_zone) {
             float pos = (fabsf(axis_right.x) - dead_zone) / range;
-            rotation.y += pos * ((axis_right.x < 0.0f) ? -1.0f : 1.0f) * rot_speed;
+            m_rotation.y += pos * ((axis_right.x < 0.0f) ? -1.0f : 1.0f) * rot_speed;
             ret_val = true;
         }
         if (fabsf(axis_right.y) > dead_zone) {
             float pos = (fabsf(axis_right.y) - dead_zone) / range;
-            rotation.x -= pos * ((axis_right.y < 0.0f) ? -1.0f : 1.0f) * rot_speed;
+            m_rotation.x -= pos * ((axis_right.y < 0.0f) ? -1.0f : 1.0f) * rot_speed;
             ret_val = true;
         }
     } else {

--- a/src/vulkan-renderer/error_handling.cpp
+++ b/src/vulkan-renderer/error_handling.cpp
@@ -10,7 +10,7 @@ namespace inexor::vulkan_renderer {
 
 /// @brief Returns a user friendly error description text.
 /// @param result_code The error code.
-std::string get_error_description_text(const VkResult &result_code) {
+std::string error_description_text(const VkResult &result_code) {
     std::string error_string = "";
 
     // For more information on error codes see:
@@ -175,7 +175,7 @@ void display_warning_message(const std::string &warning_message, const std::stri
 
 void vulkan_error_check(const VkResult &result) {
     if (result != VK_SUCCESS) {
-        std::string error_message = "Error: " + get_error_description_text(result);
+        std::string error_message = "Error: " + error_description_text(result);
         display_error_message(error_message);
     }
 }

--- a/src/vulkan-renderer/fps_counter.cpp
+++ b/src/vulkan-renderer/fps_counter.cpp
@@ -5,18 +5,18 @@ namespace inexor::vulkan_renderer {
 std::optional<std::uint32_t> FPSCounter::update() {
     auto current_time = std::chrono::high_resolution_clock::now();
 
-    auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - last_time).count();
+    auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
 
-    if (time_duration >= fps_update_interval) {
-        auto fps_value = static_cast<std::uint32_t>(frames / time_duration);
+    if (time_duration >= m_fps_update_interval) {
+        auto fps_value = static_cast<std::uint32_t>(m_frames / time_duration);
 
-        last_time = current_time;
-        frames = 0;
+        m_last_time = current_time;
+        m_frames = 0;
 
         return fps_value;
     }
 
-    frames++;
+    m_frames++;
 
     return std::nullopt;
 }

--- a/src/vulkan-renderer/frame_graph.cpp
+++ b/src/vulkan-renderer/frame_graph.cpp
@@ -38,9 +38,9 @@ void GraphicsStage::bind_buffer(const BufferResource &buffer, std::uint32_t bind
 
 void GraphicsStage::uses_shader(const wrapper::Shader &shader) {
     auto create_info = wrapper::make_info<VkPipelineShaderStageCreateInfo>();
-    create_info.module = shader.get_module();
-    create_info.stage = shader.get_type();
-    create_info.pName = shader.get_entry_point().c_str();
+    create_info.module = shader.module();
+    create_info.stage = shader.type();
+    create_info.pName = shader.entry_point().c_str();
     m_shaders.push_back(create_info);
 }
 
@@ -66,8 +66,8 @@ void FrameGraph::build_image(const TextureResource *resource, PhysicalImage *phy
     image_ci.imageType = VK_IMAGE_TYPE_2D;
 
     // TODO(): Support textures with dimensions not equal to back buffer size
-    image_ci.extent.width = m_swapchain.get_extent().width;
-    image_ci.extent.height = m_swapchain.get_extent().height;
+    image_ci.extent.width = m_swapchain.extent().width;
+    image_ci.extent.height = m_swapchain.extent().height;
     image_ci.extent.depth = 1;
 
     image_ci.arrayLayers = 1;
@@ -234,11 +234,11 @@ void FrameGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGra
     blend_state.pAttachments = &blend_attachment;
 
     VkRect2D scissor{};
-    scissor.extent = m_swapchain.get_extent();
+    scissor.extent = m_swapchain.extent();
 
     VkViewport viewport{};
-    viewport.width = static_cast<float>(m_swapchain.get_extent().width);
-    viewport.height = static_cast<float>(m_swapchain.get_extent().height);
+    viewport.width = static_cast<float>(m_swapchain.extent().width);
+    viewport.height = static_cast<float>(m_swapchain.extent().height);
     viewport.maxDepth = 1.0F;
 
     // TODO(): Custom scissors?
@@ -269,7 +269,7 @@ void FrameGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGra
 
 void FrameGraph::alloc_command_buffers(const RenderStage *stage, PhysicalStage *phys) {
     m_log->trace("Allocating command buffers for stage '{}'", stage->m_name);
-    for (std::uint32_t i = 0; i < m_swapchain.get_image_count(); i++) {
+    for (std::uint32_t i = 0; i < m_swapchain.image_count(); i++) {
         phys->m_command_buffers.emplace_back(m_device, m_command_pool);
     }
 }
@@ -296,7 +296,7 @@ void FrameGraph::record_command_buffers(const RenderStage *stage, PhysicalStage 
             render_pass_bi.clearValueCount = static_cast<std::uint32_t>(clear_values.size());
             render_pass_bi.pClearValues = clear_values.data();
             render_pass_bi.framebuffer = phys_graphics_stage->m_framebuffers[i].get();
-            render_pass_bi.renderArea.extent = m_swapchain.get_extent();
+            render_pass_bi.renderArea.extent = m_swapchain.extent();
             render_pass_bi.renderPass = phys_graphics_stage->m_render_pass;
             cmd_buf.begin_render_pass(render_pass_bi);
         }
@@ -444,10 +444,10 @@ void FrameGraph::compile(const RenderResource &target) {
                 }
 
                 std::vector<VkImageView> image_views;
-                for (std::uint32_t i = 0; i < m_swapchain.get_image_count(); i++) {
+                for (std::uint32_t i = 0; i < m_swapchain.image_count(); i++) {
                     image_views.clear();
                     for (const auto *back_buffer : back_buffers) {
-                        image_views.push_back(back_buffer->m_swapchain.get_image_view(i));
+                        image_views.push_back(back_buffer->m_swapchain.image_view(i));
                     }
 
                     for (const auto *image : images) {

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -46,8 +46,7 @@ void VulkanRenderer::setup_frame_graph() {
 }
 
 VkResult VulkanRenderer::create_descriptor_pool() {
-    m_descriptors.emplace_back(m_vkdevice->device(), m_swapchain->image_count(),
-                               std::string("unnamed descriptor"));
+    m_descriptors.emplace_back(m_vkdevice->device(), m_swapchain->image_count(), std::string("unnamed descriptor"));
 
     // Create the descriptor pool.
     m_descriptors[0].create_descriptor_pool({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER});
@@ -103,8 +102,8 @@ void VulkanRenderer::recreate_swapchain() {
     // TODO(): This is quite naive, we don't need to recompile the whole frame graph on swapchain invalidation
     m_frame_graph.reset();
     m_swapchain->recreate(m_window->width(), m_window->height());
-    m_frame_graph = std::make_unique<FrameGraph>(m_vkdevice->device(), m_command_pool->get(),
-                                                 m_vkdevice->allocator(), *m_swapchain);
+    m_frame_graph = std::make_unique<FrameGraph>(m_vkdevice->device(), m_command_pool->get(), m_vkdevice->allocator(),
+                                                 *m_swapchain);
     setup_frame_graph();
 
     m_image_available_semaphore.reset();
@@ -120,8 +119,8 @@ void VulkanRenderer::recreate_swapchain() {
     m_game_camera.m_movement_speed = 0.1f;
     m_game_camera.set_position({0.0f, 0.0f, 5.0f});
     m_game_camera.set_rotation({0.0f, 0.0f, 0.0f});
-    m_game_camera.set_perspective(
-        45.0f, static_cast<float>(m_window->width()) / static_cast<float>(m_window->height()), 0.1f, 256.0f);
+    m_game_camera.set_perspective(45.0f, static_cast<float>(m_window->width()) / static_cast<float>(m_window->height()),
+                                  0.1f, 256.0f);
 }
 
 void VulkanRenderer::render_frame() {

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -14,7 +14,7 @@ namespace inexor::vulkan_renderer {
 
 void VulkanRenderer::setup_frame_graph() {
     auto &back_buffer = m_frame_graph->add<TextureResource>("back buffer");
-    back_buffer.set_format(swapchain->get_image_format());
+    back_buffer.set_format(m_swapchain->get_image_format());
     back_buffer.set_usage(TextureUsage::BACK_BUFFER);
 
     auto &depth_buffer = m_frame_graph->add<TextureResource>("depth buffer");
@@ -33,23 +33,24 @@ void VulkanRenderer::setup_frame_graph() {
     main_stage.reads_from(vertex_buffer);
     main_stage.bind_buffer(vertex_buffer, 0);
     main_stage.set_on_record([&](const PhysicalStage *phys, const wrapper::CommandBuffer &cmd_buf) {
-        cmd_buf.bind_descriptor(descriptors[0], phys->pipeline_layout());
+        cmd_buf.bind_descriptor(m_descriptors[0], phys->pipeline_layout());
         cmd_buf.draw(m_octree_vertices.size());
     });
 
-    for (const auto &shader : shaders) {
+    for (const auto &shader : m_shaders) {
         main_stage.uses_shader(shader);
     }
 
-    main_stage.add_descriptor_layout(descriptors[0].get_descriptor_set_layout());
+    main_stage.add_descriptor_layout(m_descriptors[0].get_descriptor_set_layout());
     m_frame_graph->compile(back_buffer);
 }
 
 VkResult VulkanRenderer::create_descriptor_pool() {
-    descriptors.emplace_back(vkdevice->get_device(), swapchain->get_image_count(), std::string("unnamed descriptor"));
+    m_descriptors.emplace_back(m_vkdevice->get_device(), m_swapchain->get_image_count(),
+                               std::string("unnamed descriptor"));
 
     // Create the descriptor pool.
-    descriptors[0].create_descriptor_pool({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER});
+    m_descriptors[0].create_descriptor_pool({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER});
 
     return VK_SUCCESS;
 }
@@ -63,22 +64,22 @@ VkResult VulkanRenderer::create_descriptor_set_layouts() {
     descriptor_set_layout_bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     descriptor_set_layout_bindings[0].pImmutableSamplers = nullptr;
 
-    descriptors[0].create_descriptor_set_layouts(descriptor_set_layout_bindings);
+    m_descriptors[0].create_descriptor_set_layouts(descriptor_set_layout_bindings);
 
     return VK_SUCCESS;
 }
 
 VkResult VulkanRenderer::create_descriptor_writes() {
-    assert(!textures.empty());
+    assert(!m_textures.empty());
 
     std::vector<VkWriteDescriptorSet> descriptor_writes(1);
 
     // Link the matrices uniform buffer to the descriptor set so the shader can access it.
 
     // We can do better than this, but therefore RAII refactoring needs to be done..
-    uniform_buffer_info.buffer = uniform_buffers[0].get_buffer();
-    uniform_buffer_info.offset = 0;
-    uniform_buffer_info.range = sizeof(UniformBufferObject);
+    m_uniform_buffer_info.buffer = m_uniform_buffers[0].get_buffer();
+    m_uniform_buffer_info.offset = 0;
+    m_uniform_buffer_info.range = sizeof(UniformBufferObject);
 
     descriptor_writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_writes[0].dstSet = nullptr;
@@ -86,72 +87,72 @@ VkResult VulkanRenderer::create_descriptor_writes() {
     descriptor_writes[0].dstArrayElement = 0;
     descriptor_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_writes[0].descriptorCount = 1;
-    descriptor_writes[0].pBufferInfo = &uniform_buffer_info;
+    descriptor_writes[0].pBufferInfo = &m_uniform_buffer_info;
 
-    descriptors[0].add_descriptor_writes(descriptor_writes);
+    m_descriptors[0].add_descriptor_writes(descriptor_writes);
 
-    descriptors[0].create_descriptor_sets();
+    m_descriptors[0].create_descriptor_sets();
 
     return VK_SUCCESS;
 }
 
 void VulkanRenderer::recreate_swapchain() {
-    window->wait_for_focus();
-    vkDeviceWaitIdle(vkdevice->get_device());
+    m_window->wait_for_focus();
+    vkDeviceWaitIdle(m_vkdevice->get_device());
 
     // TODO(): This is quite naive, we don't need to recompile the whole frame graph on swapchain invalidation
     m_frame_graph.reset();
-    swapchain->recreate(window->get_width(), window->get_height());
-    m_frame_graph =
-        std::make_unique<FrameGraph>(vkdevice->get_device(), command_pool->get(), vkdevice->allocator(), *swapchain);
+    m_swapchain->recreate(m_window->get_width(), m_window->get_height());
+    m_frame_graph = std::make_unique<FrameGraph>(m_vkdevice->get_device(), m_command_pool->get(),
+                                                 m_vkdevice->allocator(), *m_swapchain);
     setup_frame_graph();
 
-    image_available_semaphore.reset();
-    rendering_finished_semaphore.reset();
-    image_available_semaphore =
-        std::make_unique<wrapper::Semaphore>(vkdevice->get_device(), "Image available semaphore");
-    rendering_finished_semaphore =
-        std::make_unique<wrapper::Semaphore>(vkdevice->get_device(), "Rendering finished semaphore");
-    vkDeviceWaitIdle(vkdevice->get_device());
+    m_image_available_semaphore.reset();
+    m_rendering_finished_semaphore.reset();
+    m_image_available_semaphore =
+        std::make_unique<wrapper::Semaphore>(m_vkdevice->get_device(), "Image available semaphore");
+    m_rendering_finished_semaphore =
+        std::make_unique<wrapper::Semaphore>(m_vkdevice->get_device(), "Rendering finished semaphore");
+    vkDeviceWaitIdle(m_vkdevice->get_device());
 
-    game_camera.type = Camera::CameraType::LOOKAT;
-    game_camera.rotation_speed = 0.25f;
-    game_camera.movement_speed = 0.1f;
-    game_camera.set_position({0.0f, 0.0f, 5.0f});
-    game_camera.set_rotation({0.0f, 0.0f, 0.0f});
-    game_camera.set_perspective(
-        45.0f, static_cast<float>(window->get_width()) / static_cast<float>(window->get_height()), 0.1f, 256.0f);
+    m_game_camera.m_type = Camera::CameraType::LOOKAT;
+    m_game_camera.m_rotation_speed = 0.25f;
+    m_game_camera.m_movement_speed = 0.1f;
+    m_game_camera.set_position({0.0f, 0.0f, 5.0f});
+    m_game_camera.set_rotation({0.0f, 0.0f, 0.0f});
+    m_game_camera.set_perspective(
+        45.0f, static_cast<float>(m_window->get_width()) / static_cast<float>(m_window->get_height()), 0.1f, 256.0f);
 }
 
 void VulkanRenderer::render_frame() {
-    if (window_resized) {
-        window_resized = false;
+    if (m_window_resized) {
+        m_window_resized = false;
         recreate_swapchain();
         return;
     }
 
-    const auto image_index = swapchain->acquire_next_image(*image_available_semaphore);
-    m_frame_graph->render(image_index, rendering_finished_semaphore->get(), image_available_semaphore->get(),
-                          vkdevice->get_graphics_queue());
+    const auto image_index = m_swapchain->acquire_next_image(*m_image_available_semaphore);
+    m_frame_graph->render(image_index, m_rendering_finished_semaphore->get(), m_image_available_semaphore->get(),
+                          m_vkdevice->get_graphics_queue());
 
     // TODO(): Create a queue wrapper class
     auto present_info = wrapper::make_info<VkPresentInfoKHR>();
     present_info.swapchainCount = 1;
     present_info.waitSemaphoreCount = 1;
     present_info.pImageIndices = &image_index;
-    present_info.pSwapchains = swapchain->get_swapchain_ptr();
-    present_info.pWaitSemaphores = rendering_finished_semaphore->get_ptr();
-    vkQueuePresentKHR(vkdevice->get_present_queue(), &present_info);
+    present_info.pSwapchains = m_swapchain->get_swapchain_ptr();
+    present_info.pWaitSemaphores = m_rendering_finished_semaphore->get_ptr();
+    vkQueuePresentKHR(m_vkdevice->get_present_queue(), &present_info);
 
-    if (auto fps_value = fps_counter.update()) {
-        window->set_title("Inexor Vulkan API renderer demo - " + std::to_string(*fps_value) + " FPS");
-        spdlog::debug("FPS: {}, window size: {} x {}.", *fps_value, window->get_width(), window->get_height());
+    if (auto fps_value = m_fps_counter.update()) {
+        m_window->set_title("Inexor Vulkan API renderer demo - " + std::to_string(*fps_value) + " FPS");
+        spdlog::debug("FPS: {}, window size: {} x {}.", *fps_value, m_window->get_width(), m_window->get_height());
     }
 }
 
 void VulkanRenderer::calculate_memory_budget() {
     VmaStats memory_stats;
-    vmaCalculateStats(vkdevice->allocator(), &memory_stats);
+    vmaCalculateStats(m_vkdevice->allocator(), &memory_stats);
 
     spdlog::debug("-------------VMA stats-------------");
     spdlog::debug("Number of `VkDeviceMemory` (physical memory) blocks allocated: {} still alive, {} in total",
@@ -170,30 +171,30 @@ void VulkanRenderer::calculate_memory_budget() {
     spdlog::debug("-------------VMA stats-------------");
 
     char *vma_stats_string = nullptr;
-    vmaBuildStatsString(vkdevice->allocator(), &vma_stats_string, VK_TRUE);
+    vmaBuildStatsString(m_vkdevice->allocator(), &vma_stats_string, VK_TRUE);
 
     std::string memory_dump_file_name = "vma-dumps/dump.json";
     std::ofstream vma_memory_dump(memory_dump_file_name, std::ios::out);
     vma_memory_dump.write(vma_stats_string, strlen(vma_stats_string));
     vma_memory_dump.close();
 
-    vmaFreeStatsString(vkdevice->allocator(), vma_stats_string);
+    vmaFreeStatsString(m_vkdevice->allocator(), vma_stats_string);
 }
 
 VulkanRenderer::~VulkanRenderer() {
     spdlog::debug("Shutting down vulkan renderer");
     // TODO: Add wrapper::Device::wait_idle()
-    vkDeviceWaitIdle(vkdevice->get_device());
+    vkDeviceWaitIdle(m_vkdevice->get_device());
 
-    if (!debug_report_callback_initialised) {
+    if (!m_debug_report_callback_initialised) {
         return;
     }
 
     // TODO(): Is there a better way to do this? Maybe add a helper function to wrapper::Instance?
     auto vk_destroy_debug_report_callback = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        vkGetInstanceProcAddr(vkinstance->get_instance(), "vkDestroyDebugReportCallbackEXT"));
+        vkGetInstanceProcAddr(m_vkinstance->get_instance(), "vkDestroyDebugReportCallbackEXT"));
     if (vk_destroy_debug_report_callback != nullptr) {
-        vk_destroy_debug_report_callback(vkinstance->get_instance(), debug_report_callback, nullptr);
+        vk_destroy_debug_report_callback(m_vkinstance->get_instance(), m_debug_report_callback, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -51,7 +51,7 @@ std::optional<VkSurfaceFormatKHR> VulkanSettingsDecisionMaker::decide_which_surf
     VkResult result =
         vkGetPhysicalDeviceSurfaceFormatsKHR(graphics_card, surface, &number_of_available_surface_formats, nullptr);
     if (result != VK_SUCCESS) {
-        std::string error_message = get_error_description_text(result);
+        std::string error_message = error_description_text(result);
         display_error_message(error_message);
         return std::nullopt;
     }
@@ -195,7 +195,7 @@ bool VulkanSettingsDecisionMaker::is_graphics_card_suitable(const VkPhysicalDevi
     return true;
 }
 
-VkPhysicalDeviceType VulkanSettingsDecisionMaker::get_graphics_card_type(const VkPhysicalDevice &graphics_card) {
+VkPhysicalDeviceType VulkanSettingsDecisionMaker::graphics_card_type(const VkPhysicalDevice &graphics_card) {
     assert(graphics_card);
 
     // The properties of the graphics card.
@@ -353,8 +353,8 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
         bool discrete_graphics_card_exists = false;
 
         // Both indices are available because number_of_available_graphics_cards is 2.
-        VkPhysicalDeviceType gpu_type_1 = get_graphics_card_type(available_graphics_cards[0]);
-        VkPhysicalDeviceType gpu_type_2 = get_graphics_card_type(available_graphics_cards[1]);
+        VkPhysicalDeviceType gpu_type_1 = graphics_card_type(available_graphics_cards[0]);
+        VkPhysicalDeviceType gpu_type_2 = graphics_card_type(available_graphics_cards[1]);
 
         if (VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_1 || VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_2) {
             discrete_graphics_card_exists = true;

--- a/src/vulkan-renderer/time_step.cpp
+++ b/src/vulkan-renderer/time_step.cpp
@@ -8,7 +8,7 @@ TimeStep::TimeStep() {
     m_last_time = std::chrono::high_resolution_clock::now();
 }
 
-float TimeStep::get_time_step() {
+float TimeStep::time_step() {
     auto current_time = std::chrono::high_resolution_clock::now();
 
     auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
@@ -18,7 +18,7 @@ float TimeStep::get_time_step() {
     return time_duration;
 }
 
-float TimeStep::get_time_step_since_initialisation() {
+float TimeStep::time_step_since_initialisation() {
     auto current_time = std::chrono::high_resolution_clock::now();
 
     auto time_duration =

--- a/src/vulkan-renderer/time_step.cpp
+++ b/src/vulkan-renderer/time_step.cpp
@@ -3,17 +3,17 @@
 namespace inexor::vulkan_renderer {
 
 TimeStep::TimeStep() {
-    initialisation_time = std::chrono::high_resolution_clock::now();
+    m_initialisation_time = std::chrono::high_resolution_clock::now();
 
-    last_time = std::chrono::high_resolution_clock::now();
+    m_last_time = std::chrono::high_resolution_clock::now();
 }
 
 float TimeStep::get_time_step() {
     auto current_time = std::chrono::high_resolution_clock::now();
 
-    auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - last_time).count();
+    auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
 
-    last_time = current_time;
+    m_last_time = current_time;
 
     return time_duration;
 }
@@ -22,7 +22,7 @@ float TimeStep::get_time_step_since_initialisation() {
     auto current_time = std::chrono::high_resolution_clock::now();
 
     auto time_duration =
-        std::chrono::duration<float, std::chrono::seconds::period>(current_time - initialisation_time).count();
+        std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_initialisation_time).count();
 
     return time_duration;
 }

--- a/src/vulkan-renderer/tools/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/cla_parser.cpp
@@ -8,16 +8,16 @@ namespace inexor::vulkan_renderer::tools {
 
 template <>
 int CommandLineArgumentValue::as() const {
-    return std::stoi(value);
+    return std::stoi(m_value);
 }
 
 template <>
 bool CommandLineArgumentValue::as() const {
-    if (value == "false") {
+    if (m_value == "false") {
         return false;
     }
 
-    if (value == "true") {
+    if (m_value == "true") {
         return true;
     }
 
@@ -32,12 +32,12 @@ std::uint32_t CommandLineArgumentValue::as() const {
 std::optional<CommandLineArgumentTemplate>
 CommandLineArgumentParser::get_arg_template(const std::string &argument_name) const {
     // clang-format off
-    auto it = std::find_if(accepted_args.begin(), accepted_args.end(), [&](const auto &accepted_arg) {
+    auto it = std::find_if(m_accepted_args.begin(), m_accepted_args.end(), [&](const auto &accepted_arg) {
         return argument_name == accepted_arg.get_argument();
     });
     // clang-format on
 
-    if (it == accepted_args.end()) {
+    if (it == m_accepted_args.end()) {
         return std::nullopt;
     }
 
@@ -56,7 +56,7 @@ void CommandLineArgumentParser::parse_args(int argc, char **argv) {
         }
 
         if (!arg_template->does_take_values()) {
-            parsed_arguments.insert(std::make_pair(arg_name, ""));
+            m_parsed_arguments.insert(std::make_pair(arg_name, ""));
             continue;
         }
 
@@ -66,7 +66,7 @@ void CommandLineArgumentParser::parse_args(int argc, char **argv) {
 
         // NOLINTNEXTLINE
         std::string arg_value(argv[++i]);
-        parsed_arguments.insert(std::make_pair(arg_name, arg_value));
+        m_parsed_arguments.insert(std::make_pair(arg_name, arg_value));
     }
 }
 

--- a/src/vulkan-renderer/tools/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/cla_parser.cpp
@@ -30,10 +30,10 @@ std::uint32_t CommandLineArgumentValue::as() const {
 }
 
 std::optional<CommandLineArgumentTemplate>
-CommandLineArgumentParser::get_arg_template(const std::string &argument_name) const {
+CommandLineArgumentParser::make_arg_template(const std::string &argument_name) const {
     // clang-format off
     auto it = std::find_if(m_accepted_args.begin(), m_accepted_args.end(), [&](const auto &accepted_arg) {
-        return argument_name == accepted_arg.get_argument();
+        return argument_name == accepted_arg.argument();
     });
     // clang-format on
 
@@ -48,14 +48,14 @@ void CommandLineArgumentParser::parse_args(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         // NOLINTNEXTLINE
         std::string arg_name(argv[i]);
-        auto arg_template = get_arg_template(arg_name);
+        auto arg_template = make_arg_template(arg_name);
 
         if (!arg_template) {
             spdlog::warn("Unknown command line argument {}!", arg_name);
             continue;
         }
 
-        if (!arg_template->does_take_values()) {
+        if (!arg_template->takes_values()) {
             m_parsed_arguments.insert(std::make_pair(arg_name, ""));
             continue;
         }

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -8,11 +8,11 @@
 namespace inexor::vulkan_renderer::tools {
 
 const std::size_t File::get_file_size() const {
-    return file_size;
+    return m_file_size;
 }
 
 const std::vector<char> &File::get_file_data() const {
-    return file_data;
+    return m_file_data;
 }
 
 bool File::load_file(const std::string &file_name) {
@@ -25,16 +25,16 @@ bool File::load_file(const std::string &file_name) {
         spdlog::debug("File {} has been opened.", file_name);
 
         // Read the size of the file.
-        file_size = file_to_load.tellg();
+        m_file_size = file_to_load.tellg();
 
         // Preallocate memory for the file buffer.
-        file_data.resize(file_size);
+        m_file_data.resize(m_file_size);
 
         // Reset the file read position to the beginning of the file.
         file_to_load.seekg(0, std::ios::beg);
 
         // Read the file data.
-        file_to_load.read(file_data.data(), file_size);
+        file_to_load.read(m_file_data.data(), m_file_size);
 
         // Close the file stream.
         file_to_load.close();

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -7,11 +7,11 @@
 
 namespace inexor::vulkan_renderer::tools {
 
-const std::size_t File::get_file_size() const {
+const std::size_t File::file_size() const {
     return m_file_size;
 }
 
-const std::vector<char> &File::get_file_data() const {
+const std::vector<char> &File::file_data() const {
     return m_file_data;
 }
 

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -30,7 +30,7 @@ void CommandBuffer::begin(VkCommandBufferUsageFlags flags) const {
 
 void CommandBuffer::bind_descriptor(const Descriptor &descriptor, VkPipelineLayout layout) const {
     vkCmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1,
-                            descriptor.get_descriptor_sets_data(), 0, nullptr);
+                            descriptor.descriptor_sets_data(), 0, nullptr);
 }
 
 void CommandBuffer::end() const {

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -4,9 +4,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-CommandPool::CommandPool(CommandPool &&other) noexcept
-    : m_device(other.m_device), m_command_pool(std::exchange(other.m_command_pool, nullptr)) {}
-
 CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family_index) : m_device(device) {
     assert(device);
 
@@ -22,6 +19,9 @@ CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family
 
     spdlog::debug("Created command pool successfully.");
 }
+
+CommandPool::CommandPool(CommandPool &&other) noexcept
+    : m_device(other.m_device), m_command_pool(std::exchange(other.m_command_pool, nullptr)) {}
 
 CommandPool::~CommandPool() {
     vkDestroyCommandPool(m_device, m_command_pool, nullptr);

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -5,16 +5,16 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 CommandPool::CommandPool(CommandPool &&other) noexcept
-    : device(other.device), command_pool(std::exchange(other.command_pool, nullptr)) {}
+    : m_device(other.m_device), m_command_pool(std::exchange(other.m_command_pool, nullptr)) {}
 
-CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family_index) : device(device) {
+CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family_index) : m_device(device) {
     assert(device);
 
     auto command_pool_ci = make_info<VkCommandPoolCreateInfo>();
     command_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     command_pool_ci.queueFamilyIndex = queue_family_index;
 
-    if (vkCreateCommandPool(device, &command_pool_ci, nullptr, &command_pool) != VK_SUCCESS) {
+    if (vkCreateCommandPool(device, &command_pool_ci, nullptr, &m_command_pool) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateCommandPool failed!");
     }
 
@@ -24,7 +24,7 @@ CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family
 }
 
 CommandPool::~CommandPool() {
-    vkDestroyCommandPool(device, command_pool, nullptr);
+    vkDestroyCommandPool(m_device, m_command_pool, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -9,6 +9,10 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+Descriptor::Descriptor(const VkDevice device, const std::uint32_t number_of_images_in_swapchain,
+                       const std::string &name)
+    : m_device(device), m_number_of_images_in_swapchain(number_of_images_in_swapchain), m_name(name) {}
+
 Descriptor::Descriptor(Descriptor &&other) noexcept
     : m_name(std::move(other.m_name)), m_number_of_images_in_swapchain(other.m_number_of_images_in_swapchain),
       m_descriptor_sets(std::move(other.m_descriptor_sets)),
@@ -17,9 +21,12 @@ Descriptor::Descriptor(Descriptor &&other) noexcept
       m_descriptor_set_layout(std::exchange(other.m_descriptor_set_layout, nullptr)),
       m_descriptor_pool(std::exchange(other.m_descriptor_pool, nullptr)), m_device(other.m_device) {}
 
-Descriptor::Descriptor(const VkDevice device, const std::uint32_t number_of_images_in_swapchain,
-                       const std::string &name)
-    : m_device(device), m_number_of_images_in_swapchain(number_of_images_in_swapchain), m_name(name) {}
+Descriptor::~Descriptor() {
+    assert(m_device);
+    spdlog::trace("Destroying descriptor {}.", m_name);
+
+    reset(true);
+}
 
 void Descriptor::create_descriptor_pool(const std::initializer_list<VkDescriptorType> descriptor_pool_types) {
     assert(m_device);
@@ -148,13 +155,6 @@ void Descriptor::create_descriptor_sets() {
     }
 
     spdlog::debug("Created descriptor sets for descriptor {} successfully.", m_name);
-}
-
-Descriptor::~Descriptor() {
-    assert(m_device);
-    spdlog::trace("Destroying descriptor {}.", m_name);
-
-    reset(true);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -32,10 +32,6 @@ constexpr float default_queue_priority = 1.0f;
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Device::Device(Device &&other) noexcept
-    : m_device(std::exchange(other.m_device, nullptr)), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)) {
-}
-
 Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
                bool prefer_distinct_transfer_queue, const std::optional<std::uint32_t> preferred_physical_device_index)
     : m_surface(surface) {
@@ -301,6 +297,10 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
     }
 
     spdlog::debug("Created device successfully.");
+}
+
+Device::Device(Device &&other) noexcept
+    : m_device(std::exchange(other.m_device, nullptr)), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)) {
 }
 
 Device::~Device() {

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -9,10 +9,10 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Fence::Fence(Fence &&other) noexcept
-    : device(other.device), fence(std::exchange(other.fence, nullptr)), name(std::move(other.name)) {}
+    : m_device(other.m_device), m_fence(std::exchange(other.m_fence, nullptr)), m_name(std::move(other.m_name)) {}
 
 Fence::Fence(const VkDevice device, const std::string &name, const bool in_signaled_state)
-    : device(device), name(name) {
+    : m_device(device), m_name(name) {
     assert(device);
     assert(!name.empty());
 
@@ -21,7 +21,7 @@ Fence::Fence(const VkDevice device, const std::string &name, const bool in_signa
 
     spdlog::debug("Creating Vulkan synchronisation fence {}.", name);
 
-    if (vkCreateFence(device, &fence_ci, nullptr, &fence) != VK_SUCCESS) {
+    if (vkCreateFence(device, &fence_ci, nullptr, &m_fence) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateFence failed!");
     }
 
@@ -31,20 +31,20 @@ Fence::Fence(const VkDevice device, const std::string &name, const bool in_signa
 }
 
 Fence::~Fence() {
-    spdlog::trace("Destroying fence {}.", name);
-    vkDestroyFence(device, fence, nullptr);
+    spdlog::trace("Destroying fence {}.", m_name);
+    vkDestroyFence(m_device, m_fence, nullptr);
 }
 
 void Fence::block(std::uint64_t timeout_limit) const {
-    assert(device);
-    assert(fence);
-    vkWaitForFences(device, 1, &fence, VK_TRUE, timeout_limit);
+    assert(m_device);
+    assert(m_fence);
+    vkWaitForFences(m_device, 1, &m_fence, VK_TRUE, timeout_limit);
 }
 
 void Fence::reset() const {
-    assert(device);
-    assert(fence);
-    vkResetFences(device, 1, &fence);
+    assert(m_device);
+    assert(m_fence);
+    vkResetFences(m_device, 1, &m_fence);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -8,9 +8,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Fence::Fence(Fence &&other) noexcept
-    : m_device(other.m_device), m_fence(std::exchange(other.m_fence, nullptr)), m_name(std::move(other.m_name)) {}
-
 Fence::Fence(const VkDevice device, const std::string &name, const bool in_signaled_state)
     : m_device(device), m_name(name) {
     assert(device);
@@ -29,6 +26,9 @@ Fence::Fence(const VkDevice device, const std::string &name, const bool in_signa
 
     spdlog::debug("Created fence successfully.");
 }
+
+Fence::Fence(Fence &&other) noexcept
+    : m_device(other.m_device), m_fence(std::exchange(other.m_fence, nullptr)), m_name(std::move(other.m_name)) {}
 
 Fence::~Fence() {
     spdlog::trace("Destroying fence {}.", m_name);

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -17,8 +17,8 @@ Framebuffer::Framebuffer(VkDevice device, VkRenderPass render_pass, const std::v
     auto framebuffer_ci = make_info<VkFramebufferCreateInfo>();
     framebuffer_ci.attachmentCount = static_cast<std::uint32_t>(attachments.size());
     framebuffer_ci.pAttachments = attachments.data();
-    framebuffer_ci.width = swapchain.get_extent().width;
-    framebuffer_ci.height = swapchain.get_extent().height;
+    framebuffer_ci.width = swapchain.extent().width;
+    framebuffer_ci.height = swapchain.extent().height;
     framebuffer_ci.layers = 1;
     framebuffer_ci.renderPass = render_pass;
 

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -8,11 +8,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
-    : m_name(std::move(other.m_name)), m_device(std::exchange(other.m_device, nullptr)),
-      m_buffer(std::exchange(other.m_buffer, nullptr)), m_allocation(std::exchange(other.m_allocation, nullptr)),
-      m_allocation_info(std::move(other.m_allocation_info)), m_allocation_ci(std::move(other.m_allocation_ci)) {}
-
 GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                                  const VkDeviceSize &size, const VkBufferUsageFlags &buffer_usage,
                                  const VmaMemoryUsage &memory_usage)
@@ -78,6 +73,11 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
     // Copy the memory into the buffer!
     std::memcpy(m_allocation_info.pMappedData, data, data_size);
 }
+
+GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
+    : m_name(std::move(other.m_name)), m_device(std::exchange(other.m_device, nullptr)),
+      m_buffer(std::exchange(other.m_buffer, nullptr)), m_allocation(std::exchange(other.m_allocation, nullptr)),
+      m_allocation_info(std::move(other.m_allocation_info)), m_allocation_ci(std::move(other.m_allocation_ci)) {}
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
     spdlog::trace("Destroying GPU memory buffer.");

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -9,14 +9,14 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
-    : name(std::move(name)), device(std::exchange(other.device, nullptr)), buffer(std::exchange(other.buffer, nullptr)),
-      allocation(std::exchange(other.allocation, nullptr)), allocation_info(std::move(other.allocation_info)),
-      allocation_ci(std::move(other.allocation_ci)) {}
+    : m_name(std::move(other.m_name)), m_device(std::exchange(other.m_device, nullptr)),
+      m_buffer(std::exchange(other.m_buffer, nullptr)), m_allocation(std::exchange(other.m_allocation, nullptr)),
+      m_allocation_info(std::move(other.m_allocation_info)), m_allocation_ci(std::move(other.m_allocation_ci)) {}
 
 GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                                  const VkDeviceSize &size, const VkBufferUsageFlags &buffer_usage,
                                  const VmaMemoryUsage &memory_usage)
-    : device(device), vma_allocator(vma_allocator), name(name), buffer_size(size) {
+    : m_device(device), m_vma_allocator(vma_allocator), m_name(name), m_buffer_size(size) {
     assert(device);
     assert(vma_allocator);
     assert(!name.empty());
@@ -28,20 +28,20 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
     buffer_ci.usage = buffer_usage;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    allocation_ci.usage = memory_usage;
+    m_allocation_ci.usage = memory_usage;
 
 #if VMA_RECORDING_ENABLED
-    allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT;
-    allocation_ci.pUserData = this->name.data();
+    m_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT;
+    m_allocation_ci.pUserData = m_name.data();
 #else
-    allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    m_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 #endif
 
     // TODO: Should we create this buffer as mapped?
     // TODO: Is it good to have memory mapped all the time?
     // TODO: When should memory be mapped / unmapped?
 
-    if (vmaCreateBuffer(vma_allocator, &buffer_ci, &allocation_ci, &buffer, &allocation, &allocation_info)) {
+    if (vmaCreateBuffer(vma_allocator, &buffer_ci, &m_allocation_ci, &m_buffer, &m_allocation, &m_allocation_info)) {
         throw std::runtime_error("Error: GPU memory buffer allocation for " + name + " failed!");
     }
 
@@ -54,7 +54,7 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
         // debugging.
         auto name_info = make_info<VkDebugMarkerObjectNameInfoEXT>();
         name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;
-        name_info.object = reinterpret_cast<std::uint64_t>(buffer);
+        name_info.object = reinterpret_cast<std::uint64_t>(m_buffer);
         name_info.pObjectName = name.c_str();
 
         spdlog::debug("Assigning internal name '{}' to GPU memory buffer.", name);
@@ -76,12 +76,12 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
     assert(data);
 
     // Copy the memory into the buffer!
-    std::memcpy(allocation_info.pMappedData, data, data_size);
+    std::memcpy(m_allocation_info.pMappedData, data, data_size);
 }
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
     spdlog::trace("Destroying GPU memory buffer.");
-    vmaDestroyBuffer(vma_allocator, buffer, allocation);
+    vmaDestroyBuffer(m_vma_allocator, m_buffer, m_allocation);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -7,14 +7,14 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Image::Image(Image &&other) noexcept
-    : device(other.device), vma_allocator(other.vma_allocator), allocation(other.allocation),
-      allocation_info(other.allocation_info), image(other.image), format(other.format), image_view(other.image_view),
-      name(std::move(other.name)) {}
+    : m_device(other.m_device), m_vma_allocator(other.m_vma_allocator), m_allocation(other.m_allocation),
+      m_allocation_info(other.m_allocation_info), m_image(other.m_image), m_format(other.m_format),
+      m_image_view(other.m_image_view), m_name(std::move(other.m_name)) {}
 
 Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
              const VkFormat format, const VkImageUsageFlags image_usage, const VkImageAspectFlags aspect_flags,
              const VkSampleCountFlagBits sample_count, const std::string &name, const VkExtent2D image_extent)
-    : device(device), vma_allocator(vma_allocator), format(format), name(name) {
+    : m_device(device), m_vma_allocator(vma_allocator), m_format(format), m_name(name) {
     assert(device);
     assert(graphics_card);
     assert(vma_allocator);
@@ -41,12 +41,12 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
 
 #if VMA_RECORDING_ENABLED
     vma_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT | VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT;
-    vma_allocation_ci.pUserData = this->name.data();
+    vma_allocation_ci.pUserData = m_name.data();
 #else
     vma_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
 #endif
 
-    if (vmaCreateImage(vma_allocator, &image_ci, &vma_allocation_ci, &image, &allocation, &allocation_info) !=
+    if (vmaCreateImage(vma_allocator, &image_ci, &vma_allocation_ci, &m_image, &m_allocation, &m_allocation_info) !=
         VK_SUCCESS) {
         throw std::runtime_error("Error: vmaCreateImage failed for depth buffer images!");
     }
@@ -54,7 +54,7 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
     // TODO: Assign an internal name using Vulkan debug markers.
 
     auto image_view_ci = make_info<VkImageViewCreateInfo>();
-    image_view_ci.image = image;
+    image_view_ci.image = m_image;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_ci.format = format;
     image_view_ci.subresourceRange.aspectMask = aspect_flags;
@@ -63,7 +63,7 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
     image_view_ci.subresourceRange.baseArrayLayer = 0;
     image_view_ci.subresourceRange.layerCount = 1;
 
-    if (vkCreateImageView(device, &image_view_ci, nullptr, &image_view) != VK_SUCCESS) {
+    if (vkCreateImageView(device, &image_view_ci, nullptr, &m_image_view) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateImageView failed!");
     }
 
@@ -71,11 +71,11 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
 }
 
 Image::~Image() {
-    spdlog::trace("Destroying image view {} .", name);
-    vkDestroyImageView(device, image_view, nullptr);
+    spdlog::trace("Destroying image view {} .", m_name);
+    vkDestroyImageView(m_device, m_image_view, nullptr);
 
-    spdlog::trace("Destroying image {} .", name);
-    vmaDestroyImage(vma_allocator, image, allocation);
+    spdlog::trace("Destroying image {} .", m_name);
+    vmaDestroyImage(m_vma_allocator, m_image, m_allocation);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -6,11 +6,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Image::Image(Image &&other) noexcept
-    : m_device(other.m_device), m_vma_allocator(other.m_vma_allocator), m_allocation(other.m_allocation),
-      m_allocation_info(other.m_allocation_info), m_image(other.m_image), m_format(other.m_format),
-      m_image_view(other.m_image_view), m_name(std::move(other.m_name)) {}
-
 Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
              const VkFormat format, const VkImageUsageFlags image_usage, const VkImageAspectFlags aspect_flags,
              const VkSampleCountFlagBits sample_count, const std::string &name, const VkExtent2D image_extent)
@@ -69,6 +64,11 @@ Image::Image(const VkDevice device, const VkPhysicalDevice graphics_card, const 
 
     // TODO: Assign an internal name using Vulkan debug markers.
 }
+
+Image::Image(Image &&other) noexcept
+    : m_device(other.m_device), m_vma_allocator(other.m_vma_allocator), m_allocation(other.m_allocation),
+      m_allocation_info(other.m_allocation_info), m_image(other.m_image), m_format(other.m_format),
+      m_image_view(other.m_image_view), m_name(std::move(other.m_name)) {}
 
 Image::~Image() {
     spdlog::trace("Destroying image view {} .", m_name);

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -10,7 +10,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Instance::Instance(Instance &&other) noexcept : instance(std::exchange(other.instance, nullptr)) {}
+Instance::Instance(Instance &&other) noexcept : m_instance(std::exchange(other.m_instance, nullptr)) {}
 
 Instance::Instance(const std::string &application_name, const std::string &engine_name,
                    const std::uint32_t application_version, const std::uint32_t engine_version,
@@ -78,7 +78,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
 
     // We are not checking for duplicated entries but this is no problem.
     for (const auto &instance_extension : instance_extension_wishlist) {
-        if (availability_checks.has_instance_extension(instance_extension)) {
+        if (m_availability_checks.has_instance_extension(instance_extension)) {
             spdlog::debug("Adding '{}' to list of enabled instance extensions.", instance_extension);
             enabled_instance_extensions.push_back(instance_extension);
         } else {
@@ -125,7 +125,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     // We have to check which instance layers of our wishlist are available on the current system!
     // We are not checking for duplicated entries but this is no problem.
     for (const auto &current_layer : instance_layers_wishlist) {
-        if (availability_checks.has_instance_layer(current_layer)) {
+        if (m_availability_checks.has_instance_layer(current_layer)) {
             spdlog::debug("Adding '{}' to list of enabled instance layers.", current_layer);
             enabled_instance_layers.push_back(current_layer);
         } else {
@@ -146,7 +146,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     instance_ci.ppEnabledLayerNames = enabled_instance_layers.data();
     instance_ci.enabledLayerCount = static_cast<std::uint32_t>(enabled_instance_layers.size());
 
-    if (vkCreateInstance(&instance_ci, nullptr, &instance) != VK_SUCCESS) {
+    if (vkCreateInstance(&instance_ci, nullptr, &m_instance) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateInstance failed!");
     }
 
@@ -163,7 +163,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
 }
 
 Instance::~Instance() {
-    vkDestroyInstance(instance, nullptr);
+    vkDestroyInstance(m_instance, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -10,8 +10,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Instance::Instance(Instance &&other) noexcept : m_instance(std::exchange(other.m_instance, nullptr)) {}
-
 Instance::Instance(const std::string &application_name, const std::string &engine_name,
                    const std::uint32_t application_version, const std::uint32_t engine_version,
                    const std::uint32_t vulkan_api_version, std::vector<std::string> requested_instance_extensions,
@@ -161,6 +159,8 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     spdlog::debug("No instance extensions or instance layers specified.");
     spdlog::debug("Validation layers are requested. RenderDoc instance layer is not requested.");
 }
+
+Instance::Instance(Instance &&other) noexcept : m_instance(std::exchange(other.m_instance, nullptr)) {}
 
 Instance::~Instance() {
     vkDestroyInstance(m_instance, nullptr);

--- a/src/vulkan-renderer/wrapper/mesh_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/mesh_buffer.cpp
@@ -5,11 +5,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-MeshBuffer::MeshBuffer(MeshBuffer &&other) noexcept
-    : m_name(std::move(other.m_name)), m_vertex_buffer(std::move(other.m_vertex_buffer)),
-      m_index_buffer(std::move(other.m_index_buffer)), m_number_of_vertices(other.m_number_of_vertices),
-      m_number_of_indices(other.m_number_of_indices) {}
-
 MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                        const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
                        const std::string &name, const VkDeviceSize size_of_vertex_structure,
@@ -93,6 +88,11 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
 
     staging_buffer_for_vertices.upload_data_to_gpu(m_vertex_buffer);
 }
+
+MeshBuffer::MeshBuffer(MeshBuffer &&other) noexcept
+    : m_name(std::move(other.m_name)), m_vertex_buffer(std::move(other.m_vertex_buffer)),
+      m_index_buffer(std::move(other.m_index_buffer)), m_number_of_vertices(other.m_number_of_vertices),
+      m_number_of_indices(other.m_number_of_indices) {}
 
 MeshBuffer::~MeshBuffer() {}
 

--- a/src/vulkan-renderer/wrapper/mesh_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/mesh_buffer.cpp
@@ -6,9 +6,9 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 MeshBuffer::MeshBuffer(MeshBuffer &&other) noexcept
-    : name(std::move(other.name)), vertex_buffer(std::move(other.vertex_buffer)),
-      index_buffer(std::move(other.index_buffer)), number_of_vertices(other.number_of_vertices),
-      number_of_indices(other.number_of_indices) {}
+    : m_name(std::move(other.m_name)), m_vertex_buffer(std::move(other.m_vertex_buffer)),
+      m_index_buffer(std::move(other.m_index_buffer)), m_number_of_vertices(other.m_number_of_vertices),
+      m_number_of_indices(other.m_number_of_indices) {}
 
 MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                        const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
@@ -18,11 +18,11 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
 
     // It's no problem to create the vertex buffer and index buffer before the corresponding staging buffers are
     // created!.
-    : vertex_buffer(device, vma_allocator, name, size_of_vertex_structure * number_of_vertices,
-                    VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
-      index_buffer(GPUMemoryBuffer(device, vma_allocator, name, size_of_index_structure * number_of_vertices,
-                                   VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-                                   VMA_MEMORY_USAGE_CPU_ONLY)) {
+    : m_vertex_buffer(device, vma_allocator, name, size_of_vertex_structure * number_of_vertices,
+                      VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
+      m_index_buffer(GPUMemoryBuffer(device, vma_allocator, name, size_of_index_structure * number_of_vertices,
+                                     VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                                     VMA_MEMORY_USAGE_CPU_ONLY)) {
     assert(device);
     assert(vma_allocator);
     assert(!name.empty());
@@ -47,7 +47,7 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                                               data_transfer_queue_family_index, name, vertex_buffer_size, vertices,
                                               vertices_memory_size);
 
-    staging_buffer_for_vertices.upload_data_to_gpu(vertex_buffer);
+    staging_buffer_for_vertices.upload_data_to_gpu(m_vertex_buffer);
 
     if (number_of_indices > 0) {
         VkDeviceSize indices_memory_size = number_of_indices * size_of_index_structure;
@@ -56,7 +56,7 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                                                  data_transfer_queue_family_index, name, index_buffer_size, indices,
                                                  indices_memory_size);
 
-        staging_buffer_for_indices.upload_data_to_gpu(*index_buffer);
+        staging_buffer_for_indices.upload_data_to_gpu(*m_index_buffer);
     } else {
         spdlog::warn("No index buffer created for mesh {}", name);
     }
@@ -68,10 +68,10 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                        const std::size_t number_of_vertices, void *vertices)
     // It's no problem to create the vertex buffer and index buffer before the corresponding staging buffers are
     // created!.
-    : vertex_buffer(device, vma_allocator, name, size_of_vertex_structure * number_of_vertices,
-                    VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
-      index_buffer(std::nullopt), number_of_vertices(static_cast<std::uint32_t>(number_of_vertices)),
-      number_of_indices(static_cast<std::uint32_t>(number_of_indices)) {
+    : m_vertex_buffer(device, vma_allocator, name, size_of_vertex_structure * number_of_vertices,
+                      VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
+      m_index_buffer(std::nullopt), m_number_of_vertices(static_cast<std::uint32_t>(number_of_vertices)),
+      m_number_of_indices(static_cast<std::uint32_t>(m_number_of_indices)) {
     assert(device);
     assert(vma_allocator);
     assert(!name.empty());
@@ -91,7 +91,7 @@ MeshBuffer::MeshBuffer(const VkDevice device, VkQueue data_transfer_queue,
                                               data_transfer_queue_family_index, name, size_of_vertex_buffer, vertices,
                                               vertices_memory_size);
 
-    staging_buffer_for_vertices.upload_data_to_gpu(vertex_buffer);
+    staging_buffer_for_vertices.upload_data_to_gpu(m_vertex_buffer);
 }
 
 MeshBuffer::~MeshBuffer() {}

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -11,44 +11,46 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept
-    : device(other.device), command_pool(std::move(other.command_pool)),
-      command_buffer(std::exchange(other.command_buffer, nullptr)), data_transfer_queue(other.data_transfer_queue),
-      recording_started(other.recording_started), command_buffer_created(other.command_buffer_created) {}
+    : m_device(other.m_device), m_command_pool(std::move(other.m_command_pool)),
+      m_command_buffer(std::exchange(other.m_command_buffer, nullptr)),
+      m_data_transfer_queue(other.m_data_transfer_queue), m_recording_started(other.m_recording_started),
+      m_command_buffer_created(other.m_command_buffer_created) {}
 
 OnceCommandBuffer::OnceCommandBuffer(const VkDevice device, const VkQueue data_transfer_queue,
                                      const std::uint32_t data_transfer_queue_family_index)
-    : device(device), data_transfer_queue(data_transfer_queue), command_pool(device, data_transfer_queue_family_index) {
+    : m_device(device), m_data_transfer_queue(data_transfer_queue),
+      m_command_pool(device, data_transfer_queue_family_index) {
 
     assert(device);
     assert(data_transfer_queue);
-    command_buffer_created = false;
-    recording_started = false;
+    m_command_buffer_created = false;
+    m_recording_started = false;
 }
 
 OnceCommandBuffer::~OnceCommandBuffer() {
-    command_buffer.reset();
-    command_buffer_created = false;
-    recording_started = false;
+    m_command_buffer.reset();
+    m_command_buffer_created = false;
+    m_recording_started = false;
 }
 
 void OnceCommandBuffer::create_command_buffer() {
-    assert(device);
-    assert(command_pool.get());
-    assert(data_transfer_queue);
-    assert(!recording_started);
-    assert(!command_buffer_created);
+    assert(m_device);
+    assert(m_command_pool.get());
+    assert(m_data_transfer_queue);
+    assert(!m_recording_started);
+    assert(!m_command_buffer_created);
 
-    command_buffer = std::make_unique<wrapper::CommandBuffer>(device, command_pool.get());
+    m_command_buffer = std::make_unique<wrapper::CommandBuffer>(m_device, m_command_pool.get());
 
-    command_buffer_created = true;
+    m_command_buffer_created = true;
 }
 
 void OnceCommandBuffer::start_recording() {
-    assert(device);
-    assert(command_pool.get());
-    assert(data_transfer_queue);
-    assert(command_buffer_created);
-    assert(!recording_started);
+    assert(m_device);
+    assert(m_command_pool.get());
+    assert(m_data_transfer_queue);
+    assert(m_command_buffer_created);
+    assert(!m_recording_started);
 
     spdlog::debug("Starting recording of once command buffer.");
 
@@ -59,26 +61,26 @@ void OnceCommandBuffer::start_recording() {
     // VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT.
     command_buffer_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
-    if (vkBeginCommandBuffer(command_buffer->get(), &command_buffer_bi) != VK_SUCCESS) {
+    if (vkBeginCommandBuffer(m_command_buffer->get(), &command_buffer_bi) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkBeginCommandBuffer failed for once command buffer!");
     }
 
-    recording_started = true;
+    m_recording_started = true;
 
     // TODO: Set object name using Vulkan debug markers.
 }
 
 void OnceCommandBuffer::end_recording_and_submit_command() {
-    assert(device);
-    assert(command_pool.get());
-    assert(command_buffer);
-    assert(data_transfer_queue);
-    assert(command_buffer_created);
-    assert(recording_started);
+    assert(m_device);
+    assert(m_command_pool.get());
+    assert(m_command_buffer);
+    assert(m_data_transfer_queue);
+    assert(m_command_buffer_created);
+    assert(m_recording_started);
 
     spdlog::debug("Ending recording of once command buffer.");
 
-    if (vkEndCommandBuffer(command_buffer->get()) != VK_SUCCESS) {
+    if (vkEndCommandBuffer(m_command_buffer->get()) != VK_SUCCESS) {
         throw std::runtime_error("Error: VkEndCommandBuffer failed for once command buffer!");
     }
 
@@ -88,25 +90,25 @@ void OnceCommandBuffer::end_recording_and_submit_command() {
 
     auto submit_info = make_info<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
-    submit_info.pCommandBuffers = command_buffer->get_ptr();
+    submit_info.pCommandBuffers = m_command_buffer->get_ptr();
 
-    if (vkQueueSubmit(data_transfer_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
+    if (vkQueueSubmit(m_data_transfer_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkQueueSubmit failed for once command buffer!");
     }
 
     // TODO: Refactor! Introduce proper synchronisation using VkFence!
-    if (vkQueueWaitIdle(data_transfer_queue) != VK_SUCCESS) {
+    if (vkQueueWaitIdle(m_data_transfer_queue) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkQueueWaitIdle failed for once command buffer!");
     }
 
     spdlog::debug("Destroying once command buffer.");
 
     // Because we destroy the command buffer after submission, we have to allocate it every time.
-    vkFreeCommandBuffers(device, command_pool.get(), 1, command_buffer->get_ptr());
+    vkFreeCommandBuffers(m_device, m_command_pool.get(), 1, m_command_buffer->get_ptr());
 
-    command_buffer_created = false;
+    m_command_buffer_created = false;
 
-    recording_started = false;
+    m_recording_started = false;
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -90,7 +90,7 @@ void OnceCommandBuffer::end_recording_and_submit_command() {
 
     auto submit_info = make_info<VkSubmitInfo>();
     submit_info.commandBufferCount = 1;
-    submit_info.pCommandBuffers = m_command_buffer->get_ptr();
+    submit_info.pCommandBuffers = m_command_buffer->ptr();
 
     if (vkQueueSubmit(m_data_transfer_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkQueueSubmit failed for once command buffer!");
@@ -104,7 +104,7 @@ void OnceCommandBuffer::end_recording_and_submit_command() {
     spdlog::debug("Destroying once command buffer.");
 
     // Because we destroy the command buffer after submission, we have to allocate it every time.
-    vkFreeCommandBuffers(m_device, m_command_pool.get(), 1, m_command_buffer->get_ptr());
+    vkFreeCommandBuffers(m_device, m_command_pool.get(), 1, m_command_buffer->ptr());
 
     m_command_buffer_created = false;
 

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -10,12 +10,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept
-    : m_device(other.m_device), m_command_pool(std::move(other.m_command_pool)),
-      m_command_buffer(std::exchange(other.m_command_buffer, nullptr)),
-      m_data_transfer_queue(other.m_data_transfer_queue), m_recording_started(other.m_recording_started),
-      m_command_buffer_created(other.m_command_buffer_created) {}
-
 OnceCommandBuffer::OnceCommandBuffer(const VkDevice device, const VkQueue data_transfer_queue,
                                      const std::uint32_t data_transfer_queue_family_index)
     : m_device(device), m_data_transfer_queue(data_transfer_queue),
@@ -26,6 +20,12 @@ OnceCommandBuffer::OnceCommandBuffer(const VkDevice device, const VkQueue data_t
     m_command_buffer_created = false;
     m_recording_started = false;
 }
+
+OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept
+    : m_device(other.m_device), m_command_pool(std::move(other.m_command_pool)),
+      m_command_buffer(std::exchange(other.m_command_buffer, nullptr)),
+      m_data_transfer_queue(other.m_data_transfer_queue), m_recording_started(other.m_recording_started),
+      m_command_buffer_created(other.m_command_buffer_created) {}
 
 OnceCommandBuffer::~OnceCommandBuffer() {
     m_command_buffer.reset();

--- a/src/vulkan-renderer/wrapper/pipeline_layout.cpp
+++ b/src/vulkan-renderer/wrapper/pipeline_layout.cpp
@@ -9,12 +9,12 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 PipelineLayout::PipelineLayout(PipelineLayout &&other) noexcept
-    : device(other.device), pipeline_layout(std::exchange(other.pipeline_layout, nullptr)),
-      name(std::move(other.name)) {}
+    : m_device(other.m_device), m_pipeline_layout(std::exchange(other.m_pipeline_layout, nullptr)),
+      m_name(std::move(other.m_name)) {}
 
 PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescriptorSetLayout> &descriptor_set_layouts,
                                const std::string &name)
-    : device(device), name(name) {
+    : m_device(device), m_name(name) {
     assert(device);
     assert(!descriptor_set_layouts.empty());
     assert(!name.empty());
@@ -25,7 +25,7 @@ PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescri
 
     spdlog::debug("Creating pipeline layout {}.", name);
 
-    if (vkCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &pipeline_layout)) {
+    if (vkCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &m_pipeline_layout)) {
         throw std::runtime_error("Error: vkCreatePipelineLayout failed for " + name + " !");
     }
 
@@ -35,8 +35,8 @@ PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescri
 }
 
 PipelineLayout::~PipelineLayout() {
-    spdlog::trace("Destroying pipeline layout {}.", name);
-    vkDestroyPipelineLayout(device, pipeline_layout, nullptr);
+    spdlog::trace("Destroying pipeline layout {}.", m_name);
+    vkDestroyPipelineLayout(m_device, m_pipeline_layout, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/pipeline_layout.cpp
+++ b/src/vulkan-renderer/wrapper/pipeline_layout.cpp
@@ -8,10 +8,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-PipelineLayout::PipelineLayout(PipelineLayout &&other) noexcept
-    : m_device(other.m_device), m_pipeline_layout(std::exchange(other.m_pipeline_layout, nullptr)),
-      m_name(std::move(other.m_name)) {}
-
 PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescriptorSetLayout> &descriptor_set_layouts,
                                const std::string &name)
     : m_device(device), m_name(name) {
@@ -33,6 +29,10 @@ PipelineLayout::PipelineLayout(const VkDevice device, const std::vector<VkDescri
 
     spdlog::debug("Created pipeline layout successfully.");
 }
+
+PipelineLayout::PipelineLayout(PipelineLayout &&other) noexcept
+    : m_device(other.m_device), m_pipeline_layout(std::exchange(other.m_pipeline_layout, nullptr)),
+      m_name(std::move(other.m_name)) {}
 
 PipelineLayout::~PipelineLayout() {
     spdlog::trace("Destroying pipeline layout {}.", m_name);

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -9,16 +9,17 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Semaphore::Semaphore(Semaphore &&other) noexcept
-    : device(other.device), semaphore(std::exchange(other.semaphore, nullptr)), name(std::move(other.name)) {}
+    : m_device(other.m_device), m_semaphore(std::exchange(other.m_semaphore, nullptr)),
+      m_name(std::move(other.m_name)) {}
 
-Semaphore::Semaphore(const VkDevice device, const std::string &name) : device(device), name(name) {
+Semaphore::Semaphore(const VkDevice device, const std::string &name) : m_device(device), m_name(name) {
     assert(device);
     assert(!name.empty());
 
     spdlog::debug("Creating semaphore {}.", name);
 
     auto semaphore_ci = make_info<VkSemaphoreCreateInfo>();
-    if (vkCreateSemaphore(device, &semaphore_ci, nullptr, &semaphore) != VK_SUCCESS) {
+    if (vkCreateSemaphore(device, &semaphore_ci, nullptr, &m_semaphore) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateSemaphore failed for " + name + " !");
     }
 
@@ -28,8 +29,8 @@ Semaphore::Semaphore(const VkDevice device, const std::string &name) : device(de
 }
 
 Semaphore::~Semaphore() {
-    spdlog::trace("Destroying semaphore {}.", name);
-    vkDestroySemaphore(device, semaphore, nullptr);
+    spdlog::trace("Destroying semaphore {}.", m_name);
+    vkDestroySemaphore(m_device, m_semaphore, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -8,10 +8,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Semaphore::Semaphore(Semaphore &&other) noexcept
-    : m_device(other.m_device), m_semaphore(std::exchange(other.m_semaphore, nullptr)),
-      m_name(std::move(other.m_name)) {}
-
 Semaphore::Semaphore(const VkDevice device, const std::string &name) : m_device(device), m_name(name) {
     assert(device);
     assert(!name.empty());
@@ -27,6 +23,10 @@ Semaphore::Semaphore(const VkDevice device, const std::string &name) : m_device(
 
     spdlog::debug("Created semaphore successfully.");
 }
+
+Semaphore::Semaphore(Semaphore &&other) noexcept
+    : m_device(other.m_device), m_semaphore(std::exchange(other.m_semaphore, nullptr)),
+      m_name(std::move(other.m_name)) {}
 
 Semaphore::~Semaphore() {
     spdlog::trace("Destroying semaphore {}.", m_name);

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -36,10 +36,6 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
                const std::string &entry_point)
     : Shader(device, type, name, read_binary(file_name), entry_point) {}
 
-Shader::Shader(Shader &&shader) noexcept
-    : m_device(shader.m_device), m_type(shader.m_type), m_name(std::move(shader.m_name)),
-      m_entry_point(std::move(shader.m_entry_point)), m_shader_module(std::exchange(shader.m_shader_module, nullptr)) {}
-
 Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::string &name,
                const std::vector<char> &code, const std::string &entry_point)
     : m_device(device), m_type(type), m_name(name), m_entry_point(entry_point) {
@@ -79,6 +75,10 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
         }
     }
 }
+
+Shader::Shader(Shader &&shader) noexcept
+    : m_device(shader.m_device), m_type(shader.m_type), m_name(std::move(shader.m_name)),
+      m_entry_point(std::move(shader.m_entry_point)), m_shader_module(std::exchange(shader.m_shader_module, nullptr)) {}
 
 Shader::~Shader() {
     vkDestroyShaderModule(m_device, m_shader_module, nullptr);

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -37,12 +37,12 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
     : Shader(device, type, name, read_binary(file_name), entry_point) {}
 
 Shader::Shader(Shader &&shader) noexcept
-    : device(shader.device), type(shader.type), name(std::move(shader.name)),
-      entry_point(std::move(shader.entry_point)), shader_module(std::exchange(shader.shader_module, nullptr)) {}
+    : m_device(shader.m_device), m_type(shader.m_type), m_name(std::move(shader.m_name)),
+      m_entry_point(std::move(shader.m_entry_point)), m_shader_module(std::exchange(shader.m_shader_module, nullptr)) {}
 
 Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::string &name,
                const std::vector<char> &code, const std::string &entry_point)
-    : device(device), type(type), name(name), entry_point(entry_point) {
+    : m_device(device), m_type(type), m_name(name), m_entry_point(entry_point) {
     assert(device);
     assert(!name.empty());
     assert(!code.empty());
@@ -57,7 +57,7 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
     shader_module_ci.pCode = reinterpret_cast<const std::uint32_t *>(code.data());
 
     spdlog::debug("Creating shader module {}.", name);
-    if (vkCreateShaderModule(device, &shader_module_ci, nullptr, &shader_module) != VK_SUCCESS) {
+    if (vkCreateShaderModule(device, &shader_module_ci, nullptr, &m_shader_module) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateShaderModule failed for shader " + name + "!");
     }
 
@@ -70,7 +70,7 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
         // debugging.
         auto name_info = make_info<VkDebugMarkerObjectNameInfoEXT>();
         name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;
-        name_info.object = reinterpret_cast<std::uint64_t>(shader_module);
+        name_info.object = reinterpret_cast<std::uint64_t>(m_shader_module);
         name_info.pObjectName = name.c_str();
 
         spdlog::debug("Assigning internal name {} to shader module.", name);
@@ -81,7 +81,7 @@ Shader::Shader(VkDevice device, const VkShaderStageFlagBits type, const std::str
 }
 
 Shader::~Shader() {
-    vkDestroyShaderModule(device, shader_module, nullptr);
+    vkDestroyShaderModule(m_device, m_shader_module, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -16,7 +16,7 @@ StagingBuffer::StagingBuffer(const VkDevice device, const VmaAllocator vma_alloc
       m_data_transfer_queue(data_transfer_queue),
       m_command_buffer_for_copying(device, data_transfer_queue, data_transfer_queueu_family_index) {}
 
-void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &target_buffer) {
+void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer) {
     spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices.");
 
     m_command_buffer_for_copying.create_command_buffer();
@@ -30,7 +30,7 @@ void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &target_buffer) {
     vertex_buffer_copy.dstOffset = 0;
     vertex_buffer_copy.size = m_buffer_size;
 
-    vkCmdCopyBuffer(m_command_buffer_for_copying.get_command_buffer(), m_buffer, target_buffer.get_buffer(), 1,
+    vkCmdCopyBuffer(m_command_buffer_for_copying.command_buffer(), m_buffer, tarbuffer.buffer(), 1,
                     &vertex_buffer_copy);
 
     spdlog::debug("Finished uploading mesh data to graphics card memory.");

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -5,37 +5,37 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept
-    : data_transfer_queue(std::move(other.data_transfer_queue)),
-      command_buffer_for_copying(std::move(other.command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)) {}
+    : m_data_transfer_queue(std::move(other.m_data_transfer_queue)),
+      m_command_buffer_for_copying(std::move(other.m_command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)) {}
 
 StagingBuffer::StagingBuffer(const VkDevice device, const VmaAllocator vma_allocator, const VkQueue data_transfer_queue,
                              const std::uint32_t data_transfer_queueu_family_index, const std::string &name,
                              const VkDeviceSize buffer_size, void *data, const std::size_t data_size)
     : GPUMemoryBuffer(device, vma_allocator, name, buffer_size, data, data_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                       VMA_MEMORY_USAGE_CPU_ONLY),
-      data_transfer_queue(data_transfer_queue),
-      command_buffer_for_copying(device, data_transfer_queue, data_transfer_queueu_family_index) {}
+      m_data_transfer_queue(data_transfer_queue),
+      m_command_buffer_for_copying(device, data_transfer_queue, data_transfer_queueu_family_index) {}
 
 void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &target_buffer) {
     spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices.");
 
-    command_buffer_for_copying.create_command_buffer();
+    m_command_buffer_for_copying.create_command_buffer();
 
-    command_buffer_for_copying.start_recording();
+    m_command_buffer_for_copying.start_recording();
 
     spdlog::debug("Specifying vertex buffer copy operation in command buffer.");
 
     VkBufferCopy vertex_buffer_copy{};
     vertex_buffer_copy.srcOffset = 0;
     vertex_buffer_copy.dstOffset = 0;
-    vertex_buffer_copy.size = buffer_size;
+    vertex_buffer_copy.size = m_buffer_size;
 
-    vkCmdCopyBuffer(command_buffer_for_copying.get_command_buffer(), buffer, target_buffer.get_buffer(), 1,
+    vkCmdCopyBuffer(m_command_buffer_for_copying.get_command_buffer(), m_buffer, target_buffer.get_buffer(), 1,
                     &vertex_buffer_copy);
 
     spdlog::debug("Finished uploading mesh data to graphics card memory.");
 
-    command_buffer_for_copying.end_recording_and_submit_command();
+    m_command_buffer_for_copying.end_recording_and_submit_command();
 
     // No need to flush stagingVertexBuffer memory because CPU_ONLY memory is always HOST_COHERENT.
 }

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -4,10 +4,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept
-    : m_data_transfer_queue(std::move(other.m_data_transfer_queue)),
-      m_command_buffer_for_copying(std::move(other.m_command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)) {}
-
 StagingBuffer::StagingBuffer(const VkDevice device, const VmaAllocator vma_allocator, const VkQueue data_transfer_queue,
                              const std::uint32_t data_transfer_queueu_family_index, const std::string &name,
                              const VkDeviceSize buffer_size, void *data, const std::size_t data_size)
@@ -15,6 +11,10 @@ StagingBuffer::StagingBuffer(const VkDevice device, const VmaAllocator vma_alloc
                       VMA_MEMORY_USAGE_CPU_ONLY),
       m_data_transfer_queue(data_transfer_queue),
       m_command_buffer_for_copying(device, data_transfer_queue, data_transfer_queueu_family_index) {}
+
+StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept
+    : m_data_transfer_queue(std::move(other.m_data_transfer_queue)),
+      m_command_buffer_for_copying(std::move(other.m_command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)) {}
 
 void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer) {
     spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices.");

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -12,48 +12,51 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Swapchain::Swapchain(Swapchain &&other) noexcept
-    : device(other.device), graphics_card(std::exchange(other.graphics_card, nullptr)),
-      surface(std::exchange(other.surface, nullptr)), swapchain(std::exchange(other.swapchain, nullptr)),
-      surface_format(other.surface_format), extent(other.extent), swapchain_images(std::move(other.swapchain_images)),
-      swapchain_image_views(std::move(other.swapchain_image_views)), swapchain_image_count(other.swapchain_image_count),
-      vsync_enabled(other.vsync_enabled), name(std::move(other.name)) {}
+    : m_device(other.m_device), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)),
+      m_surface(std::exchange(other.m_surface, nullptr)), m_swapchain(std::exchange(other.m_swapchain, nullptr)),
+      m_surface_format(other.m_surface_format), m_extent(other.m_extent),
+      m_swapchain_images(std::move(other.m_swapchain_images)),
+      m_swapchain_image_views(std::move(other.m_swapchain_image_views)),
+      m_swapchain_image_count(other.m_swapchain_image_count), m_vsync_enabled(other.m_vsync_enabled),
+      m_name(std::move(other.m_name)) {}
 
 void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width,
                                 std::uint32_t window_height) {
     VulkanSettingsDecisionMaker settings_decision_maker;
 
-    settings_decision_maker.decide_width_and_height_of_swapchain_extent(graphics_card, surface, window_width,
-                                                                        window_height, extent);
+    settings_decision_maker.decide_width_and_height_of_swapchain_extent(m_graphics_card, m_surface, window_width,
+                                                                        window_height, m_extent);
 
     std::optional<VkPresentModeKHR> present_mode =
-        settings_decision_maker.decide_which_presentation_mode_to_use(graphics_card, surface, vsync_enabled);
+        settings_decision_maker.decide_which_presentation_mode_to_use(m_graphics_card, m_surface, m_vsync_enabled);
 
     if (!present_mode) {
         throw std::runtime_error("Error: Could not find a suitable present mode!");
     }
 
-    swapchain_image_count = settings_decision_maker.decide_how_many_images_in_swapchain_to_use(graphics_card, surface);
+    m_swapchain_image_count =
+        settings_decision_maker.decide_how_many_images_in_swapchain_to_use(m_graphics_card, m_surface);
 
     auto surface_format_candidate =
-        settings_decision_maker.decide_which_surface_color_format_in_swapchain_to_use(graphics_card, surface);
+        settings_decision_maker.decide_which_surface_color_format_in_swapchain_to_use(m_graphics_card, m_surface);
 
     if (!surface_format_candidate) {
         throw std::runtime_error("Error: Could not find an image format for images in swapchain!");
     }
 
-    surface_format = *surface_format_candidate;
+    m_surface_format = *surface_format_candidate;
 
     auto swapchain_ci = make_info<VkSwapchainCreateInfoKHR>();
-    swapchain_ci.surface = surface;
-    swapchain_ci.minImageCount = swapchain_image_count;
-    swapchain_ci.imageFormat = surface_format.format;
-    swapchain_ci.imageColorSpace = surface_format.colorSpace;
-    swapchain_ci.imageExtent.width = extent.width;
-    swapchain_ci.imageExtent.height = extent.height;
+    swapchain_ci.surface = m_surface;
+    swapchain_ci.minImageCount = m_swapchain_image_count;
+    swapchain_ci.imageFormat = m_surface_format.format;
+    swapchain_ci.imageColorSpace = m_surface_format.colorSpace;
+    swapchain_ci.imageExtent.width = m_extent.width;
+    swapchain_ci.imageExtent.height = m_extent.height;
     swapchain_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     swapchain_ci.preTransform =
-        (VkSurfaceTransformFlagBitsKHR)settings_decision_maker.decide_which_image_transformation_to_use(graphics_card,
-                                                                                                        surface);
+        (VkSurfaceTransformFlagBitsKHR)settings_decision_maker.decide_which_image_transformation_to_use(m_graphics_card,
+                                                                                                        m_surface);
     swapchain_ci.imageArrayLayers = 1;
     swapchain_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchain_ci.queueFamilyIndexCount = 0;
@@ -66,41 +69,41 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
 
     // Setting clipped to VK_TRUE allows the implementation to discard rendering outside of the surface area.
     swapchain_ci.clipped = VK_TRUE;
-    swapchain_ci.compositeAlpha = settings_decision_maker.find_composite_alpha_format(graphics_card, surface);
+    swapchain_ci.compositeAlpha = settings_decision_maker.find_composite_alpha_format(m_graphics_card, m_surface);
 
     // Set additional usage flag for blitting from the swapchain images if supported.
     VkFormatProperties formatProps;
 
-    vkGetPhysicalDeviceFormatProperties(graphics_card, surface_format.format, &formatProps);
+    vkGetPhysicalDeviceFormatProperties(m_graphics_card, m_surface_format.format, &formatProps);
 
     if ((formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) ||
         (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT)) {
         swapchain_ci.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 
-    if (vkCreateSwapchainKHR(device, &swapchain_ci, nullptr, &swapchain) != VK_SUCCESS) {
+    if (vkCreateSwapchainKHR(m_device, &swapchain_ci, nullptr, &m_swapchain) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateSwapchainKHR failed!");
     }
 
-    if (vkGetSwapchainImagesKHR(device, swapchain, &swapchain_image_count, nullptr) != VK_SUCCESS) {
+    if (vkGetSwapchainImagesKHR(m_device, m_swapchain, &m_swapchain_image_count, nullptr) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkGetSwapchainImagesKHR failed!");
     }
 
-    swapchain_images.resize(swapchain_image_count);
+    m_swapchain_images.resize(m_swapchain_image_count);
 
-    if (vkGetSwapchainImagesKHR(device, swapchain, &swapchain_image_count, swapchain_images.data())) {
+    if (vkGetSwapchainImagesKHR(m_device, m_swapchain, &m_swapchain_image_count, m_swapchain_images.data())) {
         throw std::runtime_error("Error: vkGetSwapchainImagesKHR failed!");
     }
 
     // TODO: Assign an appropriate debug marker name to the swapchain images.
 
-    spdlog::debug("Creating {} swapchain image views.", swapchain_image_count);
+    spdlog::debug("Creating {} swapchain image views.", m_swapchain_image_count);
 
-    swapchain_image_views.resize(swapchain_image_count);
+    m_swapchain_image_views.resize(m_swapchain_image_count);
 
     auto image_view_ci = make_info<VkImageViewCreateInfo>();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    image_view_ci.format = surface_format.format;
+    image_view_ci.format = m_surface_format.format;
     image_view_ci.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
     image_view_ci.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
     image_view_ci.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
@@ -111,25 +114,26 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     image_view_ci.subresourceRange.baseArrayLayer = 0;
     image_view_ci.subresourceRange.layerCount = 1;
 
-    for (std::size_t i = 0; i < swapchain_image_count; i++) {
+    for (std::size_t i = 0; i < m_swapchain_image_count; i++) {
         spdlog::debug("Creating swapchain image #{}.", i);
 
-        image_view_ci.image = swapchain_images[i];
+        image_view_ci.image = m_swapchain_images[i];
 
-        if (vkCreateImageView(device, &image_view_ci, nullptr, &swapchain_image_views[i]) != VK_SUCCESS) {
+        if (vkCreateImageView(m_device, &image_view_ci, nullptr, &m_swapchain_image_views[i]) != VK_SUCCESS) {
             throw std::runtime_error("Error: vkCreateImageView failed!");
         }
 
         // TODO: Use Vulkan debug markers to assign an appropriate name to this swapchain image view.
     }
 
-    spdlog::debug("Created {} swapchain image views successfully.", swapchain_image_count);
+    spdlog::debug("Created {} swapchain image views successfully.", m_swapchain_image_count);
 }
 
 Swapchain::Swapchain(const VkDevice device, const VkPhysicalDevice graphics_card, const VkSurfaceKHR surface,
                      std::uint32_t window_width, std::uint32_t window_height, const bool enable_vsync,
                      const std::string &name)
-    : device(device), graphics_card(graphics_card), surface(surface), vsync_enabled(enable_vsync), name(name) {
+    : m_device(device), m_graphics_card(graphics_card), m_surface(surface), m_vsync_enabled(enable_vsync),
+      m_name(name) {
 
     assert(device);
     assert(graphics_card);
@@ -140,37 +144,37 @@ Swapchain::Swapchain(const VkDevice device, const VkPhysicalDevice graphics_card
 
 std::uint32_t Swapchain::acquire_next_image(const wrapper::Semaphore &semaphore) {
     std::uint32_t image_index;
-    vkAcquireNextImageKHR(device, swapchain, std::numeric_limits<std::uint64_t>::max(), semaphore.get(), VK_NULL_HANDLE,
-                          &image_index);
+    vkAcquireNextImageKHR(m_device, m_swapchain, std::numeric_limits<std::uint64_t>::max(), semaphore.get(),
+                          VK_NULL_HANDLE, &image_index);
     return image_index;
 }
 
 void Swapchain::recreate(std::uint32_t window_width, std::uint32_t window_height) {
     // Store the old swapchain. This allows us to pass it to VkSwapchainCreateInfoKHR::oldSwapchain to speed up
     // swapchain recreation.
-    VkSwapchainKHR old_swapchain = swapchain;
+    VkSwapchainKHR old_swapchain = m_swapchain;
 
     // When swapchain needs to be recreated, all the old swapchain images need to be destroyed.
 
     // Unlike swapchain images, the image views were created by us directly.
     // It is our job to destroy them again.
-    for (auto *image_view : swapchain_image_views) {
-        vkDestroyImageView(device, image_view, nullptr);
+    for (auto *image_view : m_swapchain_image_views) {
+        vkDestroyImageView(m_device, image_view, nullptr);
     }
 
-    swapchain_image_views.clear();
+    m_swapchain_image_views.clear();
 
-    swapchain_images.clear();
+    m_swapchain_images.clear();
 
     setup_swapchain(old_swapchain, window_width, window_height);
 }
 
 Swapchain::~Swapchain() {
-    spdlog::trace("Destroying swapchain {}.", name);
-    vkDestroySwapchainKHR(device, swapchain, nullptr);
+    spdlog::trace("Destroying swapchain {}.", m_name);
+    vkDestroySwapchainKHR(m_device, m_swapchain, nullptr);
 
-    for (auto *image_view : swapchain_image_views) {
-        vkDestroyImageView(device, image_view, nullptr);
+    for (auto *image_view : m_swapchain_image_views) {
+        vkDestroyImageView(m_device, image_view, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -11,6 +11,19 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+Swapchain::Swapchain(const VkDevice device, const VkPhysicalDevice graphics_card, const VkSurfaceKHR surface,
+                     std::uint32_t window_width, std::uint32_t window_height, const bool enable_vsync,
+                     const std::string &name)
+    : m_device(device), m_graphics_card(graphics_card), m_surface(surface), m_vsync_enabled(enable_vsync),
+      m_name(name) {
+
+    assert(device);
+    assert(graphics_card);
+    assert(surface);
+
+    setup_swapchain(VK_NULL_HANDLE, window_width, window_height);
+}
+
 Swapchain::Swapchain(Swapchain &&other) noexcept
     : m_device(other.m_device), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)),
       m_surface(std::exchange(other.m_surface, nullptr)), m_swapchain(std::exchange(other.m_swapchain, nullptr)),
@@ -127,19 +140,6 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     }
 
     spdlog::debug("Created {} swapchain image views successfully.", m_swapchain_image_count);
-}
-
-Swapchain::Swapchain(const VkDevice device, const VkPhysicalDevice graphics_card, const VkSurfaceKHR surface,
-                     std::uint32_t window_width, std::uint32_t window_height, const bool enable_vsync,
-                     const std::string &name)
-    : m_device(device), m_graphics_card(graphics_card), m_surface(surface), m_vsync_enabled(enable_vsync),
-      m_name(name) {
-
-    assert(device);
-    assert(graphics_card);
-    assert(surface);
-
-    setup_swapchain(VK_NULL_HANDLE, window_width, window_height);
 }
 
 std::uint32_t Swapchain::acquire_next_image(const wrapper::Semaphore &semaphore) {

--- a/src/vulkan-renderer/wrapper/texture.cpp
+++ b/src/vulkan-renderer/wrapper/texture.cpp
@@ -11,19 +11,20 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Texture::Texture(Texture &&other) noexcept
-    : texture_image(std::exchange(other.texture_image, nullptr)), name(std::move(other.name)),
-      file_name(std::move(other.file_name)), texture_width(other.texture_width), texture_height(other.texture_height),
-      texture_channels(other.texture_channels), mip_levels(other.mip_levels), device(other.device),
-      graphics_card(other.graphics_card), data_transfer_queue(other.data_transfer_queue),
-      vma_allocator(other.vma_allocator), sampler(std::exchange(other.sampler, nullptr)),
-      texture_image_format(other.texture_image_format), copy_command_buffer(std::move(other.copy_command_buffer)) {}
+    : m_texture_image(std::exchange(other.m_texture_image, nullptr)), m_name(std::move(other.m_name)),
+      m_file_name(std::move(other.m_file_name)), m_texture_width(other.m_texture_width),
+      m_texture_height(other.m_texture_height), m_texture_channels(other.m_texture_channels),
+      m_mip_levels(other.m_mip_levels), m_device(other.m_device), m_graphics_card(other.m_graphics_card),
+      m_data_transfer_queue(other.m_data_transfer_queue), m_vma_allocator(other.m_vma_allocator),
+      m_sampler(std::exchange(other.m_sampler, nullptr)), m_texture_image_format(other.m_texture_image_format),
+      m_copy_command_buffer(std::move(other.m_copy_command_buffer)) {}
 
 Texture::Texture(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
                  void *texture_data, const std::size_t texture_size, const std::string &name,
                  const VkQueue data_transfer_queue, const std::uint32_t data_transfer_queue_family_index)
-    : name(name), file_name(file_name), device(device), graphics_card(graphics_card),
-      data_transfer_queue(data_transfer_queue), vma_allocator(vma_allocator),
-      copy_command_buffer(device, data_transfer_queue, data_transfer_queue_family_index) {
+    : m_name(name), m_file_name(m_file_name), m_device(device), m_graphics_card(graphics_card),
+      m_data_transfer_queue(data_transfer_queue), m_vma_allocator(vma_allocator),
+      m_copy_command_buffer(device, data_transfer_queue, data_transfer_queue_family_index) {
 
     create_texture(texture_data, texture_size);
 }
@@ -31,9 +32,10 @@ Texture::Texture(const VkDevice device, const VkPhysicalDevice graphics_card, co
 Texture::Texture(const VkDevice device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
                  const std::string &file_name, const std::string &name, const VkQueue data_transfer_queue,
                  const std::uint32_t data_transfer_queue_family_index)
-    : name(name), file_name(file_name), device(device), graphics_card(graphics_card),
-      data_transfer_queue(data_transfer_queue), data_transfer_queue_family_index(data_transfer_queue_family_index),
-      vma_allocator(vma_allocator), copy_command_buffer(device, data_transfer_queue, data_transfer_queue_family_index) {
+    : m_name(name), m_file_name(file_name), m_device(device), m_graphics_card(graphics_card),
+      m_data_transfer_queue(data_transfer_queue), m_data_transfer_queue_family_index(data_transfer_queue_family_index),
+      m_vma_allocator(vma_allocator),
+      m_copy_command_buffer(device, data_transfer_queue, data_transfer_queue_family_index) {
     assert(device);
     assert(vma_allocator);
     assert(!file_name.empty());
@@ -45,18 +47,18 @@ Texture::Texture(const VkDevice device, const VkPhysicalDevice graphics_card, co
     // Load the texture file using stb_image library.
     // Force stb_image to load an alpha channel as well.
     stbi_uc *texture_data =
-        stbi_load(file_name.c_str(), &texture_width, &texture_height, &texture_channels, STBI_rgb_alpha);
+        stbi_load(file_name.c_str(), &m_texture_width, &m_texture_height, &m_texture_channels, STBI_rgb_alpha);
 
     if (texture_data == nullptr) {
         throw std::runtime_error("Error: Could not load texture file " + file_name + " using stbi_load!");
     }
 
-    spdlog::debug("Texture dimensions: width: {}, height: {}, channels: {}.", texture_width, texture_height,
-                  texture_channels);
+    spdlog::debug("Texture dimensions: width: {}, height: {}, channels: {}.", m_texture_width, m_texture_height,
+                  m_texture_channels);
 
     // Calculate the memory size of the texture.
     // We need 4 times the size since we have 4 channels: red, green, blue and alpha channel.
-    VkDeviceSize texture_memory_size = 4 * texture_width * texture_height;
+    VkDeviceSize texture_memory_size = 4 * m_texture_width * m_texture_height;
 
     create_texture(texture_data, texture_memory_size);
 
@@ -68,26 +70,28 @@ void Texture::create_texture(void *texture_data, const std::size_t texture_size)
 
     // For now, we will not generate mip-maps automatically.
     // TODO: Generate mip-maps automatically!
-    mip_levels = 1;
+    m_mip_levels = 1;
 
-    StagingBuffer texture_staging_buffer(device, vma_allocator, data_transfer_queue, data_transfer_queue_family_index,
-                                         name, texture_size, texture_data, texture_size);
+    StagingBuffer texture_staging_buffer(m_device, m_vma_allocator, m_data_transfer_queue,
+                                         m_data_transfer_queue_family_index, m_name, texture_size, texture_data,
+                                         texture_size);
 
     VkExtent2D extent;
-    extent.width = texture_width;
-    extent.height = texture_height;
+    extent.width = m_texture_width;
+    extent.height = m_texture_height;
 
-    texture_image = std::make_unique<wrapper::Image>(device, graphics_card, vma_allocator, texture_image_format,
-                                                     VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                                                     VK_IMAGE_ASPECT_COLOR_BIT, VK_SAMPLE_COUNT_1_BIT, name, extent);
+    m_texture_image =
+        std::make_unique<wrapper::Image>(m_device, m_graphics_card, m_vma_allocator, m_texture_image_format,
+                                         VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                         VK_IMAGE_ASPECT_COLOR_BIT, VK_SAMPLE_COUNT_1_BIT, m_name, extent);
 
-    copy_command_buffer.create_command_buffer();
+    m_copy_command_buffer.create_command_buffer();
 
-    copy_command_buffer.start_recording();
+    m_copy_command_buffer.start_recording();
 
-    spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.", name);
+    spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.", m_name);
 
-    transition_image_layout(texture_image->get(), texture_image_format, VK_IMAGE_LAYOUT_UNDEFINED,
+    transition_image_layout(m_texture_image->get(), m_texture_image_format, VK_IMAGE_LAYOUT_UNDEFINED,
                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     VkBufferImageCopy buffer_image_region{};
@@ -100,16 +104,17 @@ void Texture::create_texture(void *texture_data, const std::size_t texture_size)
     buffer_image_region.imageSubresource.baseArrayLayer = 0;
     buffer_image_region.imageSubresource.layerCount = 1;
     buffer_image_region.imageOffset = {0, 0, 0};
-    buffer_image_region.imageExtent = {static_cast<uint32_t>(texture_width), static_cast<uint32_t>(texture_height), 1};
+    buffer_image_region.imageExtent = {static_cast<uint32_t>(m_texture_width), static_cast<uint32_t>(m_texture_height),
+                                       1};
 
-    vkCmdCopyBufferToImage(copy_command_buffer.get_command_buffer(), texture_staging_buffer.get_buffer(),
-                           texture_image->get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_image_region);
+    vkCmdCopyBufferToImage(m_copy_command_buffer.get_command_buffer(), texture_staging_buffer.get_buffer(),
+                           m_texture_image->get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_image_region);
 
-    spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.", name);
+    spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.", m_name);
 
-    copy_command_buffer.end_recording_and_submit_command();
+    m_copy_command_buffer.end_recording_and_submit_command();
 
-    transition_image_layout(texture_image->get(), texture_image_format, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+    transition_image_layout(m_texture_image->get(), m_texture_image_format, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     create_texture_sampler();
@@ -152,7 +157,7 @@ void Texture::transition_image_layout(VkImage image, VkFormat format, VkImageLay
 
     spdlog::debug("Recording pipeline barrier for image layer transition");
 
-    OnceCommandBuffer image_transition_change(device, data_transfer_queue, data_transfer_queue_family_index);
+    OnceCommandBuffer image_transition_change(m_device, m_data_transfer_queue, m_data_transfer_queue_family_index);
 
     image_transition_change.create_command_buffer();
     image_transition_change.start_recording();
@@ -202,10 +207,10 @@ void Texture::create_texture_sampler() {
     sampler_ci.maxLod = 0.0f;
 
     VkPhysicalDeviceFeatures device_features;
-    vkGetPhysicalDeviceFeatures(graphics_card, &device_features);
+    vkGetPhysicalDeviceFeatures(m_graphics_card, &device_features);
 
     VkPhysicalDeviceProperties graphics_card_properties;
-    vkGetPhysicalDeviceProperties(graphics_card, &graphics_card_properties);
+    vkGetPhysicalDeviceProperties(m_graphics_card, &graphics_card_properties);
 
     if (VK_TRUE == device_features.samplerAnisotropy) {
         // Anisotropic filtering is available.
@@ -217,10 +222,10 @@ void Texture::create_texture_sampler() {
         sampler_ci.anisotropyEnable = VK_FALSE;
     }
 
-    spdlog::debug("Creating image sampler for texture {}.", name);
+    spdlog::debug("Creating image sampler for texture {}.", m_name);
 
-    if (vkCreateSampler(device, &sampler_ci, nullptr, &sampler) != VK_SUCCESS) {
-        throw std::runtime_error("Error: vkCreateSampler failed for texture " + name + " !");
+    if (vkCreateSampler(m_device, &sampler_ci, nullptr, &m_sampler) != VK_SUCCESS) {
+        throw std::runtime_error("Error: vkCreateSampler failed for texture " + m_name + " !");
     }
 
     // TODO: Vulkan debug markers!
@@ -229,8 +234,8 @@ void Texture::create_texture_sampler() {
 }
 
 Texture::~Texture() {
-    spdlog::trace("Destroying texture {}.", name);
-    vkDestroySampler(device, sampler, nullptr);
+    spdlog::trace("Destroying texture {}.", m_name);
+    vkDestroySampler(m_device, m_sampler, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/texture.cpp
+++ b/src/vulkan-renderer/wrapper/texture.cpp
@@ -107,7 +107,7 @@ void Texture::create_texture(void *texture_data, const std::size_t texture_size)
     buffer_image_region.imageExtent = {static_cast<uint32_t>(m_texture_width), static_cast<uint32_t>(m_texture_height),
                                        1};
 
-    vkCmdCopyBufferToImage(m_copy_command_buffer.get_command_buffer(), texture_staging_buffer.get_buffer(),
+    vkCmdCopyBufferToImage(m_copy_command_buffer.command_buffer(), texture_staging_buffer.buffer(),
                            m_texture_image->get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_image_region);
 
     spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.", m_name);
@@ -162,7 +162,7 @@ void Texture::transition_image_layout(VkImage image, VkFormat format, VkImageLay
     image_transition_change.create_command_buffer();
     image_transition_change.start_recording();
 
-    vkCmdPipelineBarrier(image_transition_change.get_command_buffer(), source_stage, destination_stage, 0, 0, nullptr,
+    vkCmdPipelineBarrier(image_transition_change.command_buffer(), source_stage, destination_stage, 0, 0, nullptr,
                          0, nullptr, 1, &barrier);
 
     image_transition_change.end_recording_and_submit_command();

--- a/src/vulkan-renderer/wrapper/uniform_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -5,14 +5,14 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-UniformBuffer::UniformBuffer(UniformBuffer &&other) noexcept
-    : GPUMemoryBuffer(std::move(other)), m_descriptor_buffer_info(std::move(other.m_descriptor_buffer_info)),
-      m_descriptor_set(std::move(other.m_descriptor_set)) {}
-
 UniformBuffer::UniformBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                              const VkDeviceSize &buffer_size)
     : GPUMemoryBuffer(device, vma_allocator, name, buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                       VMA_MEMORY_USAGE_CPU_TO_GPU) {}
+
+UniformBuffer::UniformBuffer(UniformBuffer &&other) noexcept
+    : GPUMemoryBuffer(std::move(other)), m_descriptor_buffer_info(std::move(other.m_descriptor_buffer_info)),
+      m_descriptor_set(std::move(other.m_descriptor_set)) {}
 
 void UniformBuffer::update(void *data, const std::size_t size) {
     assert(m_allocation_info.pMappedData);

--- a/src/vulkan-renderer/wrapper/uniform_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -6,8 +6,8 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 UniformBuffer::UniformBuffer(UniformBuffer &&other) noexcept
-    : GPUMemoryBuffer(std::move(other)), descriptor_buffer_info(std::move(other.descriptor_buffer_info)),
-      descriptor_set(std::move(other.descriptor_set)) {}
+    : GPUMemoryBuffer(std::move(other)), m_descriptor_buffer_info(std::move(other.m_descriptor_buffer_info)),
+      m_descriptor_set(std::move(other.m_descriptor_set)) {}
 
 UniformBuffer::UniformBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
                              const VkDeviceSize &buffer_size)
@@ -15,9 +15,9 @@ UniformBuffer::UniformBuffer(const VkDevice &device, const VmaAllocator &vma_all
                       VMA_MEMORY_USAGE_CPU_TO_GPU) {}
 
 void UniformBuffer::update(void *data, const std::size_t size) {
-    assert(allocation_info.pMappedData);
+    assert(m_allocation_info.pMappedData);
 
-    std::memcpy(allocation_info.pMappedData, data, size);
+    std::memcpy(m_allocation_info.pMappedData, data, size);
 }
 
 }; // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -6,11 +6,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Window::Window(Window &&other) noexcept : window(std::exchange(other.window, nullptr)) {}
+Window::Window(Window &&other) noexcept : m_window(std::exchange(other.m_window, nullptr)) {}
 
 Window::Window(const std::string &title, const std::uint32_t width, const std::uint32_t height, const bool visible,
                const bool resizable)
-    : width(width), height(height) {
+    : m_width(width), m_height(height) {
     assert(!title.empty());
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -19,79 +19,79 @@ Window::Window(const std::string &title, const std::uint32_t width, const std::u
 
     spdlog::debug("Creating window.");
 
-    this->window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
+    m_window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
 
-    if (!window) {
+    if (!m_window) {
         throw std::runtime_error("Error: glfwCreateWindow failed for window " + title + " !");
     }
 }
 
 void Window::wait_for_focus() {
-    assert(window);
+    assert(m_window);
 
     int current_width = 0;
     int current_height = 0;
 
     while (current_width == 0 || current_height == 0) {
-        glfwGetFramebufferSize(window, &current_width, &current_height);
+        glfwGetFramebufferSize(m_window, &current_width, &current_height);
         glfwWaitEvents();
     }
 
-    width = current_width;
-    height = current_height;
+    m_width = current_width;
+    m_height = current_height;
 }
 
 void Window::set_title(const std::string &title) {
-    assert(window);
+    assert(m_window);
     assert(!title.empty());
-    glfwSetWindowTitle(window, title.c_str());
+    glfwSetWindowTitle(m_window, title.c_str());
 }
 
 void Window::set_user_ptr(void *user_ptr) {
-    assert(window);
+    assert(m_window);
     assert(user_ptr);
-    glfwSetWindowUserPointer(window, user_ptr);
+    glfwSetWindowUserPointer(m_window, user_ptr);
 }
 
 void Window::set_resize_callback(GLFWframebuffersizefun frame_buffer_resize_callback) {
-    assert(window);
+    assert(m_window);
     assert(frame_buffer_resize_callback);
-    glfwSetFramebufferSizeCallback(window, frame_buffer_resize_callback);
+    glfwSetFramebufferSizeCallback(m_window, frame_buffer_resize_callback);
 }
 
 void Window::show() {
-    assert(window);
-    glfwShowWindow(window);
+    assert(m_window);
+    glfwShowWindow(m_window);
 }
 
 void Window::hide() {
-    assert(window);
-    glfwHideWindow(window);
+    assert(m_window);
+    glfwHideWindow(m_window);
 }
 
 void Window::get_cursor_pos(double &pos_x, double &pos_y) {
-    assert(window);
-    glfwGetCursorPos(window, &pos_x, &pos_y);
+    assert(m_window);
+    glfwGetCursorPos(m_window, &pos_x, &pos_y);
 }
 
 bool Window::is_button_pressed(int button) {
-    assert(window);
-    return glfwGetMouseButton(window, button);
+    assert(m_window);
+    return glfwGetMouseButton(m_window, button);
 }
 
 void Window::poll() {
-    assert(window);
+    assert(m_window);
     glfwPollEvents();
 }
 
 bool Window::should_close() {
-    assert(window);
-    return glfwWindowShouldClose(window);
+    assert(m_window);
+    return glfwWindowShouldClose(m_window);
 }
 
 Window::~Window() {
     spdlog::trace("Destroying window.");
-    glfwDestroyWindow(window);
+    glfwDestroyWindow(m_window);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -6,8 +6,6 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Window::Window(Window &&other) noexcept : m_window(std::exchange(other.m_window, nullptr)) {}
-
 Window::Window(const std::string &title, const std::uint32_t width, const std::uint32_t height, const bool visible,
                const bool resizable)
     : m_width(width), m_height(height) {
@@ -25,6 +23,8 @@ Window::Window(const std::string &title, const std::uint32_t width, const std::u
         throw std::runtime_error("Error: glfwCreateWindow failed for window " + title + " !");
     }
 }
+
+Window::Window(Window &&other) noexcept : m_window(std::exchange(other.m_window, nullptr)) {}
 
 void Window::wait_for_focus() {
     assert(m_window);

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -69,7 +69,7 @@ void Window::hide() {
     glfwHideWindow(m_window);
 }
 
-void Window::get_cursor_pos(double &pos_x, double &pos_y) {
+void Window::cursor_pos(double &pos_x, double &pos_y) {
     assert(m_window);
     glfwGetCursorPos(m_window, &pos_x, &pos_y);
 }

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -2,13 +2,13 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : instance(instance) {
+WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_instance(instance) {
     assert(instance);
     assert(window);
 
     spdlog::debug("Creating window surface.");
 
-    if (glfwCreateWindowSurface(instance, window, nullptr, &surface) != VK_SUCCESS) {
+    if (glfwCreateWindowSurface(instance, window, nullptr, &m_surface) != VK_SUCCESS) {
         throw std::runtime_error("Error: glfwCreateWindowSurface failed!");
     }
 
@@ -17,7 +17,7 @@ WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : in
 
 WindowSurface::~WindowSurface() {
     spdlog::trace("Destroying window surface.");
-    vkDestroySurfaceKHR(instance, surface, nullptr);
+    vkDestroySurfaceKHR(m_instance, m_surface, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -1,5 +1,7 @@
 #include "inexor/vulkan-renderer/wrapper/window_surface.hpp"
 
+#include <utility>
+
 namespace inexor::vulkan_renderer::wrapper {
 
 WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_instance(instance) {
@@ -14,6 +16,9 @@ WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_
 
     spdlog::debug("Created window surface successfully");
 }
+
+WindowSurface::WindowSurface(WindowSurface &&other) noexcept
+    : m_instance(other.m_instance), m_surface(std::exchange(other.m_surface, nullptr)) {}
 
 WindowSurface::~WindowSurface() {
     spdlog::trace("Destroying window surface.");


### PR DESCRIPTION
- Prefix member fields with `m_`
- Remove `get_` prefix from getters
- Cleanup constructors and assignment operators
  - Put constructors/assignment operators in the order
    1. Normal constructors
    2. Copy constructor
    3. Move constructor
    4. Destructor
    5. Copy assignment operator
    6. Move assignment operator
  - Fix a few trivial move constructor issues
  - Remove `noexcept` from move assignment operators