### PR TITLE
[renderer] Remove redundant arguments which are available through device wrapper.

### DIFF
--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -72,8 +72,8 @@ protected:
 
     std::unique_ptr<wrapper::GLFWContext> m_glfw_context;
     std::unique_ptr<wrapper::Window> m_window;
-    std::unique_ptr<wrapper::Instance> m_vkinstance;
-    std::unique_ptr<wrapper::Device> m_vkdevice;
+    std::unique_ptr<wrapper::Instance> m_instance;
+    std::unique_ptr<wrapper::Device> m_device;
     std::unique_ptr<wrapper::WindowSurface> m_surface;
     std::unique_ptr<wrapper::Swapchain> m_swapchain;
     std::unique_ptr<wrapper::CommandPool> m_command_pool;

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <cstdint>
 #include <string>
@@ -8,12 +8,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
 class ResourceDescriptor;
 
 // TODO(): Make trivially copyable (this class doesn't really "own" the command buffer, more just an OOP wrapper)
 class CommandBuffer {
-
-private:
     VkCommandBuffer m_command_buffer{VK_NULL_HANDLE};
     const wrapper::Device &m_device;
     const std::string m_name;

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -7,16 +7,17 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class CommandPool {
-private:
-    VkDevice m_device;
+    const Device &m_device;
     VkCommandPool m_command_pool;
 
 public:
     /// @brief Creates a Vulkan command pool.
     /// @param device [in] The Vulkan device.
     /// @param queue_family_index [in] The queue family index for the command pool.
-    CommandPool(const VkDevice device, const std::uint32_t queue_family_index);
+    CommandPool(const Device &device, const std::uint32_t queue_family_index);
     CommandPool(const CommandPool &) = delete;
     CommandPool(CommandPool &&) noexcept;
     ~CommandPool();

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -12,7 +12,6 @@ namespace inexor::vulkan_renderer::wrapper {
 
 /// @brief A RAII wrapper for VkDevice, VkPhysicalDevice and VkQueues.
 class Device {
-private:
     VkDevice m_device;
     VkPhysicalDevice m_graphics_card;
     VmaAllocator m_allocator;
@@ -55,12 +54,10 @@ public:
     Device &operator=(Device &&) = default;
 
     [[nodiscard]] const VkDevice device() const {
-        assert(m_device);
         return m_device;
     }
 
     [[nodiscard]] const VkPhysicalDevice physical_device() const {
-        assert(m_graphics_card);
         return m_graphics_card;
     }
 
@@ -68,25 +65,22 @@ public:
         return m_allocator;
     }
 
+    [[nodiscard]] const std::string &gpu_name() const {
+        return m_gpu_name;
+    }
+
     [[nodiscard]] const VkQueue graphics_queue() const {
-        assert(m_graphics_queue);
         return m_graphics_queue;
     }
 
     [[nodiscard]] const VkQueue present_queue() const {
-        assert(m_present_queue);
         return m_present_queue;
-    }
-
-    [[nodiscard]] const std::string &gpu_name() const {
-        return m_gpu_name;
     }
 
     /// @note Transfer queues are the fastest way to copy data across the PCIe bus.
     /// They are heavily underutilized even in modern games.
     /// Transfer queues can be used asynchronously to graphics queuey.
     [[nodiscard]] const VkQueue transfer_queue() const {
-        assert(m_transfer_queue);
         return m_transfer_queue;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <cassert>
 #include <limits>
@@ -8,8 +8,9 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class Fence {
-private:
     const wrapper::Device &m_device;
     const std::string m_name;
     VkFence m_fence;
@@ -28,7 +29,6 @@ public:
     Fence &operator=(Fence &&) = default;
 
     [[nodiscard]] VkFence get() const {
-        assert(m_fence);
         return m_fence;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -1,23 +1,23 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
 class Swapchain;
 
 class Framebuffer {
-private:
     const wrapper::Device &m_device;
     VkFramebuffer m_framebuffer{VK_NULL_HANDLE};
     const std::string m_name;
 
 public:
-    Framebuffer(const wrapper::Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
-                const wrapper::Swapchain &swapchain, const std::string &name);
+    Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
+                const Swapchain &swapchain, const std::string &name);
     Framebuffer(const Framebuffer &) = delete;
     Framebuffer(Framebuffer &&) noexcept;
     ~Framebuffer();

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -7,12 +7,12 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class GPUMemoryBuffer {
 protected:
     std::string m_name;
-
-    VkDevice m_device;
-    VmaAllocator m_vma_allocator;
+    const Device &m_device;
     VkBuffer m_buffer{VK_NULL_HANDLE};
     VkDeviceSize m_buffer_size{0};
     VmaAllocation m_allocation{VK_NULL_HANDLE};
@@ -22,27 +22,24 @@ protected:
 public:
     /// @brief Creates a new GPU memory buffer.
     /// @param device [in] The Vulkan device from which the buffer will be created.
-    /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
     /// @param name [in] The internal name of the buffer.
     /// @param size [in] The size of the buffer in bytes.
     /// @param buffer_usage [in] The Vulkan buffer usage flags.
     /// @param memory_usage [in] The Vulkan Memory Allocator library's memory usage flags.
-    GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                    const VkDeviceSize &size, const VkBufferUsageFlags &buffer_usage,
-                    const VmaMemoryUsage &memory_usage);
+    GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &size,
+                    const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage);
 
     /// @brief Creates a new GPU memory buffer.
     /// @param device [in] The Vulkan device from which the buffer will be created.
-    /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
     /// @param name [in] The internal name of the buffer.
     /// @param buffer_size [in] The size of the buffer in bytes.
     /// @param data [in] The address of the data which will be copied.
     /// @param data_size [in] The size of the data which will be copied.
     /// @param buffer_usage [in] The Vulkan buffer usage flags.
     /// @param memory_usage [in] The Vulkan Memory Allocator library's memory usage flags.
-    GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                    const VkDeviceSize &buffer_size, void *data, const std::size_t data_size,
-                    const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage);
+    GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &buffer_size, void *data,
+                    const std::size_t data_size, const VkBufferUsageFlags &buffer_usage,
+                    const VmaMemoryUsage &memory_usage);
     GPUMemoryBuffer(const GPUMemoryBuffer &) = delete;
     GPUMemoryBuffer(GPUMemoryBuffer &&) noexcept;
     virtual ~GPUMemoryBuffer();

--- a/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
@@ -7,9 +7,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class GraphicsPipeline {
 private:
-    VkDevice device;
+    const Device &m_device;
     VkPipeline graphics_pipeline;
     VkPipelineCache pipeline_cache;
     std::string name;
@@ -33,7 +35,7 @@ public:
     /// @param window_width [in] The width of the window.
     /// @param window_height [in] The height of the window.
     /// @param name [in] The internal name of the graphics pipeline.
-    GraphicsPipeline(const VkDevice device, const VkPipelineLayout pipeline_layout, const VkRenderPass render_pass,
+    GraphicsPipeline(const Device &device, const VkPipelineLayout pipeline_layout, const VkRenderPass render_pass,
                      const std::vector<VkPipelineShaderStageCreateInfo> &shader_stages,
                      const std::vector<VkVertexInputBindingDescription> &vertex_binding,
                      const std::vector<VkVertexInputAttributeDescription> &attribute_binding,

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
-
 #include <vma/vk_mem_alloc.h>
 
 #include <cassert>
@@ -9,10 +7,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class Image {
 private:
     const wrapper::Device &m_device;
-    VmaAllocator m_vma_allocator;
     VmaAllocation m_allocation;
     VmaAllocationInfo m_allocation_info;
     VkImage m_image;
@@ -22,18 +21,16 @@ private:
 
 public:
     /// @brief Creates an image and a corresponding image view.
-    /// @param device [in] The Vulkan device.
-    /// @param graphics_card [in] The graphics card.
-    /// @param vma_allocator [in] The Vulkan Memory Allocator library handle.
+    /// @param device [in] A reference to the device wrapper.
     /// @param format [in] The image format.
     /// @param image_usage [in] The image usage flags.
     /// @param aspect_flags [in] The image aspect flags for the image view.
     /// @param sample_count [in] The sample count, mostly 1 if multisampling for this image is disabled.
     /// @param name [in] The internal name of this image.
     /// @param image_extent [in] The width and height of the image.
-    Image(const wrapper::Device &device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
-          const VkFormat format, const VkImageUsageFlags image_usage, const VkImageAspectFlags aspect_flags,
-          const VkSampleCountFlagBits sample_count, const std::string &name, const VkExtent2D image_extent);
+    Image(const Device &device, const VkFormat format, const VkImageUsageFlags image_usage,
+          const VkImageAspectFlags aspect_flags, const VkSampleCountFlagBits sample_count, const std::string &name,
+          const VkExtent2D image_extent);
     Image(const Image &) = delete;
     Image(Image &&) noexcept;
     ~Image();
@@ -46,12 +43,10 @@ public:
     }
 
     [[nodiscard]] VkImageView image_view() const {
-        assert(m_image_view);
         return m_image_view;
     }
 
     [[nodiscard]] VkImage get() const {
-        assert(m_image);
         return m_image;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
 
 #include <vma/vma_usage.h>
@@ -14,6 +13,8 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 /// @brief A structure which bundles vertex buffer and index buffer (if existent).
 /// It contains all data which are related to memory allocations for these buffers.
 /// @todo Driver developers recommend that you store multiple
@@ -25,9 +26,7 @@ namespace inexor::vulkan_renderer::wrapper {
 /// of course. This is known as aliasing and some Vulkan functions have explicit
 /// flags to specify that you want to do this.
 class MeshBuffer {
-
-private:
-    const wrapper::Device &m_device;
+    const Device &m_device;
     std::string m_name;
 
     GPUMemoryBuffer m_vertex_buffer;
@@ -50,30 +49,22 @@ public:
     MeshBuffer &operator=(MeshBuffer &&) = default;
 
     /// @brief Creates a new vertex buffer with an associated index buffer and copies memory into it.
-    MeshBuffer(const wrapper::Device &device, const VkQueue data_transfer_queue,
-               const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
-               const std::string &name, const VkDeviceSize size_of_vertex_structure,
+    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
                const std::size_t number_of_vertices, void *vertices, const VkDeviceSize size_of_index_structure,
                const std::size_t number_of_indices, void *indices);
 
     /// @brief Creates a new vertex buffer with an associated index buffer but does not copy memory into it.
     /// This is useful when you know the size of the buffer but you don't know it's data values yet.
-    MeshBuffer(const wrapper::Device &device, const VkQueue data_transfer_queue,
-               const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
-               const std::string &name, const VkDeviceSize size_of_vertex_structure,
+    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
                const std::size_t number_of_vertices, const VkDeviceSize size_of_index_structure,
                const std::size_t number_of_indices);
 
     /// @brief Creates a vertex buffer without index buffer, but copies the vertex data into it.
-    MeshBuffer(const wrapper::Device &device, const VkQueue data_transfer_queue,
-               const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
-               const std::string &name, const VkDeviceSize size_of_vertex_structure,
+    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
                const std::size_t number_of_vertices, void *vertices);
 
     /// @brief Creates a vertex buffer without index buffer and copies no vertex data into it.
-    MeshBuffer(const wrapper::Device &device, const VkQueue data_transfer_queue,
-               const std::uint32_t data_transfer_queue_family_index, const VmaAllocator vma_allocator,
-               const std::string &name, const VkDeviceSize size_of_vertex_structure,
+    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
                const std::size_t number_of_vertices);
 
     ~MeshBuffer() = default;
@@ -87,7 +78,6 @@ public:
     }
 
     [[nodiscard]] VkBuffer get_index_buffer() const {
-        assert(m_index_buffer);
         return m_index_buffer.value().buffer();
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -2,7 +2,6 @@
 
 #include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
 
 #include <vulkan/vulkan_core.h>
 
@@ -12,23 +11,24 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 /// @brief A OnceCommandBuffer is a command buffer which is being used only once.
 class OnceCommandBuffer {
-private:
-    wrapper::CommandPool m_command_pool;
-    std::unique_ptr<wrapper::CommandBuffer> m_command_buffer;
-    VkQueue m_data_transfer_queue;
-    const wrapper::Device &m_device;
+    const Device &m_device;
+    // We must store the VkQueue separately since we don't know from
+    // the context of the use of this OnceCommandBuffer which queue to use!
+    const VkQueue m_queue;
+    CommandPool m_command_pool;
+    std::unique_ptr<CommandBuffer> m_command_buffer;
 
     bool m_command_buffer_created;
     bool m_recording_started;
 
 public:
     /// @brief Creates a new commandbuffer which is being called only once.
-    /// @param device [in] The Vulkan device.
-    /// @param data_transfer_queue [in] The data transfer queue.
-    OnceCommandBuffer(const wrapper::Device &device, const VkQueue data_transfer_queue,
-                      const std::uint32_t data_transfer_queue_family_index);
+    /// @param device [in] A const reference to the Vulkan device.
+    OnceCommandBuffer(const Device &device, const VkQueue queue, const std::uint32_t queue_family_index);
     OnceCommandBuffer(const OnceCommandBuffer &) = delete;
     OnceCommandBuffer(OnceCommandBuffer &&) noexcept;
     ~OnceCommandBuffer();

--- a/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
@@ -2,15 +2,16 @@
 
 #include <vulkan/vulkan_core.h>
 
+#include <cassert>
 #include <string>
 #include <vector>
-#include <cassert>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class RenderPass {
-private:
-    VkDevice device;
+    const Device &m_device;
     VkRenderPass renderpass;
     std::string name;
 
@@ -24,22 +25,18 @@ public:
     RenderPass &operator=(RenderPass &&) noexcept = default;
 
     /// @brief Creates a renderpass.
-    /// @param device [in] The Vulkan device.
+    /// @param device [in] A const reference to the Vulkan device wrapper.
     /// @param attachments [in] The renderpass attachments.
     /// @param dependencies [in] The subpass dependencies.
     /// @param subpass_description [in] The subpass description.
     /// @param name [in] The internal name of this renderpass.
-    RenderPass(const VkDevice device, const std::vector<VkAttachmentDescription> &attachments,
+    RenderPass(const Device &device, const std::vector<VkAttachmentDescription> &attachments,
                const std::vector<VkSubpassDependency> &dependencies, const VkSubpassDescription subpass_description,
                const std::string &name);
 
     ~RenderPass();
 
     [[nodiscard]] VkRenderPass get() const {
-        assert(device);
-        assert(!name.empty());
-        assert(renderpass);
-
         return renderpass;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
+
+class Device;
 
 /// @brief A class for descriptor management.
 /// Shader access of data is managed through descriptors.
@@ -13,9 +15,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// Descriptors sets are described through their descriptor set layout.
 /// Descriptor sets are allocated from descriptor pools.
 class ResourceDescriptor {
-private:
     const std::string m_name;
-    const wrapper::Device &m_device;
+    const Device &m_device;
     VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
     VkDescriptorSetLayout m_descriptor_set_layout{VK_NULL_HANDLE};
     std::vector<VkDescriptorSetLayoutBinding> m_descriptor_set_layout_bindings;
@@ -25,7 +26,7 @@ private:
 
 public:
     // @note Creates a descriptor pool.
-    ResourceDescriptor(const wrapper::Device &device, std::uint32_t swapchain_image_count,
+    ResourceDescriptor(const Device &device, std::uint32_t swapchain_image_count,
                        std::initializer_list<VkDescriptorType> pool_types,
                        const std::vector<VkDescriptorSetLayoutBinding> &layout_bindings,
                        const std::vector<VkWriteDescriptorSet> &descriptor_writes, const std::string &name);

--- a/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
@@ -1,19 +1,20 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class Semaphore {
-private:
-    const wrapper::Device &m_device;
+    const Device &m_device;
     VkSemaphore m_semaphore;
     const std::string m_name;
 
 public:
-    Semaphore(const wrapper::Device &device, const std::string &name);
+    Semaphore(const Device &device, const std::string &name);
     Semaphore(const Semaphore &) = delete;
     Semaphore(Semaphore &&) noexcept;
     ~Semaphore();

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <string>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class Shader {
-private:
-    const wrapper::Device &m_device;
-    VkShaderStageFlagBits m_type;
+    const Device &m_device;
     const std::string m_name;
     const std::string m_entry_point;
-
+    VkShaderStageFlagBits m_type;
     VkShaderModule m_shader_module;
 
 public:
@@ -23,8 +23,8 @@ public:
     /// @param name [in] The internal name of the shader module.
     /// @param code [in] The SPIR-V shader code.
     /// @param entry_point [in] The entry point of the shader code, in most cases just "main".
-    Shader(const wrapper::Device &m_device, VkShaderStageFlagBits type, const std::string &name,
-           const std::vector<char> &code, const std::string &entry_point = "main");
+    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code,
+           const std::string &entry_point = "main");
 
     /// @brief Creates a shader from a SPIR-V file.
     /// @param device [in] The Vulkan device which will be used to create the shader module.
@@ -32,8 +32,8 @@ public:
     /// @param name [in] The internal name of the shader module.
     /// @param file_name [in] The name of the SPIR-V shader file.
     /// @param entry_point [in] The entry point of the shader code, in most cases just "main".
-    Shader(const wrapper::Device &m_device, VkShaderStageFlagBits type, const std::string &name,
-           const std::string &file_name, const std::string &entry_point = "main");
+    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name,
+           const std::string &entry_point = "main");
     Shader(const Shader &) = delete;
     Shader(Shader &&) noexcept;
     ~Shader();

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/once_command_buffer.hpp"
 
@@ -8,12 +7,13 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 /// @brief In general, it is inefficient to use normal memory mapping to a vertex buffer.
 /// It is highly advised to use a staging buffer. Once the staging buffer is filled with data,
 /// a queue command can be executed to use a transfer queue to upload the data to the GPU memory.
 class StagingBuffer : public GPUMemoryBuffer {
-private:
-    VkQueue m_data_transfer_queue;
+    const Device &m_device;
     OnceCommandBuffer m_command_buffer_for_copying;
 
 public:
@@ -25,9 +25,8 @@ public:
     /// @param size [in] The size of the buffer in bytes.
     /// @note Staging buffers always have VK_BUFFER_USAGE_TRANSFER_SRC_BIT as VkBufferUsageFlags.
     /// @note Staging buffers always have VMA_MEMORY_USAGE_CPU_ONLY as VmaMemoryUsage.
-    StagingBuffer(const wrapper::Device &device, const VmaAllocator vma_allocator, const VkQueue data_transfer_queue,
-                  const std::uint32_t data_transfer_queueu_family_index, const std::string &name,
-                  const VkDeviceSize buffer_size, void *data, const std::size_t data_size);
+    StagingBuffer(const Device &device, const std::string &name, const VkDeviceSize buffer_size, void *data,
+                  const std::size_t data_size);
     StagingBuffer(const StagingBuffer &) = delete;
     StagingBuffer(StagingBuffer &&) noexcept;
     ~StagingBuffer() = default;

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
+#include <vulkan/vulkan_core.h>
 
 #include <stdexcept>
 #include <string>
@@ -8,12 +8,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
 class Semaphore;
 
 class Swapchain {
-private:
     const wrapper::Device &m_device;
-    VkPhysicalDevice m_graphics_card;
     VkSurfaceKHR m_surface;
     VkSwapchainKHR m_swapchain;
     VkSurfaceFormatKHR m_surface_format;
@@ -33,11 +32,8 @@ private:
     void setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width, std::uint32_t window_height);
 
 public:
-    /// @brief
-    /// @note We must pass width and height as call by reference!
-    Swapchain(const wrapper::Device &device, const VkPhysicalDevice graphics_card, const VkSurfaceKHR surface,
-              std::uint32_t window_width, std::uint32_t window_height, const bool enable_vsync,
-              const std::string &name);
+    Swapchain(const Device &device, const VkSurfaceKHR surface, std::uint32_t window_width, std::uint32_t window_height,
+              const bool enable_vsync, const std::string &name);
     Swapchain(const Swapchain &) = delete;
     Swapchain(Swapchain &&) noexcept;
     ~Swapchain();
@@ -48,7 +44,7 @@ public:
     /// @brief Acquires the next writable image in the swapchain
     /// @param semaphore A semaphore to signal once image acquisition has completed
     /// @returns The image index
-    [[nodiscard]] std::uint32_t acquire_next_image(const wrapper::Semaphore &semaphore);
+    [[nodiscard]] std::uint32_t acquire_next_image(const Semaphore &semaphore);
 
     /// @brief The swapchain needs to be recreated if it has been invalidated.
     /// @note We must pass width and height as call by reference!

--- a/include/inexor/vulkan-renderer/wrapper/texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/texture.hpp
@@ -12,31 +12,28 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+class GPUMemoryBuffer;
+class OnceCommandBuffer;
+
 // TODO: 3D textures and cube maps.
 // TODO: Scan asset directory automatically.
 // TODO: Create multiple textures from file and submit them in 1 command buffer for performance reasons.
 
 class Texture {
-private:
     std::unique_ptr<wrapper::Image> m_texture_image;
+    OnceCommandBuffer m_copy_command_buffer;
+    VkSampler m_sampler;
 
-    const std::string m_name;
-    const std::string m_file_name;
     int m_texture_width{0};
     int m_texture_height{0};
     int m_texture_channels{0};
     int m_mip_levels{0};
 
+    const std::string m_name;
+    const std::string m_file_name;
     const wrapper::Device &m_device;
-    VkSampler m_sampler;
-    VmaAllocator m_vma_allocator;
-    VkQueue m_data_transfer_queue;
-    VkPhysicalDevice m_graphics_card;
-
-    std::uint32_t m_data_transfer_queue_family_index;
     const VkFormat m_texture_image_format{VK_FORMAT_R8G8B8A8_UNORM};
-
-    OnceCommandBuffer m_copy_command_buffer;
 
     ///
     void create_texture(void *texture_data, const std::size_t texture_size);
@@ -56,9 +53,7 @@ public:
     /// @param name [in] The internal memory allocation name of the texture.
     /// @param data_transfer_queue [in] The Vulkan data transfer queue.
     /// @param data_transfer_queue_family_index [in] The queue family index of the data transfer queue to use.
-    Texture(const wrapper::Device &device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
-            const std::string &file_name, const std::string &name, const VkQueue data_transfer_queue,
-            const std::uint32_t data_transfer_queue_family_index);
+    Texture(const Device &device, const std::string &file_name, const std::string &name);
 
     /// @brief Creates a texture from memory.
     /// @param device [in] The Vulkan device from which the texture will be created.
@@ -71,9 +66,8 @@ public:
     /// @param name [in] The internal memory allocation name of the texture.
     /// @param data_transfer_queue [in] The Vulkan data transfer queue.
     /// @param data_transfer_queue_family_index [in] The queue family index of the data transfer queue to use.
-    Texture(const wrapper::Device &device, const VkPhysicalDevice graphics_card, const VmaAllocator vma_allocator,
-            void *texture_data, const std::uint32_t texture_width, const std::uint32_t texture_height, const std::size_t texture_size, const std::string &name,
-            const VkQueue data_transfer_queue, const std::uint32_t data_transfer_queue_family_index);
+    Texture(const Device &device, void *texture_data, const std::uint32_t texture_width,
+            const std::uint32_t texture_height, const std::size_t texture_size, const std::string &name);
     Texture(const Texture &) = delete;
     Texture(Texture &&) noexcept;
     ~Texture();
@@ -90,17 +84,14 @@ public:
     }
 
     [[nodiscard]] const VkImage image() const {
-        assert(m_texture_image);
         return m_texture_image->get();
     }
 
     [[nodiscard]] const VkImageView image_view() const {
-        assert(m_texture_image);
         return m_texture_image->image_view();
     }
 
     [[nodiscard]] const VkSampler sampler() const {
-        assert(m_texture_image);
         return m_sampler;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
@@ -8,6 +8,8 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+class Device;
+
 class UniformBuffer : public GPUMemoryBuffer {
 protected:
     VkDescriptorBufferInfo m_descriptor_buffer_info{};
@@ -20,8 +22,7 @@ public:
     /// @param size [in] The size of the buffer in bytes.
     /// @param buffer_usage [in] The Vulkan buffer usage flags.
     /// @param memory_usage [in] The Vulkan Memory Allocator library's memory usage flags.
-    UniformBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                  const VkDeviceSize &size);
+    UniformBuffer(const Device &device, const std::string &name, const VkDeviceSize &size);
     UniformBuffer(const UniformBuffer &) = delete;
     UniformBuffer(UniformBuffer &&) noexcept;
     ~UniformBuffer() = default;

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -8,7 +8,6 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 class Window {
-private:
     GLFWwindow *m_window;
     std::uint32_t m_width;
     std::uint32_t m_height;

--- a/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
@@ -9,7 +9,6 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 class WindowSurface {
-private:
     VkInstance m_instance;
     VkSurfaceKHR m_surface;
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -113,9 +113,9 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
 }
 
 VkResult Application::load_textures() {
-    assert(m_vkdevice->device());
-    assert(m_vkdevice->physical_device());
-    assert(m_vkdevice->allocator());
+    assert(m_device->device());
+    assert(m_device->physical_device());
+    assert(m_device->allocator());
 
     // TODO: Refactor! use key from TOML file as name!
     std::size_t texture_number = 1;
@@ -124,15 +124,14 @@ VkResult Application::load_textures() {
     std::string texture_name = "unnamed texture";
 
     for (const auto &texture_file : m_texture_files) {
-        m_textures.emplace_back(*m_vkdevice, m_vkdevice->physical_device(), m_vkdevice->allocator(), texture_file,
-                                texture_name, m_vkdevice->graphics_queue(), m_vkdevice->graphics_queue_family_index());
+        m_textures.emplace_back(*m_device, texture_file, texture_name);
     }
 
     return VK_SUCCESS;
 }
 
 VkResult Application::load_shaders() {
-    assert(m_vkdevice->device());
+    assert(m_device->device());
 
     spdlog::debug("Loading vertex shaders.");
 
@@ -147,7 +146,7 @@ VkResult Application::load_shaders() {
         spdlog::debug("Loading vertex shader file {}.", vertex_shader_file);
 
         // Insert the new shader into the list of shaders.
-        m_shaders.emplace_back(*m_vkdevice, VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader", vertex_shader_file);
+        m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader", vertex_shader_file);
     }
 
     spdlog::debug("Loading fragment shaders.");
@@ -161,7 +160,7 @@ VkResult Application::load_shaders() {
         spdlog::debug("Loading fragment shader file {}.", fragment_shader_file);
 
         // Insert the new shader into the list of shaders.
-        m_shaders.emplace_back(*m_vkdevice, VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
+        m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
                                fragment_shader_file);
     }
 
@@ -199,11 +198,11 @@ VkResult Application::load_octree_geometry() {
 }
 
 VkResult Application::check_application_specific_features() {
-    assert(m_vkdevice->physical_device());
+    assert(m_device->physical_device());
 
     VkPhysicalDeviceFeatures graphics_card_features;
 
-    vkGetPhysicalDeviceFeatures(m_vkdevice->physical_device(), &graphics_card_features);
+    vkGetPhysicalDeviceFeatures(m_device->physical_device(), &graphics_card_features);
 
     // Check if anisotropic filtering is available!
     if (!graphics_card_features.samplerAnisotropy) {
@@ -256,13 +255,13 @@ Application::Application(int argc, char **argv) {
 
     m_glfw_context = std::make_unique<wrapper::GLFWContext>();
 
-    m_vkinstance = std::make_unique<wrapper::Instance>(
+    m_instance = std::make_unique<wrapper::Instance>(
         m_application_name, m_engine_name, m_application_version, m_engine_version, VK_API_VERSION_1_1,
         enable_khronos_validation_instance_layer, enable_renderdoc_instance_layer);
 
     m_window = std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true);
 
-    m_surface = std::make_unique<wrapper::WindowSurface>(m_vkinstance->instance(), m_window->get());
+    m_surface = std::make_unique<wrapper::WindowSurface>(m_instance->instance(), m_window->get());
 
     spdlog::debug("Storing GLFW window user pointer.");
 
@@ -286,11 +285,11 @@ Application::Application(int argc, char **argv) {
             // We have to explicitly load this function.
             PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT =
                 reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-                    vkGetInstanceProcAddr(m_vkinstance->instance(), "vkCreateDebugReportCallbackEXT"));
+                    vkGetInstanceProcAddr(m_instance->instance(), "vkCreateDebugReportCallbackEXT"));
 
             if (vkCreateDebugReportCallbackEXT) {
                 // Create the debug report callback.
-                VkResult result = vkCreateDebugReportCallbackEXT(m_vkinstance->instance(), &debug_report_ci, nullptr,
+                VkResult result = vkCreateDebugReportCallbackEXT(m_instance->instance(), &debug_report_ci, nullptr,
                                                                  &m_debug_report_callback);
                 if (VK_SUCCESS == result) {
                     spdlog::debug("Creating Vulkan debug callback.");
@@ -376,16 +375,15 @@ Application::Application(int argc, char **argv) {
         enable_debug_marker_device_extension = false;
     }
 
-    m_vkdevice =
-        std::make_unique<wrapper::Device>(m_vkinstance->instance(), m_surface->get(),
+    m_device =
+        std::make_unique<wrapper::Device>(m_instance->instance(), m_surface->get(),
                                           enable_debug_marker_device_extension, use_distinct_data_transfer_queue);
 
     VkResult result = check_application_specific_features();
     vulkan_error_check(result);
 
-    m_swapchain = std::make_unique<wrapper::Swapchain>(*m_vkdevice, m_vkdevice->physical_device(), m_surface->get(),
-                                                       m_window->width(), m_window->height(), m_vsync_enabled,
-                                                       "Standard swapchain");
+    m_swapchain = std::make_unique<wrapper::Swapchain>(*m_device, m_surface->get(), m_window->width(),
+                                                       m_window->height(), m_vsync_enabled, "Standard swapchain");
 
     result = load_textures();
     vulkan_error_check(result);
@@ -393,11 +391,9 @@ Application::Application(int argc, char **argv) {
     result = load_shaders();
     vulkan_error_check(result);
 
-    m_command_pool =
-        std::make_unique<wrapper::CommandPool>(m_vkdevice->device(), m_vkdevice->graphics_queue_family_index());
+    m_command_pool = std::make_unique<wrapper::CommandPool>(*m_device, m_device->graphics_queue_family_index());
 
-    m_uniform_buffers.emplace_back(m_vkdevice->device(), m_vkdevice->allocator(), "matrices uniform buffer",
-                                   sizeof(UniformBufferObject));
+    m_uniform_buffers.emplace_back(*m_device, "matrices uniform buffer", sizeof(UniformBufferObject));
 
     std::vector<VkDescriptorSetLayoutBinding> layout_bindings(1);
 
@@ -424,7 +420,7 @@ Application::Application(int argc, char **argv) {
     descriptor_writes[0].descriptorCount = 1;
     descriptor_writes[0].pBufferInfo = &m_uniform_buffer_info;
 
-    m_descriptors.emplace_back(wrapper::ResourceDescriptor{*m_vkdevice,
+    m_descriptors.emplace_back(wrapper::ResourceDescriptor{*m_device,
                                                            m_swapchain->image_count(),
                                                            {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER},
                                                            layout_bindings,
@@ -508,7 +504,7 @@ void Application::update_imgui_overlay() {
     ImGui::SetNextWindowSize(ImVec2(200, 0));
     ImGui::Begin("Inexor Vulkan-renderer", nullptr,
                  ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
-    ImGui::Text("%s", m_vkdevice->gpu_name().c_str());
+    ImGui::Text("%s", m_device->gpu_name().c_str());
     ImGui::Text("Engine version %d.%d.%d", VK_VERSION_MAJOR(m_engine_version), VK_VERSION_MINOR(m_engine_version),
                 VK_VERSION_PATCH(m_engine_version));
     ImGui::PushItemWidth(150.0f * m_imgui_overlay->get_scale());

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -98,12 +98,10 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
 
     spdlog::debug("Creating ImGUI font texture");
 
-    m_imgui_texture = std::make_unique<wrapper::Texture>(m_device, m_device.physical_device(), m_device.allocator(),
-                                                         font_texture_data, font_texture_width, font_texture_height,
-                                                         uploadSize, "ImGUI font texture", m_device.graphics_queue(),
-                                                         m_device.graphics_queue_family_index());
+    m_imgui_texture = std::make_unique<wrapper::Texture>(m_device, font_texture_data, font_texture_width,
+                                                         font_texture_height, uploadSize, "ImGUI font texture");
 
-    m_command_pool = std::make_unique<wrapper::CommandPool>(m_device.device(), m_device.graphics_queue_family_index());
+    m_command_pool = std::make_unique<wrapper::CommandPool>(m_device, m_device.graphics_queue_family_index());
 
     VkDescriptorImageInfo font_desc{};
     font_desc.sampler = m_imgui_texture->sampler();
@@ -163,8 +161,7 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
 
     spdlog::debug("Creating ImGUI renderpass");
 
-    m_renderpass =
-        std::make_unique<wrapper::RenderPass>(m_device.device(), attachments, subpass_deps, subpass_desc, "ImGUI");
+    m_renderpass = std::make_unique<wrapper::RenderPass>(m_device, attachments, subpass_deps, subpass_desc, "ImGUI");
 
     VkPushConstantRange push_constant_range{};
     push_constant_range.offset = 0;
@@ -224,7 +221,7 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     spdlog::debug("Creating ImGUI graphics pipeline");
 
     m_pipeline = std::make_unique<wrapper::GraphicsPipeline>(
-        m_device.device(), m_pipeline_layout, m_renderpass->get(), m_shaders, vertex_input_bindings, vertex_input_attrs,
+        m_device, m_pipeline_layout, m_renderpass->get(), m_shaders, vertex_input_bindings, vertex_input_attrs,
         m_swapchain.extent().width, m_swapchain.extent().height, "ImGUI");
 
     m_ui_rendering_finished = std::make_unique<wrapper::Fence>(m_device, "ImGUI rendering done", true);
@@ -253,10 +250,9 @@ void ImGUIOverlay::update() {
 
     // TODO() Do not allocate memory at runtime!
     if (!m_imgui_mesh) {
-        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(
-            m_device, m_device.graphics_queue(), m_device.graphics_queue_family_index(), m_device.allocator(),
-            "imgui_mesh_buffer", sizeof(ImDrawVert), imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
-            imgui_draw_data->TotalIdxCount);
+        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(m_device, "imgui_mesh_buffer", sizeof(ImDrawVert),
+                                                             imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
+                                                             imgui_draw_data->TotalIdxCount);
     }
 
     if ((m_imgui_mesh->get_vertex_buffer() == VK_NULL_HANDLE) || (m_vertex_count != imgui_draw_data->TotalVtxCount)) {
@@ -264,10 +260,9 @@ void ImGUIOverlay::update() {
 
         spdlog::debug("Creating ImGUI vertex buffer");
 
-        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(
-            m_device, m_device.graphics_queue(), m_device.graphics_queue_family_index(), m_device.allocator(),
-            "imgui_mesh_buffer", sizeof(ImDrawVert), imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
-            imgui_draw_data->TotalIdxCount);
+        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(m_device, "imgui_mesh_buffer", sizeof(ImDrawVert),
+                                                             imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
+                                                             imgui_draw_data->TotalIdxCount);
 
         m_vertex_count = imgui_draw_data->TotalVtxCount;
 
@@ -280,10 +275,9 @@ void ImGUIOverlay::update() {
 
         spdlog::debug("Creating ImGUI index buffer");
 
-        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(
-            m_device, m_device.graphics_queue(), m_device.graphics_queue_family_index(), m_device.allocator(),
-            "imgui_mesh_buffer", sizeof(ImDrawVert), imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
-            imgui_draw_data->TotalIdxCount);
+        m_imgui_mesh = std::make_unique<wrapper::MeshBuffer>(m_device, "imgui_mesh_buffer", sizeof(ImDrawVert),
+                                                             imgui_draw_data->TotalVtxCount, sizeof(ImDrawIdx),
+                                                             imgui_draw_data->TotalIdxCount);
 
         m_index_count = imgui_draw_data->TotalIdxCount;
 

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -72,18 +72,18 @@ void VulkanRenderer::generate_octree_indices() {
 
 void VulkanRenderer::recreate_swapchain() {
     m_window->wait_for_focus();
-    vkDeviceWaitIdle(m_vkdevice->device());
+    vkDeviceWaitIdle(m_device->device());
 
     // TODO(): This is quite naive, we don't need to recompile the whole frame graph on swapchain invalidation
     m_frame_graph.reset();
     m_swapchain->recreate(m_window->width(), m_window->height());
-    m_frame_graph = std::make_unique<FrameGraph>(*m_vkdevice, m_command_pool->get(), *m_swapchain);
+    m_frame_graph = std::make_unique<FrameGraph>(*m_device, m_command_pool->get(), *m_swapchain);
     setup_frame_graph();
 
     m_image_available_semaphore.reset();
     m_rendering_finished_semaphore.reset();
-    m_image_available_semaphore = std::make_unique<wrapper::Semaphore>(*m_vkdevice, "Image available semaphore");
-    m_rendering_finished_semaphore = std::make_unique<wrapper::Semaphore>(*m_vkdevice, "Rendering finished semaphore");
+    m_image_available_semaphore = std::make_unique<wrapper::Semaphore>(*m_device, "Image available semaphore");
+    m_rendering_finished_semaphore = std::make_unique<wrapper::Semaphore>(*m_device, "Rendering finished semaphore");
 
     m_game_camera.m_type = Camera::CameraType::LOOKAT;
     m_game_camera.m_rotation_speed = 0.25f;
@@ -94,7 +94,7 @@ void VulkanRenderer::recreate_swapchain() {
                                   0.1f, 256.0f);
 
     m_imgui_overlay.reset();
-    m_imgui_overlay = std::make_unique<ImGUIOverlay>(*m_vkdevice, *m_swapchain);
+    m_imgui_overlay = std::make_unique<ImGUIOverlay>(*m_device, *m_swapchain);
 }
 
 void VulkanRenderer::render_frame() {
@@ -106,7 +106,7 @@ void VulkanRenderer::render_frame() {
 
     const auto image_index = m_swapchain->acquire_next_image(*m_image_available_semaphore);
     m_frame_graph->render(image_index, m_rendering_finished_semaphore->get(), m_image_available_semaphore->get(),
-                          m_vkdevice->graphics_queue());
+                          m_device->graphics_queue());
 
     m_imgui_overlay->render(image_index);
 
@@ -118,7 +118,7 @@ void VulkanRenderer::render_frame() {
     present_info.pSwapchains = m_swapchain->swapchain_ptr();
     present_info.pWaitSemaphores = m_rendering_finished_semaphore->ptr();
 
-    vkQueuePresentKHR(m_vkdevice->present_queue(), &present_info);
+    vkQueuePresentKHR(m_device->present_queue(), &present_info);
 
     if (auto fps_value = m_fps_counter.update()) {
         m_window->set_title("Inexor Vulkan API renderer demo - " + std::to_string(*fps_value) + " FPS");
@@ -128,7 +128,7 @@ void VulkanRenderer::render_frame() {
 
 void VulkanRenderer::calculate_memory_budget() {
     VmaStats memory_stats;
-    vmaCalculateStats(m_vkdevice->allocator(), &memory_stats);
+    vmaCalculateStats(m_device->allocator(), &memory_stats);
 
     spdlog::debug("-------------VMA stats-------------");
     spdlog::debug("Number of `VkDeviceMemory` (physical memory) blocks allocated: {} still alive, {} in total",
@@ -147,20 +147,20 @@ void VulkanRenderer::calculate_memory_budget() {
     spdlog::debug("-------------VMA stats-------------");
 
     char *vma_stats_string = nullptr;
-    vmaBuildStatsString(m_vkdevice->allocator(), &vma_stats_string, VK_TRUE);
+    vmaBuildStatsString(m_device->allocator(), &vma_stats_string, VK_TRUE);
 
     std::string memory_dump_file_name = "vma-dumps/dump.json";
     std::ofstream vma_memory_dump(memory_dump_file_name, std::ios::out);
     vma_memory_dump.write(vma_stats_string, strlen(vma_stats_string));
     vma_memory_dump.close();
 
-    vmaFreeStatsString(m_vkdevice->allocator(), vma_stats_string);
+    vmaFreeStatsString(m_device->allocator(), vma_stats_string);
 }
 
 VulkanRenderer::~VulkanRenderer() {
     spdlog::debug("Shutting down vulkan renderer");
     // TODO: Add wrapper::Device::wait_idle()
-    vkDeviceWaitIdle(m_vkdevice->device());
+    vkDeviceWaitIdle(m_device->device());
 
     if (!m_debug_report_callback_initialised) {
         return;
@@ -168,9 +168,9 @@ VulkanRenderer::~VulkanRenderer() {
 
     // TODO(): Is there a better way to do this? Maybe add a helper function to wrapper::Instance?
     auto vk_destroy_debug_report_callback = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        vkGetInstanceProcAddr(m_vkinstance->instance(), "vkDestroyDebugReportCallbackEXT"));
+        vkGetInstanceProcAddr(m_instance->instance(), "vkDestroyDebugReportCallbackEXT"));
     if (vk_destroy_debug_report_callback != nullptr) {
-        vk_destroy_debug_report_callback(m_vkinstance->instance(), m_debug_report_callback, nullptr);
+        vk_destroy_debug_report_callback(m_instance->instance(), m_debug_report_callback, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 #include "inexor/vulkan-renderer/wrapper/resource_descriptor.hpp"
 

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -1,17 +1,18 @@
 #include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 namespace inexor::vulkan_renderer::wrapper {
 
-CommandPool::CommandPool(const VkDevice device, const std::uint32_t queue_family_index) : m_device(device) {
-    assert(device);
+CommandPool::CommandPool(const Device &device, const std::uint32_t queue_family_index) : m_device(device) {
+    assert(device.device());
 
     auto command_pool_ci = make_info<VkCommandPoolCreateInfo>();
     command_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     command_pool_ci.queueFamilyIndex = queue_family_index;
 
-    if (vkCreateCommandPool(device, &command_pool_ci, nullptr, &m_command_pool) != VK_SUCCESS) {
+    if (vkCreateCommandPool(m_device.device(), &command_pool_ci, nullptr, &m_command_pool) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateCommandPool failed!");
     }
 
@@ -25,7 +26,7 @@ CommandPool::CommandPool(CommandPool &&other) noexcept
 
 CommandPool::~CommandPool() {
     if (m_command_pool != nullptr) {
-        vkDestroyCommandPool(m_device, m_command_pool, nullptr);
+        vkDestroyCommandPool(m_device.device(), m_command_pool, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/fence.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <spdlog/spdlog.h>

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/framebuffer.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 
@@ -9,9 +10,8 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Framebuffer::Framebuffer(const wrapper::Device &device, VkRenderPass render_pass,
-                         const std::vector<VkImageView> &attachments, const wrapper::Swapchain &swapchain,
-                         const std::string &name)
+Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
+                         const wrapper::Swapchain &swapchain, const std::string &name)
     : m_device(device), m_name(name) {
     spdlog::trace("Creating framebuffer {}.", m_name);
 

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <spdlog/spdlog.h>
@@ -8,12 +9,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                                 const VkDeviceSize &size, const VkBufferUsageFlags &buffer_usage,
-                                 const VmaMemoryUsage &memory_usage)
-    : m_device(device), m_vma_allocator(vma_allocator), m_name(name), m_buffer_size(size) {
-    assert(device);
-    assert(vma_allocator);
+GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &size,
+                                 const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage)
+    : m_device(device), m_name(name), m_buffer_size(size) {
+    assert(device.device());
+    assert(device.allocator());
     assert(!name.empty());
 
     spdlog::debug("Creating GPU memory buffer of size {} for '{}'.", size, name);
@@ -36,13 +36,14 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
     // TODO: Is it good to have memory mapped all the time?
     // TODO: When should memory be mapped / unmapped?
 
-    if (vmaCreateBuffer(vma_allocator, &buffer_ci, &m_allocation_ci, &m_buffer, &m_allocation, &m_allocation_info)) {
+    if (vmaCreateBuffer(m_device.allocator(), &buffer_ci, &m_allocation_ci, &m_buffer, &m_allocation,
+                        &m_allocation_info)) {
         throw std::runtime_error("Error: GPU memory buffer allocation for " + name + " failed!");
     }
 
     // Try to find the Vulkan debug marker function.
     auto *vkDebugMarkerSetObjectNameEXT = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(
-        vkGetDeviceProcAddr(device, "vkDebugMarkerSetObjectNameEXT"));
+        vkGetDeviceProcAddr(m_device.device(), "vkDebugMarkerSetObjectNameEXT"));
 
     if (vkDebugMarkerSetObjectNameEXT != nullptr) {
         // Since the function vkDebugMarkerSetObjectNameEXT has been found, we can assign an internal name for
@@ -53,18 +54,18 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
         name_info.pObjectName = name.c_str();
 
         spdlog::debug("Assigning internal name '{}' to GPU memory buffer.", name);
-        if (vkDebugMarkerSetObjectNameEXT(device, &name_info) != VK_SUCCESS) {
+        if (vkDebugMarkerSetObjectNameEXT(m_device.device(), &name_info) != VK_SUCCESS) {
             throw std::runtime_error("Error: vkDebugMarkerSetObjectNameEXT failed for GPU memory buffer " + name + "!");
         }
     }
 }
 
-GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                                 const VkDeviceSize &buffer_size, void *data, const std::size_t data_size,
-                                 const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage)
-    : GPUMemoryBuffer(device, vma_allocator, name, buffer_size, buffer_usage, memory_usage) {
-    assert(device);
-    assert(vma_allocator);
+GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &buffer_size,
+                                 void *data, const std::size_t data_size, const VkBufferUsageFlags &buffer_usage,
+                                 const VmaMemoryUsage &memory_usage)
+    : GPUMemoryBuffer(device, name, buffer_size, buffer_usage, memory_usage) {
+    assert(device.device());
+    assert(device.allocator());
     assert(!name.empty());
     assert(buffer_size > 0);
     assert(data_size > 0);
@@ -75,14 +76,14 @@ GPUMemoryBuffer::GPUMemoryBuffer(const VkDevice &device, const VmaAllocator &vma
 }
 
 GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
-    : m_name(std::move(other.m_name)), m_device(std::exchange(other.m_device, nullptr)),
-      m_buffer(std::exchange(other.m_buffer, nullptr)), m_allocation(std::exchange(other.m_allocation, nullptr)),
-      m_allocation_info(std::move(other.m_allocation_info)), m_allocation_ci(std::move(other.m_allocation_ci)) {}
+    : m_name(std::move(other.m_name)), m_device(other.m_device), m_buffer(std::exchange(other.m_buffer, nullptr)),
+      m_allocation(std::exchange(other.m_allocation, nullptr)), m_allocation_info(std::move(other.m_allocation_info)),
+      m_allocation_ci(std::move(other.m_allocation_ci)) {}
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
     if (m_buffer != nullptr) {
         spdlog::trace("Destroying GPU memory buffer.");
-        vmaDestroyBuffer(m_vma_allocator, m_buffer, m_allocation);
+        vmaDestroyBuffer(m_device.allocator(), m_buffer, m_allocation);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/renderpass.cpp
+++ b/src/vulkan-renderer/wrapper/renderpass.cpp
@@ -1,16 +1,18 @@
 #include "inexor/vulkan-renderer/wrapper/renderpass.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
+
 #include <spdlog/spdlog.h>
 
 namespace inexor::vulkan_renderer::wrapper {
 
 RenderPass::RenderPass(RenderPass &&other) noexcept
-    : device(other.device), renderpass(std::exchange(other.renderpass, nullptr)), name(std::move(other.name)) {}
+    : m_device(other.m_device), renderpass(std::exchange(other.renderpass, nullptr)), name(std::move(other.name)) {}
 
-RenderPass::RenderPass(const VkDevice device, const std::vector<VkAttachmentDescription> &attachments,
+RenderPass::RenderPass(const Device &device, const std::vector<VkAttachmentDescription> &attachments,
                        const std::vector<VkSubpassDependency> &dependencies,
                        const VkSubpassDescription subpass_description, const std::string &name)
-    : device(device), name(name) {
+    : m_device(device), name(name) {
 
     VkRenderPassCreateInfo renderpass_ci = {};
     renderpass_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -23,7 +25,7 @@ RenderPass::RenderPass(const VkDevice device, const std::vector<VkAttachmentDesc
 
     spdlog::debug("Creating renderpass {}.", name);
 
-    if (vkCreateRenderPass(device, &renderpass_ci, nullptr, &renderpass) != VK_SUCCESS) {
+    if (vkCreateRenderPass(m_device.device(), &renderpass_ci, nullptr, &renderpass) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkCreateRenderPass failed for " + name + " !");
     }
 
@@ -32,7 +34,7 @@ RenderPass::RenderPass(const VkDevice device, const std::vector<VkAttachmentDesc
 
 RenderPass::~RenderPass() {
     spdlog::trace("Destroying render pass {}.", name);
-    vkDestroyRenderPass(device, renderpass, nullptr);
+    vkDestroyRenderPass(m_device.device(), renderpass, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/resource_descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/resource_descriptor.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/resource_descriptor.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <spdlog/spdlog.h>
@@ -16,7 +17,7 @@ ResourceDescriptor::ResourceDescriptor(ResourceDescriptor &&other) noexcept
       m_write_descriptor_sets(std::move(other.m_write_descriptor_sets)),
       m_descriptor_sets(std::move(other.m_descriptor_sets)), m_swapchain_image_count(other.m_swapchain_image_count) {}
 
-ResourceDescriptor::ResourceDescriptor(const wrapper::Device &device, std::uint32_t swapchain_image_count,
+ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapchain_image_count,
                                        std::initializer_list<VkDescriptorType> pool_types,
                                        const std::vector<VkDescriptorSetLayoutBinding> &layout_bindings,
                                        const std::vector<VkWriteDescriptorSet> &descriptor_writes,

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <spdlog/spdlog.h>
@@ -8,7 +9,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Semaphore::Semaphore(const wrapper::Device &device, const std::string &name) : m_device(device), m_name(name) {
+Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(device), m_name(name) {
     assert(device.device());
     assert(!name.empty());
 

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/wrapper/shader.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <spdlog/spdlog.h>
@@ -32,11 +33,11 @@ std::vector<char> read_binary(const std::string &file_name) {
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Shader::Shader(const wrapper::Device &device, const VkShaderStageFlagBits type, const std::string &name,
+Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std::string &name,
                const std::string &file_name, const std::string &entry_point)
     : Shader(device, type, name, read_binary(file_name), entry_point) {}
 
-Shader::Shader(const wrapper::Device &device, const VkShaderStageFlagBits type, const std::string &name,
+Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std::string &name,
                const std::vector<char> &code, const std::string &entry_point)
     : m_device(device), m_type(type), m_name(name), m_entry_point(entry_point) {
     assert(device.device());

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -1,27 +1,26 @@
 ﻿#include "inexor/vulkan-renderer/wrapper/staging_buffer.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/device.hpp"
+
 #include <spdlog/spdlog.h>
 
 namespace inexor::vulkan_renderer::wrapper {
 
-StagingBuffer::StagingBuffer(const wrapper::Device &device, const VmaAllocator vma_allocator,
-                             const VkQueue data_transfer_queue, const std::uint32_t data_transfer_queueu_family_index,
-                             const std::string &name, const VkDeviceSize buffer_size, void *data,
+StagingBuffer::StagingBuffer(const Device &device, const std::string &name, const VkDeviceSize buffer_size, void *data,
                              const std::size_t data_size)
-    : GPUMemoryBuffer(device.device(), vma_allocator, name, buffer_size, data, data_size,
-                      VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
-      m_data_transfer_queue(data_transfer_queue),
-      m_command_buffer_for_copying(device, data_transfer_queue, data_transfer_queueu_family_index) {}
+    : GPUMemoryBuffer(device, name, buffer_size, data, data_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                      VMA_MEMORY_USAGE_CPU_ONLY),
+      m_command_buffer_for_copying(device, device.transfer_queue(), device.transfer_queue_family_index()),
+      m_device(device) {}
 
 StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept
-    : m_data_transfer_queue(std::move(other.m_data_transfer_queue)),
-      m_command_buffer_for_copying(std::move(other.m_command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)) {}
+    : m_command_buffer_for_copying(std::move(other.m_command_buffer_for_copying)), GPUMemoryBuffer(std::move(other)),
+      m_device(other.m_device) {}
 
 void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer) {
     spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices.");
 
     m_command_buffer_for_copying.create_command_buffer();
-
     m_command_buffer_for_copying.start_recording();
 
     spdlog::debug("Specifying vertex buffer copy operation in command buffer.");

--- a/src/vulkan-renderer/wrapper/uniform_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -1,14 +1,14 @@
 #include "inexor/vulkan-renderer/wrapper/uniform_buffer.hpp"
 
+#include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
+
 #include <cassert>
 #include <cstring>
 
 namespace inexor::vulkan_renderer::wrapper {
 
-UniformBuffer::UniformBuffer(const VkDevice &device, const VmaAllocator &vma_allocator, const std::string &name,
-                             const VkDeviceSize &buffer_size)
-    : GPUMemoryBuffer(device, vma_allocator, name, buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                      VMA_MEMORY_USAGE_CPU_TO_GPU) {}
+UniformBuffer::UniformBuffer(const Device &device, const std::string &name, const VkDeviceSize &buffer_size)
+    : GPUMemoryBuffer(device, name, buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU) {}
 
 UniformBuffer::UniformBuffer(UniformBuffer &&other) noexcept
     : GPUMemoryBuffer(std::move(other)), m_descriptor_buffer_info(std::move(other.m_descriptor_buffer_info)),
@@ -16,7 +16,6 @@ UniformBuffer::UniformBuffer(UniformBuffer &&other) noexcept
 
 void UniformBuffer::update(void *data, const std::size_t size) {
     assert(m_allocation_info.pMappedData);
-
     std::memcpy(m_allocation_info.pMappedData, data, size);
 }
 


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/238

This pull requests takes the essential work from my overloaded draft pr https://github.com/inexorgame/vulkan-renderer/pull/241.
In this pull request, I removed redundant arguments which are already available through the device wrapper's get methods.

This code change also fixes an issues with queue management. The problem is that sometimes we passed the graphics queue to a constructor which names it internally as `data_transfer_queue`. Because both are just `VkQueue`, the constructor accepts it and passes it on even further down to the members.

For example this:

```cpp
m_textures.emplace_back(*m_vkdevice, m_vkdevice->physical_device(),
                                       m_vkdevice->allocator(), texture_file,
                                       texture_name, m_vkdevice->graphics_queue(),
                                       m_vkdevice->graphics_queue_family_index());
```

will be passed on to:

```cpp
Texture::Texture(const wrapper::Device &device, const VkPhysicalDevice graphics_card,
                 const VmaAllocator vma_allocator, const std::string &file_name,
                 const std::string &name, const VkQueue data_transfer_queue,
                 const std::uint32_t data_transfer_queue_family_index)
```

This new code has been changed so it is the constructor call to `CommandBuffer` which specifies the queue which is used.

**EDIT**:  I forgot to mention I also forward-declared most variables in the RAII wrapper header files.