### PR TITLE
Rotation functionality to Cube-class and refactor

### DIFF
--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -31,8 +31,8 @@ using Polygon = std::array<glm::vec3, 3>;
 
 using PolygonCache = std::shared_ptr<std::vector<Polygon>>;
 
-/// IDs of the children in a order so that we rotate the octants when moving the child with the first ID to the second ID,
-/// the second, to the third, ...
+/// IDs of the children in a order so that we rotate the octants when moving the child with the first ID to the second
+/// ID, the second, to the third, ...
 using ChildRotationOrder = std::array<std::array<uint8_t, 4>, 2>;
 
 /// IDs of the edges in a order so that we rotate the cube when moving the edge with the first ID to the second ID,
@@ -57,44 +57,27 @@ public:
     static constexpr std::size_t EDGES = 12;
 
     /// IDs of the edges in the order of for a 90° rotation around the X-axis.
-    static constexpr EdgeRotationOrder X_EDGE_ROTATION_ORDER {{
-          // First edge need to point to (crossing with) second, second to third, third to second (again) and fourth to third
-        {{2, 4, 11, 1}},
-        {{5, 7, 8, 10}},
-        {{0, 9, 6, 3}}
-    }};
+    static constexpr EdgeRotationOrder X_EDGE_ROTATION_ORDER{
+        {// First edge need to point to (crossing with) second, second to third, third to second (again) and fourth to
+         // third
+         {{2, 4, 11, 1}},
+         {{5, 7, 8, 10}},
+         {{0, 9, 6, 3}}}};
 
     /// IDs of the edges in the order of for a 90° rotation around the Y-axis.
-    static constexpr EdgeRotationOrder Y_EDGE_ROTATION_ORDER {{
-        {{0, 5, 9, 2}},
-        {{3, 8, 6, 11}},
-        {{1, 10, 7, 4}}
-    }};
+    static constexpr EdgeRotationOrder Y_EDGE_ROTATION_ORDER{{{{0, 5, 9, 2}}, {{3, 8, 6, 11}}, {{1, 10, 7, 4}}}};
 
     /// IDs of the edges in the order of for a 90° rotation around the Z-axis.
-    static constexpr EdgeRotationOrder Z_EDGE_ROTATION_ORDER {{
-        {{1, 3, 10, 0}},
-        {{4, 6, 7, 9}},
-        {{2, 11, 8, 5}}
-    }};
+    static constexpr EdgeRotationOrder Z_EDGE_ROTATION_ORDER{{{{1, 3, 10, 0}}, {{4, 6, 7, 9}}, {{2, 11, 8, 5}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the X-axis.
-    static constexpr ChildRotationOrder X_CHILD_ROTATION_ORDER {{
-        {{0, 1, 3, 2}},
-        {{4, 5, 7, 6}}
-    }};
+    static constexpr ChildRotationOrder X_CHILD_ROTATION_ORDER{{{{0, 1, 3, 2}}, {{4, 5, 7, 6}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the Y-axis.
-    static constexpr ChildRotationOrder Y_CHILD_ROTATION_ORDER {{
-        {{0, 4, 5, 1}},
-        {{2, 6, 7, 3}}
-    }};
+    static constexpr ChildRotationOrder Y_CHILD_ROTATION_ORDER{{{{0, 4, 5, 1}}, {{2, 6, 7, 3}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the Z-axis.
-    static constexpr ChildRotationOrder Z_CHILD_ROTATION_ORDER {{
-        {{0, 2, 6, 4}},
-        {{1, 3, 7, 5}}
-    }};
+    static constexpr ChildRotationOrder Z_CHILD_ROTATION_ORDER{{{{0, 2, 6, 4}}, {{1, 3, 7, 5}}}};
 
     /// Cube Type.
     enum class Type {
@@ -138,7 +121,8 @@ private:
     ///                   element will go to the place of the second, each second to the third, etc.
     /// @param child_order The rotation-orders of the children which should be rotated. At a 90° rotation, each first
     ///                    element will go to the place of the second, each second to the third, etc.
-    void rotate(const uint8_t &rotation_level, const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
+    void rotate(const uint8_t &rotation_level, const EdgeRotationOrder &edge_order,
+                const ChildRotationOrder &child_order);
 
     /// Rotate a cube by 90°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
@@ -146,14 +130,14 @@ private:
     void rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
     /// Rotate elements by 90° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    template<typename TYPE, std::size_t SIZE>
+    template <typename TYPE, std::size_t SIZE>
     static void rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Rotate a cube by 180°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
     /// @param child_order The rotation-orders of the children which should be rotated.
     void rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
-    template<typename TYPE, std::size_t SIZE>
+    template <typename TYPE, std::size_t SIZE>
     /// Rotate elements by 180° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
     static void rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
@@ -164,7 +148,7 @@ private:
     void rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
     /// Rotate elements by 270° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    template<typename TYPE, std::size_t SIZE>
+    template <typename TYPE, std::size_t SIZE>
     static void rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Get the root to this cube.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -118,17 +118,17 @@ private:
     void rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
     /// Rotate elements by 90° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    template <typename TYPE, std::size_t SIZE>
-    static void rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    template <typename T, std::size_t Size>
+    static void rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements);
 
     /// Rotate a cube by 180°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
     /// @param child_order The rotation-orders of the children which should be rotated.
     void rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
-    template <typename TYPE, std::size_t SIZE>
+    template <typename T, std::size_t Size>
     /// Rotate elements by 180° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    static void rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    static void rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements);
 
     /// Rotate a cube by 270°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
@@ -136,8 +136,8 @@ private:
     void rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
     /// Rotate elements by 270° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    template <typename TYPE, std::size_t SIZE>
-    static void rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    template <typename T, std::size_t Size>
+    static void rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements);
 
     /// Get the root to this cube.
     [[nodiscard]] std::weak_ptr<Cube> root() const noexcept;

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -39,10 +39,12 @@ using ChildRotationOrder = std::array<std::array<std::uint8_t, 4>, 2>;
 /// the second, to the third, ...
 /// As we need to update the indentations, it is required that first two indentations in the array
 /// point in the correct order towards the same corner as the second two corners. Example:
-///    -1->       Correct are either {{0, 1, 3, 2}} or {{3, 2, 0, 1}}
-///   ^    ^      Incorrect are all other variants.
-/// 0 |    | 2
-///    -3->
+/// Correct are either ``{{0, 1, 3, 2}}`` or ``{{3, 2, 0, 1}}``. Incorrect are all other variants.
+///
+///        -1->
+///       ^    ^
+///     0 |    | 2
+///        -3->
 using EdgeRotationOrder = std::array<std::array<std::uint8_t, 4>, 3>;
 
 class Cube : public std::enable_shared_from_this<Cube> {

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -97,11 +97,16 @@ public:
     }};
 
     /// Cube Type.
-    /// EMPTY: The cube does not have any faces.
-    /// SOLID: The cube has six equal faces (no indentations).
-    /// NORMAL: The cube has at least one indentation.
-    /// OCTANT: The cube is divided in 8 sub-cubes (children/octants).
-    enum class Type { EMPTY = 0b00U, SOLID = 0b01U, NORMAL = 0b10U, OCTANT = 0b11U };
+    enum class Type {
+        /// The cube does not have any faces.
+        EMPTY = 0b00U,
+        /// The cube has six equal faces (no indentations).
+        SOLID = 0b01U,
+        /// The cube has at least one indentation.
+        NORMAL = 0b10U,
+        /// The cube is divided in 8 sub-cubes (children/octants).
+        OCTANT = 0b11U
+    };
 
 private:
     Type m_type{Type::SOLID};

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -112,20 +112,6 @@ private:
     /// Removes all children recursively.
     void remove_children();
 
-    /// Rotate a cube.
-    /// The (child-, and edge-)orders implicitly contain the axis around which the cube will be rotated.
-    /// @param rotation_level The degree to which a cube should be rotated:
-    ///                       lvl mod 4 = 0 -> no rotation
-    ///                       lvl mod 4 = 1 -> 90°
-    ///                       lvl mod 4 = 2 -> 180°
-    ///                       lvl mod 4 = 3 -> 270°
-    /// @param edge_order The rotation-orders of the edges which should be rotated. At a 90° rotation, each first
-    ///                   element will go to the place of the second, each second to the third, etc.
-    /// @param child_order The rotation-orders of the children which should be rotated. At a 90° rotation, each first
-    ///                    element will go to the place of the second, each second to the third, etc.
-    void rotate(const std::uint8_t &rotation_level, const EdgeRotationOrder &edge_order,
-                const ChildRotationOrder &child_order);
-
     /// Rotate a cube by 90°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
     /// @param child_order The rotation-orders of the children which should be rotated.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -123,7 +123,7 @@ private:
     ///                   element will go to the place of the second, each second to the third, etc.
     /// @param child_order The rotation-orders of the children which should be rotated. At a 90° rotation, each first
     ///                    element will go to the place of the second, each second to the third, etc.
-    void rotate(const uint8_t &rotation_level, const EdgeRotationOrder &edge_order,
+    void rotate(const std::uint8_t &rotation_level, const EdgeRotationOrder &edge_order,
                 const ChildRotationOrder &child_order);
 
     /// Rotate a cube by 90°.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -59,7 +59,7 @@ public:
     static constexpr std::size_t EDGES = 12;
 
     /// IDs of the edges in the order of for a 90° rotation around the X-axis.
-    static constexpr EdgeRotationOrder X_EDGE_ROTATION_ORDER{
+    static constexpr EdgeRotationOrder ROTATION_ORDER_EDGE_X{
         {// First edge need to point to (crossing with) second, second to third, third to second (again) and fourth to
          // third
          {{2, 4, 11, 1}},
@@ -67,19 +67,19 @@ public:
          {{0, 9, 6, 3}}}};
 
     /// IDs of the edges in the order of for a 90° rotation around the Y-axis.
-    static constexpr EdgeRotationOrder Y_EDGE_ROTATION_ORDER{{{{0, 5, 9, 2}}, {{3, 8, 6, 11}}, {{1, 10, 7, 4}}}};
+    static constexpr EdgeRotationOrder ROTATION_ORDER_EDGE_Y{{{{0, 5, 9, 2}}, {{3, 8, 6, 11}}, {{1, 10, 7, 4}}}};
 
     /// IDs of the edges in the order of for a 90° rotation around the Z-axis.
-    static constexpr EdgeRotationOrder Z_EDGE_ROTATION_ORDER{{{{1, 3, 10, 0}}, {{4, 6, 7, 9}}, {{2, 11, 8, 5}}}};
+    static constexpr EdgeRotationOrder ROTATION_ORDER_EDGE_Z{{{{1, 3, 10, 0}}, {{4, 6, 7, 9}}, {{2, 11, 8, 5}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the X-axis.
-    static constexpr ChildRotationOrder X_CHILD_ROTATION_ORDER{{{{0, 1, 3, 2}}, {{4, 5, 7, 6}}}};
+    static constexpr ChildRotationOrder CHILD_ROTATION_ORDER_X{{{{0, 1, 3, 2}}, {{4, 5, 7, 6}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the Y-axis.
-    static constexpr ChildRotationOrder Y_CHILD_ROTATION_ORDER{{{{0, 4, 5, 1}}, {{2, 6, 7, 3}}}};
+    static constexpr ChildRotationOrder CHILD_ROTATION_ORDER_Y{{{{0, 4, 5, 1}}, {{2, 6, 7, 3}}}};
 
     /// IDs of the children in the order of for a 90° rotation around the Z-axis.
-    static constexpr ChildRotationOrder Z_CHILD_ROTATION_ORDER{{{{0, 2, 6, 4}}, {{1, 3, 7, 5}}}};
+    static constexpr ChildRotationOrder CHILD_ROTATION_ORDER_Z{{{{0, 2, 6, 4}}, {{1, 3, 7, 5}}}};
 
     /// Cube Type.
     enum class Type {

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -33,7 +33,7 @@ using PolygonCache = std::shared_ptr<std::vector<Polygon>>;
 
 /// IDs of the children in a order so that we rotate the octants when moving the child with the first ID to the second
 /// ID, the second, to the third, ...
-using ChildRotationOrder = std::array<std::array<uint8_t, 4>, 2>;
+using ChildRotationOrder = std::array<std::array<std::uint8_t, 4>, 2>;
 
 /// IDs of the edges in a order so that we rotate the cube when moving the edge with the first ID to the second ID,
 /// the second, to the third, ...
@@ -43,7 +43,7 @@ using ChildRotationOrder = std::array<std::array<uint8_t, 4>, 2>;
 ///   ^    ^      Incorrect are all other variants.
 /// 0 |    | 2
 ///    -3->
-using EdgeRotationOrder = std::array<std::array<uint8_t, 4>, 3>;
+using EdgeRotationOrder = std::array<std::array<std::uint8_t, 4>, 3>;
 
 class Cube : public std::enable_shared_from_this<Cube> {
     friend void ::swap(Cube &lhs, Cube &rhs) noexcept;
@@ -131,7 +131,7 @@ private:
     /// Rotate elements by 90° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
     template <typename TYPE, std::size_t SIZE>
-    static void rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    static void rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Rotate a cube by 180°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
@@ -140,7 +140,7 @@ private:
     template <typename TYPE, std::size_t SIZE>
     /// Rotate elements by 180° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
-    static void rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    static void rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Rotate a cube by 270°.
     /// @param edge_order The rotation-orders of the edges which should be rotated.
@@ -149,7 +149,7 @@ private:
     /// Rotate elements by 270° (must contain the correct order for the rotation).
     /// @param order The rotation-order of the elements which should be rotated.
     template <typename TYPE, std::size_t SIZE>
-    static void rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+    static void rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Get the root to this cube.
     [[nodiscard]] std::weak_ptr<Cube> root() const noexcept;

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -31,7 +31,18 @@ using Polygon = std::array<glm::vec3, 3>;
 
 using PolygonCache = std::shared_ptr<std::vector<Polygon>>;
 
+/// IDs of the children in a order so that we rotate the octants when moving the child with the first ID to the second ID,
+/// the second, to the third, ...
 using ChildRotationOrder = std::array<std::array<uint8_t, 4>, 2>;
+
+/// IDs of the edges in a order so that we rotate the cube when moving the edge with the first ID to the second ID,
+/// the second, to the third, ...
+/// As we need to update the indentations, it is required that first two indentations in the array
+/// point in the correct order towards the same corner as the second two corners. Example:
+///    -1->       Correct are either {{0, 1, 3, 2}} or {{3, 2, 0, 1}}
+///   ^    ^      Incorrect are all other variants.
+/// 0 |    | 2
+///    -3->
 using EdgeRotationOrder = std::array<std::array<uint8_t, 4>, 3>;
 
 class Cube : public std::enable_shared_from_this<Cube> {
@@ -40,12 +51,12 @@ class Cube : public std::enable_shared_from_this<Cube> {
     friend std::shared_ptr<world::Cube> io::deserialize_octree_impl(const io::ByteStream &stream);
 
 public:
-    /// Maximum of sub cubes (childs)
+    /// Maximum number of sub cubes (children, i.e. octants)
     static constexpr std::size_t SUB_CUBES = 8;
-    /// Cube edges.
+    /// Number of edges a cube has.
     static constexpr std::size_t EDGES = 12;
 
-    // First two arrays are the edges not parallel to the axis, last array is parallel to the axis
+    /// IDs of the edges in the order of for a 90° rotation around the X-axis.
     static constexpr EdgeRotationOrder X_EDGE_ROTATION_ORDER {{
           // First edge need to point to (crossing with) second, second to third, third to second (again) and fourth to third
         {{2, 4, 11, 1}},
@@ -53,34 +64,43 @@ public:
         {{0, 9, 6, 3}}
     }};
 
+    /// IDs of the edges in the order of for a 90° rotation around the Y-axis.
     static constexpr EdgeRotationOrder Y_EDGE_ROTATION_ORDER {{
         {{0, 5, 9, 2}},
         {{3, 8, 6, 11}},
         {{1, 10, 7, 4}}
     }};
 
+    /// IDs of the edges in the order of for a 90° rotation around the Z-axis.
     static constexpr EdgeRotationOrder Z_EDGE_ROTATION_ORDER {{
         {{1, 3, 10, 0}},
         {{4, 6, 7, 9}},
         {{2, 11, 8, 5}}
     }};
 
+    /// IDs of the children in the order of for a 90° rotation around the X-axis.
     static constexpr ChildRotationOrder X_CHILD_ROTATION_ORDER {{
         {{0, 1, 3, 2}},
         {{4, 5, 7, 6}}
     }};
 
+    /// IDs of the children in the order of for a 90° rotation around the Y-axis.
     static constexpr ChildRotationOrder Y_CHILD_ROTATION_ORDER {{
         {{0, 4, 5, 1}},
         {{2, 6, 7, 3}}
     }};
 
+    /// IDs of the children in the order of for a 90° rotation around the Z-axis.
     static constexpr ChildRotationOrder Z_CHILD_ROTATION_ORDER {{
         {{0, 2, 6, 4}},
         {{1, 3, 7, 5}}
     }};
 
     /// Cube Type.
+    /// EMPTY: The cube does not have any faces.
+    /// SOLID: The cube has six equal faces (no indentations).
+    /// NORMAL: The cube has at least one indentation.
+    /// OCTANT: The cube is divided in 8 sub-cubes (children/octants).
     enum class Type { EMPTY = 0b00U, SOLID = 0b01U, NORMAL = 0b10U, OCTANT = 0b11U };
 
 private:
@@ -93,16 +113,54 @@ private:
 
     /// Indentations, should only be used if it is a geometry cube.
     std::array<Indentation, Cube::EDGES> m_indentations{};
-    std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> m_childs{};
+    std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> m_children{};
 
     /// Only geometry cube (Type::SOLID and Type::Normal) have a polygon cache.
     mutable PolygonCache m_polygon_cache{nullptr};
     mutable bool m_polygon_cache_valid{false};
 
-    /// Removes all childs recursive.
-    void remove_childs();
+    /// Removes all children recursively.
+    void remove_children();
 
-    void rotate(const uint8_t rotation_level, const EdgeRotationOrder corner_order, const ChildRotationOrder child_order);
+    /// Rotate a cube.
+    /// The (child-, and edge-)orders implicitly contain the axis around which the cube will be rotated.
+    /// @param rotation_level The degree to which a cube should be rotated:
+    ///                       lvl mod 4 = 0 -> no rotation
+    ///                       lvl mod 4 = 1 -> 90°
+    ///                       lvl mod 4 = 2 -> 180°
+    ///                       lvl mod 4 = 3 -> 270°
+    /// @param edge_order The rotation-orders of the edges which should be rotated. At a 90° rotation, each first
+    ///                   element will go to the place of the second, each second to the third, etc.
+    /// @param child_order The rotation-orders of the children which should be rotated. At a 90° rotation, each first
+    ///                    element will go to the place of the second, each second to the third, etc.
+    void rotate(const uint8_t &rotation_level, const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
+
+    /// Rotate a cube by 90°.
+    /// @param edge_order The rotation-orders of the edges which should be rotated.
+    /// @param child_order The rotation-orders of the children which should be rotated.
+    void rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
+    /// Rotate elements by 90° (must contain the correct order for the rotation).
+    /// @param order The rotation-order of the elements which should be rotated.
+    template<typename TYPE, std::size_t SIZE>
+    static void rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+
+    /// Rotate a cube by 180°.
+    /// @param edge_order The rotation-orders of the edges which should be rotated.
+    /// @param child_order The rotation-orders of the children which should be rotated.
+    void rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
+    template<typename TYPE, std::size_t SIZE>
+    /// Rotate elements by 180° (must contain the correct order for the rotation).
+    /// @param order The rotation-order of the elements which should be rotated.
+    static void rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
+
+    /// Rotate a cube by 270°.
+    /// @param edge_order The rotation-orders of the edges which should be rotated.
+    /// @param child_order The rotation-orders of the children which should be rotated.
+    void rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order);
+    /// Rotate elements by 270° (must contain the correct order for the rotation).
+    /// @param order The rotation-order of the elements which should be rotated.
+    template<typename TYPE, std::size_t SIZE>
+    static void rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements);
 
     /// Get the root to this cube.
     [[nodiscard]] std::weak_ptr<Cube> root() const noexcept;
@@ -136,8 +194,8 @@ public:
     /// Get type.
     [[nodiscard]] Type type() const noexcept;
 
-    /// Get childs.
-    [[nodiscard]] const std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> &childs() const;
+    /// Get children.
+    [[nodiscard]] const std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> &children() const;
     /// Get indentations.
     [[nodiscard]] std::array<Indentation, Cube::EDGES> indentations() const noexcept;
 
@@ -147,9 +205,12 @@ public:
     /// @param positive_direction Indent in  positive axis direction.
     void indent(std::uint8_t edge_id, bool positive_direction, std::uint8_t steps);
     /// Rotate a cube on one axis.
-    /// @param axis Axis to rotate on (all values except must be 0 or a multiple of 4 [which indicates no rotation]).
-    ///             0 = rotate by 0°, 1 = rotate by 90°, 2 = rotate by 180°, 3 = rotate by 270°
-    ///             -1 = rotate by 270°, -2 = rotate by 180°, -3 = rotate by 90°
+    /// @param axis Axis to rotate the cube around. Only one of x, y, or z may not be 0. If this that value
+    ///              - mod 4 = 0 then no rotation
+    ///              - mod 4 = 1 then a 90° rotation
+    ///              - mod 4 = 2 then a 180° rotation
+    ///              - mod 4 = 3 then a 270° rotation
+    ///             will be performed.
     void rotate(const glm::vec<3, int8_t> &axis);
 
     /// TODO: in special cases some polygons have no surface, if completely surrounded by others

--- a/include/inexor/vulkan-renderer/world/indentation.hpp
+++ b/include/inexor/vulkan-renderer/world/indentation.hpp
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] std::uint8_t end() const noexcept;
     /// Difference between start and end.
     [[nodiscard]] std::uint8_t offset() const noexcept;
-
+    /// Mirror the indentation, such that the distance from 0 to start and distance from end to max switches
     void mirror();
 
     /// Positive steps into the direction of end.

--- a/include/inexor/vulkan-renderer/world/indentation.hpp
+++ b/include/inexor/vulkan-renderer/world/indentation.hpp
@@ -35,6 +35,8 @@ public:
     /// Difference between start and end.
     [[nodiscard]] std::uint8_t offset() const noexcept;
 
+    void mirror();
+
     /// Positive steps into the direction of end.
     void indent_start(std::int8_t steps) noexcept;
     /// Positive steps into the direction of start.

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -181,6 +181,9 @@ VkResult Application::load_octree_geometry() {
         child->indent(1, false, 2);
     }
 
+    cube->childs()[3]->rotate({0, 1, 0});
+    cube->childs()[6]->rotate({0, 0, 1});
+
     for (const auto &polygons : cube->polygons(true)) {
         for (const auto &triangle : *polygons) {
             for (const auto &vertex : triangle) {

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -174,15 +174,15 @@ VkResult Application::load_octree_geometry() {
 
     std::shared_ptr<world::Cube> cube =
         std::make_shared<world::Cube>(world::Cube::Type::OCTANT, 2.0f, glm::vec3{0, -1, -1});
-    for (const auto &child : cube->childs()) {
+    for (const auto &child : cube->children()) {
         child->set_type(world::Cube::Type::NORMAL);
         child->indent(8, true, 3);
         child->indent(11, true, 5);
         child->indent(1, false, 2);
     }
 
-    cube->childs()[3]->rotate({0, 1, 0});
-    cube->childs()[6]->rotate({0, 0, 1});
+    cube->children()[3]->rotate({0, 1, 0});
+    cube->children()[6]->rotate({0, 0, 1});
 
     for (const auto &polygons : cube->polygons(true)) {
         for (const auto &triangle : *polygons) {

--- a/src/vulkan-renderer/io/octree_parser.cpp
+++ b/src/vulkan-renderer/io/octree_parser.cpp
@@ -21,7 +21,7 @@ ByteStream serialize_octree_impl<0>(const std::shared_ptr<const world::Cube> cub
     iter_func = [&iter_func, &writer](const std::shared_ptr<const world::Cube> &cube) {
         writer.write(cube->type());
         if (cube->type() == world::Cube::Type::OCTANT) {
-            for (const auto &child : cube->childs()) {
+            for (const auto &child : cube->children()) {
                 iter_func(child);
             }
             return;
@@ -51,7 +51,7 @@ std::shared_ptr<world::Cube> deserialize_octree_impl<0>(const ByteStream &stream
     iter_func = [&iter_func, &reader](std::shared_ptr<world::Cube> &cube) {
         cube->set_type(reader.read<world::Cube::Type>());
         if (cube->type() == world::Cube::Type::OCTANT) {
-            for (auto child : cube->childs()) {
+            for (auto child : cube->children()) {
                 iter_func(child);
             }
             return;

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -25,6 +25,113 @@ void Cube::remove_children() {
     }
 }
 
+void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
+    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
+        return;
+    }
+    if (m_type == Type::NORMAL) {
+        uint8_t i = 0;
+        for (const auto &order : edge_order) {
+            rotate_elements_90(order, m_indentations);
+            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
+            // (as the last array contains the edges parallel to the axis around which we rotate)
+            if (i++ < 2) {
+                m_indentations[order[0]].mirror();
+                m_indentations[order[2]].mirror();
+            }
+        }
+        return;
+    }
+    if (m_type == Type::OCTANT) {
+        for (const auto &child : children()) {
+            child->rotate_90(edge_order, child_order);
+        }
+        for (const auto &order : child_order) {
+            rotate_elements_90(order, m_children);
+        }
+    }
+}
+
+template <typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    auto tmp = elements[order[3]];
+    elements[order[3]] = std::move(elements[order[2]]);
+    elements[order[2]] = std::move(elements[order[1]]);
+    elements[order[1]] = std::move(elements[order[0]]);
+    elements[order[0]] = tmp;
+}
+
+void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
+    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
+        return;
+    }
+    if (m_type == Type::NORMAL) {
+        uint8_t i = 0;
+        for (const auto &order : edge_order) {
+            rotate_elements_180(order, m_indentations);
+            // All indentations need to be mirrored.
+            if (i < 2) {
+                m_indentations[order[0]].mirror();
+                m_indentations[order[1]].mirror();
+                m_indentations[order[2]].mirror();
+                m_indentations[order[3]].mirror();
+            }
+            i++;
+        }
+    }
+    if (m_type == Type::OCTANT) {
+        for (const auto &child : children()) {
+            child->rotate_180(edge_order, child_order);
+        }
+        for (const auto &order : child_order) {
+            rotate_elements_180(order, m_children);
+        }
+    }
+}
+
+template <typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    std::swap(elements[order[0]], elements[order[2]]);
+    std::swap(elements[order[1]], elements[order[3]]);
+}
+
+void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
+    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
+        return;
+    }
+    if (m_type == Type::NORMAL) {
+        uint8_t i = 0;
+        for (const auto &order : edge_order) {
+            rotate_elements_270(order, m_indentations);
+            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
+            // (as the last array contains the edges parallel to the axis around which we rotate)
+            if (i < 2) {
+                m_indentations[order[1]].mirror();
+                m_indentations[order[3]].mirror();
+            }
+            i++;
+        }
+        return;
+    }
+    if (m_type == Type::OCTANT) {
+        for (const auto &child : children()) {
+            child->rotate_270(edge_order, child_order);
+        }
+        for (const auto &order : child_order) {
+            rotate_elements_270(order, m_children);
+        }
+    }
+}
+
+template <typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    auto tmp = elements[order[1]];
+    elements[order[3]] = std::move(elements[order[0]]);
+    elements[order[2]] = std::move(elements[order[3]]);
+    elements[order[1]] = std::move(elements[order[2]]);
+    elements[order[0]] = tmp;
+}
+
 std::weak_ptr<Cube> Cube::root() const noexcept {
     if (auto parent = m_parent.lock(); parent != nullptr) {
         while (!parent->is_root()) {
@@ -237,113 +344,6 @@ void Cube::rotate(const glm::vec<3, int8_t> &axis) {
     default:
         assert(false);
     }
-}
-
-void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
-    if (m_type == Type::NORMAL) {
-        uint8_t i = 0;
-        for (const auto &order : edge_order) {
-            rotate_elements_90(order, m_indentations);
-            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
-            // (as the last array contains the edges parallel to the axis around which we rotate)
-            if (i++ < 2) {
-                m_indentations[order[0]].mirror();
-                m_indentations[order[2]].mirror();
-            }
-        }
-        return;
-    }
-    if (m_type == Type::OCTANT) {
-        for (const auto &child : children()) {
-            child->rotate_90(edge_order, child_order);
-        }
-        for (const auto &order : child_order) {
-            rotate_elements_90(order, m_children);
-        }
-    }
-}
-
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
-    auto tmp = elements[order[3]];
-    elements[order[3]] = std::move(elements[order[2]]);
-    elements[order[2]] = std::move(elements[order[1]]);
-    elements[order[1]] = std::move(elements[order[0]]);
-    elements[order[0]] = tmp;
-}
-
-void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
-    if (m_type == Type::NORMAL) {
-        uint8_t i = 0;
-        for (const auto &order : edge_order) {
-            rotate_elements_180(order, m_indentations);
-            // All indentations need to be mirrored.
-            if (i < 2) {
-                m_indentations[order[0]].mirror();
-                m_indentations[order[1]].mirror();
-                m_indentations[order[2]].mirror();
-                m_indentations[order[3]].mirror();
-            }
-            i++;
-        }
-    }
-    if (m_type == Type::OCTANT) {
-        for (const auto &child : children()) {
-            child->rotate_180(edge_order, child_order);
-        }
-        for (const auto &order : child_order) {
-            rotate_elements_180(order, m_children);
-        }
-    }
-}
-
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
-    std::swap(elements[order[0]], elements[order[2]]);
-    std::swap(elements[order[1]], elements[order[3]]);
-}
-
-void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
-    if (m_type == Type::NORMAL) {
-        uint8_t i = 0;
-        for (const auto &order : edge_order) {
-            rotate_elements_270(order, m_indentations);
-            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
-            // (as the last array contains the edges parallel to the axis around which we rotate)
-            if (i < 2) {
-                m_indentations[order[1]].mirror();
-                m_indentations[order[3]].mirror();
-            }
-            i++;
-        }
-        return;
-    }
-    if (m_type == Type::OCTANT) {
-        for (const auto &child : children()) {
-            child->rotate_270(edge_order, child_order);
-        }
-        for (const auto &order : child_order) {
-            rotate_elements_270(order, m_children);
-        }
-    }
-}
-
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
-    auto tmp = elements[order[1]];
-    elements[order[3]] = std::move(elements[order[0]]);
-    elements[order[2]] = std::move(elements[order[3]]);
-    elements[order[1]] = std::move(elements[order[2]]);
-    elements[order[0]] = tmp;
 }
 
 void Cube::update_polygon_cache() const {

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -12,15 +12,15 @@ void swap(inexor::vulkan_renderer::world::Cube &lhs, inexor::vulkan_renderer::wo
     std::swap(lhs.m_position, rhs.m_position);
     std::swap(lhs.m_parent, rhs.m_parent);
     std::swap(lhs.m_indentations, rhs.m_indentations);
-    std::swap(lhs.m_childs, rhs.m_childs);
+    std::swap(lhs.m_children, rhs.m_children);
     std::swap(lhs.m_polygon_cache, rhs.m_polygon_cache);
     std::swap(lhs.m_polygon_cache_valid, rhs.m_polygon_cache_valid);
 }
 
 namespace inexor::vulkan_renderer::world {
-void Cube::remove_childs() {
-    for (auto &child : m_childs) {
-        child->remove_childs();
+void Cube::remove_children() {
+    for (auto &child : m_children) {
+        child->remove_children();
         child.reset();
     }
 }
@@ -88,8 +88,8 @@ Cube::Cube(const Cube &rhs) : Cube(rhs.m_type, rhs.m_size, rhs.m_position) {
     if (m_type == Type::NORMAL) {
         m_indentations = rhs.m_indentations;
     } else if (m_type == Type::OCTANT) {
-        for (std::size_t idx = 0; idx <= rhs.m_childs.size(); idx++) {
-            m_childs[idx] = std::make_shared<Cube>(*rhs.m_childs[idx]);
+        for (std::size_t idx = 0; idx <= rhs.m_children.size(); idx++) {
+            m_children[idx] = std::make_shared<Cube>(*rhs.m_children[idx]);
         }
     }
     m_polygon_cache_valid = rhs.m_polygon_cache_valid;
@@ -109,12 +109,12 @@ Cube &Cube::operator=(Cube rhs) {
 
 std::shared_ptr<Cube> Cube::operator[](std::size_t idx) {
     assert(idx <= SUB_CUBES);
-    return m_childs[idx];
+    return m_children[idx];
 }
 
 const std::shared_ptr<const Cube> Cube::operator[](std::size_t idx) const {
     assert(idx <= SUB_CUBES);
-    return m_childs[idx];
+    return m_children[idx];
 }
 
 bool Cube::is_root() const noexcept {
@@ -137,7 +137,7 @@ std::size_t Cube::count_geometry_cubes() const noexcept {
     }
     if (m_type == Type::OCTANT) {
         std::size_t count = 0;
-        for (const auto &cube : m_childs) {
+        for (const auto &cube : m_children) {
             count += cube->count_geometry_cubes();
         }
         return count;
@@ -162,18 +162,18 @@ void Cube::set_type(const Type new_type) {
             return std::make_shared<Cube>(weak_from_this(), Type::SOLID, half_size, m_position + offset);
         };
         // about the order look into the octree documentation
-        m_childs = {create_cube({0, 0, 0}),
-                    create_cube({0, 0, half_size}),
-                    create_cube({0, half_size, 0}),
-                    create_cube({0, half_size, half_size}),
-                    create_cube({half_size, 0, 0}),
-                    create_cube({half_size, 0, half_size}),
-                    create_cube({half_size, half_size, 0}),
-                    create_cube({half_size, half_size, half_size})};
+        m_children = {create_cube({0, 0, 0}),
+                      create_cube({0, 0, half_size}),
+                      create_cube({0, half_size, 0}),
+                      create_cube({0, half_size, half_size}),
+                      create_cube({half_size, 0, 0}),
+                      create_cube({half_size, 0, half_size}),
+                      create_cube({half_size, half_size, 0}),
+                      create_cube({half_size, half_size, half_size})};
         break;
     }
     if (m_type == Type::OCTANT && new_type != Type::OCTANT) {
-        remove_childs();
+        remove_children();
     }
     m_polygon_cache_valid = false;
     m_type = new_type;
@@ -184,8 +184,8 @@ Cube::Type Cube::type() const noexcept {
     return m_type;
 }
 
-const std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> &Cube::childs() const {
-    return m_childs;
+const std::array<std::shared_ptr<Cube>, Cube::SUB_CUBES> &Cube::children() const {
+    return m_children;
 }
 
 std::array<Indentation, Cube::EDGES> Cube::indentations() const noexcept {
@@ -224,105 +224,129 @@ void Cube::rotate(const glm::vec<3, int8_t> &axis) {
     }
     const auto edge_order = x != 0 ? X_EDGE_ROTATION_ORDER : y != 0 ? Y_EDGE_ROTATION_ORDER : Z_EDGE_ROTATION_ORDER;
     const auto child_order = x != 0 ? X_CHILD_ROTATION_ORDER : y != 0 ? Y_CHILD_ROTATION_ORDER : Z_CHILD_ROTATION_ORDER;
-    rotate(rotation_level, edge_order, child_order);
+    switch (rotation_level) {
+        case 1:
+            rotate_90(edge_order, child_order);
+            return;
+        case 2:
+            rotate_180(edge_order, child_order);
+            return;
+        case 3:
+            rotate_270(edge_order, child_order);
+            return;
+        default:
+            assert(false);
+    }
 }
-void Cube::rotate(const uint8_t rotation_level, const EdgeRotationOrder edge_order, const ChildRotationOrder child_order) {
+
+void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
     if (m_type == Type::EMPTY || m_type == Type::SOLID) {
         return;
     }
     if (m_type == Type::NORMAL) {
-        // We could of course only implement rotation_level == 1 and do a recursive call, but to save moves
-        // we'll implement each rotation_level by hand.
-        if (rotation_level == 1) {
-            // Rotate the indentations by 90°
-            uint8_t i = 0;
-            for (const auto &order: edge_order) {
-                auto tmp = m_indentations[order[3]];
-                m_indentations[order[3]] = std::move(m_indentations[order[2]]);
-                m_indentations[order[2]] = std::move(m_indentations[order[1]]);
-                m_indentations[order[1]] = std::move(m_indentations[order[0]]);
-                m_indentations[order[0]] = tmp;
-                // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
-                // (as the last array contains the edges parallel to the axis around which we rotate)
-                if (i < 2) {
-                    m_indentations[order[0]].mirror();
-                    m_indentations[order[2]].mirror();
-                }
-                i++;
+        uint8_t i = 0;
+        for (const auto &order: edge_order) {
+            rotate_elements_90(order, m_indentations);
+            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
+            // (as the last array contains the edges parallel to the axis around which we rotate)
+            if (i < 2) {
+                m_indentations[order[0]].mirror();
+                m_indentations[order[2]].mirror();
             }
-            return;
+            i++;
         }
-        if (rotation_level == 2) {
-            // Rotate the indentations by 180°
-            uint8_t i = 0;
-            for (const auto &order: edge_order) {
-                std::swap(m_indentations[order[0]], m_indentations[order[2]]);
-                std::swap(m_indentations[order[1]], m_indentations[order[3]]);
-                // All indentations need to be mirrored.
-                if (i < 2) {
-                    m_indentations[order[0]].mirror();
-                    m_indentations[order[1]].mirror();
-                    m_indentations[order[2]].mirror();
-                    m_indentations[order[3]].mirror();
-                }
-                i++;
-            }
-            return;
+        return;
+    }
+    if (m_type == Type::OCTANT) {
+        for (const auto &child: children()) {
+            child->rotate_90(edge_order, child_order);
         }
-        if (rotation_level == 3) {
-            // Rotate the indentations by 270°
-            uint8_t i = 0;
-            for (const auto &order: edge_order) {
-                auto tmp = m_indentations[order[1]];
-                m_indentations[order[3]] = std::move(m_indentations[order[0]]);
-                m_indentations[order[2]] = std::move(m_indentations[order[3]]);
-                m_indentations[order[1]] = std::move(m_indentations[order[2]]);
-                m_indentations[order[0]] = tmp;
-                // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
-                // (as the last array contains the edges parallel to the axis around which we rotate)
-                if (i < 2) {
-                    m_indentations[order[1]].mirror();
-                    m_indentations[order[3]].mirror();
-                }
-                i++;
+        for (const auto &order: child_order) {
+            rotate_elements_90(order, m_children);
+        }
+    }
+}
+
+template<typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    auto tmp = elements[order[3]];
+    elements[order[3]] = std::move(elements[order[2]]);
+    elements[order[2]] = std::move(elements[order[1]]);
+    elements[order[1]] = std::move(elements[order[0]]);
+    elements[order[0]] = tmp;
+}
+
+void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
+    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
+        return;
+    }
+    if (m_type == Type::NORMAL) {
+        uint8_t i = 0;
+        for (const auto &order: edge_order) {
+            rotate_elements_180(order, m_indentations);
+            // All indentations need to be mirrored.
+            if (i < 2) {
+                m_indentations[order[0]].mirror();
+                m_indentations[order[1]].mirror();
+                m_indentations[order[2]].mirror();
+                m_indentations[order[3]].mirror();
             }
-            return;
+            i++;
         }
     }
     if (m_type == Type::OCTANT) {
-        for (const auto &child: childs()) {
-            child->rotate(rotation_level, edge_order, child_order);
+        for (const auto &child: children()) {
+            child->rotate_180(edge_order, child_order);
         }
-        if (rotation_level == 1) {
-            for (const auto &order: child_order) {
-                auto tmp = m_childs[order[3]];
-                m_childs[order[3]] = std::move(m_childs[order[2]]);
-                m_childs[order[2]] = std::move(m_childs[order[1]]);
-                m_childs[order[1]] = std::move(m_childs[order[0]]);
-                m_childs[order[0]] = tmp;
-            }
-            return;
-        }
-        if (rotation_level == 2) {
-            for (const auto &order: child_order) {
-                std::swap(m_childs[order[0]], m_childs[order[2]]);
-                std::swap(m_childs[order[1]], m_childs[order[3]]);
-            }
-            return;
-        }
-        if (rotation_level == 3) {
-            for (const auto &order: child_order) {
-                auto tmp = m_childs[order[1]];
-                m_childs[order[3]] = std::move(m_childs[order[0]]);
-                m_childs[order[2]] = std::move(m_childs[order[3]]);
-                m_childs[order[1]] = std::move(m_childs[order[2]]);
-                m_childs[order[0]] = tmp;
-            }
-            return;
+        for (const auto &order: child_order) {
+            rotate_elements_180(order, m_children);
         }
     }
-    assert(false);
 }
+
+template<typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    std::swap(elements[order[0]], elements[order[2]]);
+    std::swap(elements[order[1]], elements[order[3]]);
+}
+
+void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
+    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
+        return;
+    }
+    if (m_type == Type::NORMAL) {
+        uint8_t i = 0;
+        for (const auto &order: edge_order) {
+            rotate_elements_270(order, m_indentations);
+            // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
+            // (as the last array contains the edges parallel to the axis around which we rotate)
+            if (i < 2) {
+                m_indentations[order[1]].mirror();
+                m_indentations[order[3]].mirror();
+            }
+            i++;
+        }
+        return;
+    }
+    if (m_type == Type::OCTANT) {
+        for (const auto &child: children()) {
+            child->rotate_270(edge_order, child_order);
+        }
+        for (const auto &order: child_order) {
+            rotate_elements_270(order, m_children);
+        }
+    }
+}
+
+template<typename TYPE, std::size_t SIZE>
+void Cube::rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+    auto tmp = elements[order[1]];
+    elements[order[3]] = std::move(elements[order[0]]);
+    elements[order[2]] = std::move(elements[order[3]]);
+    elements[order[1]] = std::move(elements[order[2]]);
+    elements[order[0]] = tmp;
+}
+
 
 void Cube::update_polygon_cache() const {
     if (m_type == Type::OCTANT || m_type == Type::EMPTY) {
@@ -402,7 +426,7 @@ std::vector<PolygonCache> Cube::polygons(const bool update_invalid) const {
     // pre-order traversal
     collect = [&collect, &polygons, &update_invalid](std::shared_ptr<const world::Cube> cube) {
         if (cube->type() == world::Cube::Type::OCTANT) {
-            for (const auto &child : cube->childs()) {
+            for (const auto &child : cube->children()) {
                 collect(child);
             }
             return;

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -225,17 +225,17 @@ void Cube::rotate(const glm::vec<3, int8_t> &axis) {
     const auto edge_order = x != 0 ? X_EDGE_ROTATION_ORDER : y != 0 ? Y_EDGE_ROTATION_ORDER : Z_EDGE_ROTATION_ORDER;
     const auto child_order = x != 0 ? X_CHILD_ROTATION_ORDER : y != 0 ? Y_CHILD_ROTATION_ORDER : Z_CHILD_ROTATION_ORDER;
     switch (rotation_level) {
-        case 1:
-            rotate_90(edge_order, child_order);
-            return;
-        case 2:
-            rotate_180(edge_order, child_order);
-            return;
-        case 3:
-            rotate_270(edge_order, child_order);
-            return;
-        default:
-            assert(false);
+    case 1:
+        rotate_90(edge_order, child_order);
+        return;
+    case 2:
+        rotate_180(edge_order, child_order);
+        return;
+    case 3:
+        rotate_270(edge_order, child_order);
+        return;
+    default:
+        assert(false);
     }
 }
 
@@ -245,7 +245,7 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
     }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
-        for (const auto &order: edge_order) {
+        for (const auto &order : edge_order) {
             rotate_elements_90(order, m_indentations);
             // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
             // (as the last array contains the edges parallel to the axis around which we rotate)
@@ -257,16 +257,16 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
         return;
     }
     if (m_type == Type::OCTANT) {
-        for (const auto &child: children()) {
+        for (const auto &child : children()) {
             child->rotate_90(edge_order, child_order);
         }
-        for (const auto &order: child_order) {
+        for (const auto &order : child_order) {
             rotate_elements_90(order, m_children);
         }
     }
 }
 
-template<typename TYPE, std::size_t SIZE>
+template <typename TYPE, std::size_t SIZE>
 void Cube::rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     auto tmp = elements[order[3]];
     elements[order[3]] = std::move(elements[order[2]]);
@@ -281,7 +281,7 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
     }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
-        for (const auto &order: edge_order) {
+        for (const auto &order : edge_order) {
             rotate_elements_180(order, m_indentations);
             // All indentations need to be mirrored.
             if (i < 2) {
@@ -294,16 +294,16 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
         }
     }
     if (m_type == Type::OCTANT) {
-        for (const auto &child: children()) {
+        for (const auto &child : children()) {
             child->rotate_180(edge_order, child_order);
         }
-        for (const auto &order: child_order) {
+        for (const auto &order : child_order) {
             rotate_elements_180(order, m_children);
         }
     }
 }
 
-template<typename TYPE, std::size_t SIZE>
+template <typename TYPE, std::size_t SIZE>
 void Cube::rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     std::swap(elements[order[0]], elements[order[2]]);
     std::swap(elements[order[1]], elements[order[3]]);
@@ -315,7 +315,7 @@ void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOr
     }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
-        for (const auto &order: edge_order) {
+        for (const auto &order : edge_order) {
             rotate_elements_270(order, m_indentations);
             // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
             // (as the last array contains the edges parallel to the axis around which we rotate)
@@ -328,16 +328,16 @@ void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOr
         return;
     }
     if (m_type == Type::OCTANT) {
-        for (const auto &child: children()) {
+        for (const auto &child : children()) {
             child->rotate_270(edge_order, child_order);
         }
-        for (const auto &order: child_order) {
+        for (const auto &order : child_order) {
             rotate_elements_270(order, m_children);
         }
     }
 }
 
-template<typename TYPE, std::size_t SIZE>
+template <typename TYPE, std::size_t SIZE>
 void Cube::rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     auto tmp = elements[order[1]];
     elements[order[3]] = std::move(elements[order[0]]);
@@ -345,7 +345,6 @@ void Cube::rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<T
     elements[order[1]] = std::move(elements[order[2]]);
     elements[order[0]] = tmp;
 }
-
 
 void Cube::update_polygon_cache() const {
     if (m_type == Type::OCTANT || m_type == Type::EMPTY) {

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -26,9 +26,6 @@ void Cube::remove_children() {
 }
 
 void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
         for (const auto &order : edge_order) {
@@ -41,8 +38,7 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
             }
         }
         return;
-    }
-    if (m_type == Type::OCTANT) {
+    } else if (m_type == Type::OCTANT) {
         for (const auto &child : children()) {
             child->rotate_90(edge_order, child_order);
         }
@@ -62,9 +58,6 @@ void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::arr
 }
 
 void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
         for (const auto &order : edge_order) {
@@ -80,8 +73,7 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
             }
             i++;
         }
-    }
-    if (m_type == Type::OCTANT) {
+    } else if (m_type == Type::OCTANT) {
         for (const auto &child : children()) {
             child->rotate_180(edge_order, child_order);
         }
@@ -98,9 +90,6 @@ void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::ar
 }
 
 void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOrder &child_order) {
-    if (m_type == Type::EMPTY || m_type == Type::SOLID) {
-        return;
-    }
     if (m_type == Type::NORMAL) {
         uint8_t i = 0;
         for (const auto &order : edge_order) {
@@ -114,8 +103,7 @@ void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOr
             i++;
         }
         return;
-    }
-    if (m_type == Type::OCTANT) {
+    } else if (m_type == Type::OCTANT) {
         for (const auto &child : children()) {
             child->rotate_270(edge_order, child_order);
         }
@@ -159,8 +147,7 @@ std::array<glm::vec3, 8> Cube::vertices() const noexcept {
                  {max.x, pos.y, max.z},
                  {max.x, max.y, pos.z},
                  {max.x, max.y, max.z}}};
-    }
-    if (m_type == Type::NORMAL) {
+    } else if (m_type == Type::NORMAL) {
         const float step = m_size / Indentation::MAX;
         const std::array<Indentation, Cube::EDGES> &ind = m_indentations;
 
@@ -243,8 +230,7 @@ std::size_t Cube::grid_level() const noexcept {
 std::size_t Cube::count_geometry_cubes() const noexcept {
     if (m_type == Type::SOLID || m_type == Type::NORMAL) {
         return 1;
-    }
-    if (m_type == Type::OCTANT) {
+    } else if (m_type == Type::OCTANT) {
         std::size_t count = 0;
         for (const auto &cube : m_children) {
             count += cube->count_geometry_cubes();
@@ -372,8 +358,7 @@ void Cube::update_polygon_cache() const {
     if (m_type == Type::SOLID) {
         m_polygon_cache_valid = true;
         return;
-    }
-    if (m_type == Type::NORMAL) {
+    } else if (m_type == Type::NORMAL) {
         const std::array<Indentation, Cube::EDGES> ind = m_indentations;
 
         // Check for each side if the side is convex, rotate the hypotenuse (middle diagonal edge) so it becomes convex!

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -249,11 +249,10 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
             rotate_elements_90(order, m_indentations);
             // Some indentations need to be mirrored, as the direction has changed. But only in the first two arrays
             // (as the last array contains the edges parallel to the axis around which we rotate)
-            if (i < 2) {
+            if (i++ < 2) {
                 m_indentations[order[0]].mirror();
                 m_indentations[order[2]].mirror();
             }
-            i++;
         }
         return;
     }

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -48,8 +48,8 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
     }
 }
 
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+template <typename T, std::size_t Size>
+void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements) {
     auto tmp = elements[order[3]];
     elements[order[3]] = std::move(elements[order[2]]);
     elements[order[2]] = std::move(elements[order[1]]);
@@ -83,8 +83,8 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
     }
 }
 
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+template <typename T, std::size_t Size>
+void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements) {
     std::swap(elements[order[0]], elements[order[2]]);
     std::swap(elements[order[1]], elements[order[3]]);
 }
@@ -113,8 +113,8 @@ void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOr
     }
 }
 
-template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+template <typename T, std::size_t Size>
+void Cube::rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<T, Size> &elements) {
     auto tmp = elements[order[1]];
     elements[order[3]] = std::move(elements[order[0]]);
     elements[order[2]] = std::move(elements[order[3]]);

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -71,6 +71,8 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
             rotate_elements_180(order, m_indentations);
             // All indentations need to be mirrored.
             if (i < 2) {
+                // only the first two arrays of edges in the EdgeRotationOrder are mirrored (as the last array contains
+                // the edges which are parallel to the axis and thus should not be mirrored).
                 m_indentations[order[0]].mirror();
                 m_indentations[order[1]].mirror();
                 m_indentations[order[2]].mirror();

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -267,7 +267,7 @@ void Cube::rotate_90(const EdgeRotationOrder &edge_order, const ChildRotationOrd
 }
 
 template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_90(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+void Cube::rotate_elements_90(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     auto tmp = elements[order[3]];
     elements[order[3]] = std::move(elements[order[2]]);
     elements[order[2]] = std::move(elements[order[1]]);
@@ -304,7 +304,7 @@ void Cube::rotate_180(const EdgeRotationOrder &edge_order, const ChildRotationOr
 }
 
 template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_180(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+void Cube::rotate_elements_180(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     std::swap(elements[order[0]], elements[order[2]]);
     std::swap(elements[order[1]], elements[order[3]]);
 }
@@ -338,7 +338,7 @@ void Cube::rotate_270(const EdgeRotationOrder &edge_order, const ChildRotationOr
 }
 
 template <typename TYPE, std::size_t SIZE>
-void Cube::rotate_elements_270(const std::array<uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
+void Cube::rotate_elements_270(const std::array<std::uint8_t, 4> &order, std::array<TYPE, SIZE> &elements) {
     auto tmp = elements[order[1]];
     elements[order[3]] = std::move(elements[order[0]]);
     elements[order[2]] = std::move(elements[order[3]]);

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -222,8 +222,8 @@ void Cube::rotate(const glm::vec<3, int8_t> &axis) {
     if (rotation_level == 0) {
         return;
     }
-    const auto edge_order = x != 0 ? X_EDGE_ROTATION_ORDER : y != 0 ? Y_EDGE_ROTATION_ORDER : Z_EDGE_ROTATION_ORDER;
-    const auto child_order = x != 0 ? X_CHILD_ROTATION_ORDER : y != 0 ? Y_CHILD_ROTATION_ORDER : Z_CHILD_ROTATION_ORDER;
+    const auto edge_order = x != 0 ? ROTATION_ORDER_EDGE_X : y != 0 ? ROTATION_ORDER_EDGE_Y : ROTATION_ORDER_EDGE_Z;
+    const auto child_order = x != 0 ? CHILD_ROTATION_ORDER_X : y != 0 ? CHILD_ROTATION_ORDER_Y : CHILD_ROTATION_ORDER_Z;
     switch (rotation_level) {
     case 1:
         rotate_90(edge_order, child_order);

--- a/src/vulkan-renderer/world/indentation.cpp
+++ b/src/vulkan-renderer/world/indentation.cpp
@@ -60,6 +60,12 @@ std::uint8_t Indentation::offset() const noexcept {
     return this->m_end - this->m_start;
 }
 
+void Indentation::mirror() {
+    std::uint8_t new_start = Indentation::MAX - m_end;
+    m_end = Indentation::MAX - m_start;
+    m_start = new_start;
+}
+
 void Indentation::indent_start(std::int8_t steps) noexcept {
     this->set_start(this->m_start + steps);
 }


### PR DESCRIPTION
I implemented several rotation methods. This was also a try by me to implement the methods as efficiently as possible, so I'll be very grateful on some insights on that.

What this PR includes:
 * Implementation of the rotate-method as per #190 
 * Refactoring (improving comments, renaming 'childs' to 'children')

I am not sure if the changes in the code from e99287cfb6e2e9d27edb3bcfaf4c108365d61ebe to cf51c2a6091563bdb56739e8941002e60a0efa4c are actually improving performance and not (too much) impair readability, so I would love to hear a comment on that.