### PR TITLE
Fix most clang-tidy warnings and msvc code analysis warnings

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -5,8 +5,6 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
-using namespace inexor::vulkan_renderer;
-
 int main(int argc, char *argv[]) {
     spdlog::init_thread_pool(8192, 2);
 
@@ -24,7 +22,7 @@ int main(int argc, char *argv[]) {
     spdlog::debug("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
     spdlog::debug("Parsing command line arguments.");
 
-    Application renderer(argc, argv);
+    inexor::vulkan_renderer::Application renderer(argc, argv);
     renderer.run();
     renderer.calculate_memory_budget();
     spdlog::debug("Window closed");

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -66,18 +66,18 @@ class BezierCurve {
 
     std::vector<BezierOutputPoint> m_output_points;
 
-    uint32_t binomial_coefficient(uint32_t n, const uint32_t k);
+    uint32_t binomial_coefficient(uint32_t n, uint32_t k);
 
-    float bernstein_polynomial(uint32_t n, uint32_t k, const float curve_precision, const float coordinate_value);
+    float bernstein_polynomial(uint32_t n, uint32_t k, float curve_precision, float coordinate_value);
 
-    BezierOutputPoint calculate_point_on_curve(const float curve_precision);
+    BezierOutputPoint calculate_point_on_curve(float curve_precision);
 
 public:
     void add_input_point(const BezierInputPoint &input_point);
 
-    void add_input_point(const glm::vec3 &position, const float weight = 1.0f);
+    void add_input_point(const glm::vec3 &position, float weight = 1.0f);
 
-    void calculate_bezier_curve(const float curve_precision);
+    void calculate_bezier_curve(float curve_precision);
 
     [[nodiscard]] std::vector<BezierOutputPoint> output_points();
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -60,9 +60,9 @@ struct BezierOutputPoint : public BezierInputPoint {
 /// @brief This struct bundles describes everything about the bezier curve.
 /// It contains both the input points and the generated output points.
 class BezierCurve {
-    bool m_curve_generated;
+    bool m_curve_generated{false};
 
-    float m_curve_precision;
+    float m_curve_precision{1.0f};
 
     std::vector<BezierInputPoint> m_input_points;
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -62,8 +62,6 @@ struct BezierOutputPoint : public BezierInputPoint {
 class BezierCurve {
     bool m_curve_generated{false};
 
-    float m_curve_precision{1.0f};
-
     std::vector<BezierInputPoint> m_input_points;
 
     std::vector<BezierOutputPoint> m_output_points;

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -7,8 +7,9 @@ namespace inexor::vulkan_renderer {
 /// @brief A RAII wrapper class for camera position and movement.
 /// @todo Refactor method naming!
 class Camera {
-    float m_fov;
-    float m_z_near, m_z_far;
+    float m_fov{0.0f};
+    float m_z_near{0.0f};
+    float m_z_far{0.0f};
 
     /// @brief Update the view matrix.
     /// @note The view matrix should only be updated if necessary.
@@ -29,8 +30,8 @@ public:
     bool m_updated{false};
 
     struct {
-        glm::mat4 perspective;
-        glm::mat4 view;
+        glm::mat4 perspective = glm::mat4();
+        glm::mat4 view = glm::mat4();
     } m_matrices;
 
     struct {

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -17,7 +17,7 @@ class Camera {
 public:
     // TODO: Why is so much stuff here public? refactor!
 
-    enum CameraType { LOOKAT, FIRSTPERSON };
+    enum class CameraType { LOOKAT, FIRSTPERSON };
     CameraType m_type{CameraType::LOOKAT};
 
     glm::vec3 m_rotation{};

--- a/include/inexor/vulkan-renderer/frame_graph.hpp
+++ b/include/inexor/vulkan-renderer/frame_graph.hpp
@@ -235,7 +235,7 @@ protected:
     // TODO: Add OOP device functions (see above todo) and only store a wrapper::Device here.
     VmaAllocator m_allocator;
     VkDevice m_device;
-    VmaAllocation m_allocation{VK_NULL_HANDLE};
+    VmaAllocation m_allocation{nullptr};
 
     PhysicalResource(VmaAllocator allocator, VkDevice device) : m_allocator(allocator), m_device(device) {}
 
@@ -251,7 +251,7 @@ class PhysicalBuffer : public PhysicalResource {
     friend FrameGraph;
 
 private:
-    VkBuffer m_buffer{VK_NULL_HANDLE};
+    VkBuffer m_buffer{nullptr};
 
 public:
     PhysicalBuffer(VmaAllocator allocator, VkDevice device) : PhysicalResource(allocator, device) {}
@@ -267,8 +267,8 @@ class PhysicalImage : public PhysicalResource {
     friend FrameGraph;
 
 private:
-    VkImage m_image{VK_NULL_HANDLE};
-    VkImageView m_image_view{VK_NULL_HANDLE};
+    VkImage m_image{nullptr};
+    VkImageView m_image_view{nullptr};
 
 public:
     PhysicalImage(VmaAllocator allocator, VkDevice device) : PhysicalResource(allocator, device) {}
@@ -302,8 +302,8 @@ class PhysicalStage : public FrameGraphObject {
 private:
     std::vector<wrapper::CommandBuffer> m_command_buffers;
     const wrapper::Device &m_device;
-    VkPipeline m_pipeline{VK_NULL_HANDLE};
-    VkPipelineLayout m_pipeline_layout{VK_NULL_HANDLE};
+    VkPipeline m_pipeline{nullptr};
+    VkPipelineLayout m_pipeline_layout{nullptr};
 
 protected:
     [[nodiscard]] VkDevice device() const {
@@ -330,7 +330,7 @@ class PhysicalGraphicsStage : public PhysicalStage {
     friend FrameGraph;
 
 private:
-    VkRenderPass m_render_pass{VK_NULL_HANDLE};
+    VkRenderPass m_render_pass{nullptr};
     std::vector<wrapper::Framebuffer> m_framebuffers;
 
 public:

--- a/include/inexor/vulkan-renderer/imgui.hpp
+++ b/include/inexor/vulkan-renderer/imgui.hpp
@@ -72,7 +72,7 @@ public:
     }
 
     void update();
-    void render(const std::uint32_t image_index);
+    void render(std::uint32_t image_index);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/imgui.hpp
+++ b/include/inexor/vulkan-renderer/imgui.hpp
@@ -25,7 +25,7 @@ namespace inexor::vulkan_renderer {
 class ImGUIOverlay {
     const wrapper::Device &m_device;
     const wrapper::Swapchain &m_swapchain;
-    VkPipelineLayout m_pipeline_layout{VK_NULL_HANDLE};
+    VkPipelineLayout m_pipeline_layout{nullptr};
 
     float m_scale{1.0f};
 

--- a/include/inexor/vulkan-renderer/octree_gpu_vertex.hpp
+++ b/include/inexor/vulkan-renderer/octree_gpu_vertex.hpp
@@ -24,8 +24,8 @@ namespace std {
 template <>
 struct hash<inexor::vulkan_renderer::OctreeGpuVertex> {
     std::size_t operator()(const inexor::vulkan_renderer::OctreeGpuVertex &vertex) const {
-        auto h1 = std::hash<glm::vec3>{}(vertex.position);
-        auto h2 = std::hash<glm::vec3>{}(vertex.color);
+        const auto h1 = std::hash<glm::vec3>{}(vertex.position);
+        const auto h2 = std::hash<glm::vec3>{}(vertex.color);
         return h1 ^ h2;
     }
 };

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -8,6 +8,12 @@
 
 namespace inexor::vulkan_renderer {
 
+/// @brief A wrapper class for swapchain settings.
+struct SwapchainSettings {
+    VkExtent2D window_size;
+    VkExtent2D swapchain_size;
+};
+
 /// @brief This class makes automatic decisions about setting up Vulkan.
 /// Examples:
 /// - Which graphics card will be used if more than one is available?
@@ -74,9 +80,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param window_height The height of the window.
     /// @param swapchain_extent [out] The extent of the swapchain.
     /// @todo Make this function return a std::optional<VkExtend2D> instead of using call by reference!
-    void decide_swapchain_extent(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
-                                 std::uint32_t &window_width, std::uint32_t &window_height,
-                                 VkExtent2D &swapchain_extent);
+    SwapchainSettings decide_swapchain_extent(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
+                                              std::uint32_t window_width, std::uint32_t window_height);
 
     /// @brief Automatically find the image transform, relative to the presentation engine's natural orientation,
     /// applied to the image content prior to presentation.

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -90,8 +90,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The composite alpha flag bits.
-    [[nodiscard]] VkCompositeAlphaFlagBitsKHR find_composite_alpha_format(const VkPhysicalDevice selected_graphics_card,
-                                                                          const VkSurfaceKHR surface);
+    [[nodiscard]] VkCompositeAlphaFlagBitsKHR find_composite_alpha_format(VkPhysicalDevice selected_graphics_card,
+                                                                          VkSurfaceKHR surface);
 
     /// @brief Automatically decide which presentation mode the presentation engine will be using.
     /// @note We can only use presentation modes that are available in the current system. The preferred presentation
@@ -162,8 +162,8 @@ struct VulkanSettingsDecisionMaker {
     /// @return A VkFormat value if a suitable depth buffer format could be found, std::nullopt otherwise.
     [[nodiscard]] std::optional<VkFormat> find_depth_buffer_format(const VkPhysicalDevice &graphics_card,
                                                                    const std::vector<VkFormat> &formats,
-                                                                   const VkImageTiling tiling,
-                                                                   const VkFormatFeatureFlags feature_flags);
+                                                                   VkImageTiling tiling,
+                                                                   VkFormatFeatureFlags feature_flags);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -14,7 +14,7 @@ class ResourceDescriptor;
 /// @brief RAII wrapper class for VkCommandBuffer.
 /// @todo Make trivially copyable (this class doesn't really "own" the command buffer, more just an OOP wrapper).
 class CommandBuffer {
-    VkCommandBuffer m_command_buffer{VK_NULL_HANDLE};
+    VkCommandBuffer m_command_buffer{nullptr};
     const wrapper::Device &m_device;
     const std::string m_name;
 

--- a/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
@@ -59,8 +59,8 @@ public:
         return m_mip_levels;
     }
 
-    [[nodiscard]] void *data() const {
-        return static_cast<void *>(m_texture_data);
+    [[nodiscard]] stbi_uc *data() const {
+        return m_texture_data;
     }
 
     [[nodiscard]] std::size_t data_size() const {

--- a/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
@@ -65,7 +65,8 @@ public:
 
     [[nodiscard]] std::size_t data_size() const {
         // TODO: We will need to update this once we fully support mip levels.
-        return m_texture_width * m_texture_height * m_texture_channels;
+        return static_cast<std::size_t>(m_texture_width) * static_cast<std::size_t>(m_texture_height) *
+               static_cast<std::size_t>(m_texture_channels);
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -61,11 +61,11 @@ public:
     Device &operator=(const Device &) = delete;
     Device &operator=(Device &&) = default;
 
-    [[nodiscard]] const VkDevice device() const {
+    [[nodiscard]] VkDevice device() const {
         return m_device;
     }
 
-    [[nodiscard]] const VkPhysicalDevice physical_device() const {
+    [[nodiscard]] VkPhysicalDevice physical_device() const {
         return m_graphics_card;
     }
 
@@ -77,17 +77,17 @@ public:
         return m_gpu_name;
     }
 
-    [[nodiscard]] const VkQueue graphics_queue() const {
+    [[nodiscard]] VkQueue graphics_queue() const {
         return m_graphics_queue;
     }
 
-    [[nodiscard]] const VkQueue present_queue() const {
+    [[nodiscard]] VkQueue present_queue() const {
         return m_present_queue;
     }
 
     /// @note Transfer queues are the fastest way to copy data across the PCIe bus. They are heavily underutilized even
     /// in modern games. Transfer queues can be used asynchronously to graphics queuey.
-    [[nodiscard]] const VkQueue transfer_queue() const {
+    [[nodiscard]] VkQueue transfer_queue() const {
         return m_transfer_queue;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -14,7 +14,7 @@ namespace inexor::vulkan_renderer::wrapper {
 class Device {
     VkDevice m_device;
     VkPhysicalDevice m_graphics_card;
-    VmaAllocator m_allocator;
+    VmaAllocator m_allocator{VK_NULL_HANDLE};
     std::string m_gpu_name;
 
     VkQueue m_graphics_queue;

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -49,7 +49,7 @@ public:
     /// application's purpose, another graphics card will be selected automatically. See the details of the device
     /// selection mechanism!
     /// @todo Add overloaded constructors for VkPhysicalDeviceFeatures and requested device extensions in the future!
-    Device(const VkInstance instance, const VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
+    Device(VkInstance instance, VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
            bool prefer_distinct_transfer_queue,
            const std::optional<std::uint32_t> preferred_physical_device_index = std::nullopt);
 

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -13,7 +13,7 @@ class Swapchain;
 /// @brief RAII wrapper class for VkFramebuffer.
 class Framebuffer {
     const wrapper::Device &m_device;
-    VkFramebuffer m_framebuffer{VK_NULL_HANDLE};
+    VkFramebuffer m_framebuffer{nullptr};
     const std::string m_name;
 
 public:

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -16,9 +16,9 @@ class GPUMemoryBuffer {
 protected:
     std::string m_name;
     const Device &m_device;
-    VkBuffer m_buffer{VK_NULL_HANDLE};
+    VkBuffer m_buffer{nullptr};
     VkDeviceSize m_buffer_size{0};
-    VmaAllocation m_allocation{VK_NULL_HANDLE};
+    VmaAllocation m_allocation{nullptr};
     VmaAllocationInfo m_allocation_info{};
     VmaAllocationCreateInfo m_allocation_ci{};
 

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -56,19 +56,19 @@ public:
         return m_name;
     }
 
-    [[nodiscard]] const VkBuffer buffer() const {
+    [[nodiscard]] VkBuffer buffer() const {
         return m_buffer;
     }
 
-    [[nodiscard]] const VmaAllocation allocation() const {
+    [[nodiscard]] VmaAllocation allocation() const {
         return m_allocation;
     }
 
-    [[nodiscard]] const VmaAllocationInfo allocation_info() const {
+    [[nodiscard]] VmaAllocationInfo allocation_info() const {
         return m_allocation_info;
     }
 
-    [[nodiscard]] const VmaAllocationCreateInfo allocation_create_info() const {
+    [[nodiscard]] VmaAllocationCreateInfo allocation_create_info() const {
         return m_allocation_ci;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
@@ -31,7 +31,7 @@ public:
                      const std::vector<VkPipelineShaderStageCreateInfo> &shader_stages,
                      const std::vector<VkVertexInputBindingDescription> &vertex_binding,
                      const std::vector<VkVertexInputAttributeDescription> &attribute_binding,
-                     const std::uint32_t window_width, const std::uint32_t window_height, const std::string &name);
+                     std::uint32_t window_width, std::uint32_t window_height, const std::string &name);
 
     GraphicsPipeline(const GraphicsPipeline &) = delete;
     GraphicsPipeline(GraphicsPipeline &&other) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -12,7 +12,7 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief RAII wrapper class for VkInstances.
 class Instance {
 protected:
-    VkInstance m_instance{VK_NULL_HANDLE};
+    VkInstance m_instance{nullptr};
     AvailabilityChecksManager m_availability_checks;
 
 public:

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -54,7 +54,7 @@ public:
     Instance &operator=(const Instance &) = delete;
     Instance &operator=(Instance &&) = default;
 
-    [[nodiscard]] const VkInstance instance() const {
+    [[nodiscard]] VkInstance instance() const {
         return m_instance;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -37,9 +37,6 @@ class MeshBuffer {
     std::uint32_t m_number_of_vertices{0};
     std::uint32_t m_number_of_indices{0};
 
-    // Don't forget that index buffers are optional!
-    bool m_index_buffer_available = false;
-
 public:
     /// @brief Construct the mesh buffer and copy the vertex buffers's data and index buffer's data.
     /// @param device The const reference to a device RAII wrapper instance.

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -36,7 +36,7 @@ public:
     /// @warn We can't determine the queue and queue family index to use automatically using the device wrapper
     /// reference because we might choose a queue which is unsuitable for the requested purpose!
     /// This is the reason we must specify the queue and queue family index in the constructor.
-    OnceCommandBuffer(const Device &device, const VkQueue queue, const std::uint32_t queue_family_index);
+    OnceCommandBuffer(const Device &device, VkQueue queue, std::uint32_t queue_family_index);
 
     OnceCommandBuffer(const OnceCommandBuffer &) = delete;
     OnceCommandBuffer(OnceCommandBuffer &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
@@ -24,7 +24,7 @@ public:
     /// @param subpass_description The subpass description.
     /// @param name The internal debug marker name of the VkRenderPass.
     RenderPass(const Device &device, const std::vector<VkAttachmentDescription> &attachments,
-               const std::vector<VkSubpassDependency> &dependencies, const VkSubpassDescription subpass_description,
+               const std::vector<VkSubpassDependency> &dependencies, VkSubpassDescription subpass_description,
                const std::string &name);
 
     RenderPass(const RenderPass &) = delete;

--- a/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
@@ -13,8 +13,8 @@ class Device;
 class ResourceDescriptor {
     const std::string m_name;
     const Device &m_device;
-    VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
-    VkDescriptorSetLayout m_descriptor_set_layout{VK_NULL_HANDLE};
+    VkDescriptorPool m_descriptor_pool{nullptr};
+    VkDescriptorSetLayout m_descriptor_set_layout{nullptr};
     std::vector<VkDescriptorSetLayoutBinding> m_descriptor_set_layout_bindings;
     std::vector<VkWriteDescriptorSet> m_write_descriptor_sets;
     std::vector<VkDescriptorSet> m_descriptor_sets;

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -23,8 +23,8 @@ public:
     /// @param buffer_size The size of the memory buffer to copy.
     /// @param data A pointer to the memory buffer.
     /// @param data_size The size of the memory buffer to copy.
-    StagingBuffer(const Device &device, const std::string &name, const VkDeviceSize buffer_size, void *data,
-                  const std::size_t data_size);
+    StagingBuffer(const Device &device, const std::string &name, VkDeviceSize buffer_size, void *data,
+                  std::size_t data_size);
 
     StagingBuffer(const StagingBuffer &) = delete;
     StagingBuffer(StagingBuffer &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -3,6 +3,7 @@
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.h>
 
+#include <array>
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -11,8 +11,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief RAII wrapper class for GLFW windows.
 class Window {
     GLFWwindow *m_window;
-    std::uint32_t m_width;
-    std::uint32_t m_height;
+    std::uint32_t m_width{0};
+    std::uint32_t m_height{0};
 
 public:
     /// @brief Default constructor.

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -45,7 +45,7 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     auto renderer_configuration = toml::parse(file_name);
 
     // Search for the title of the configuration file and print it to debug output.
-    auto configuration_title = toml::find<std::string>(renderer_configuration, "title");
+    const auto &configuration_title = toml::find<std::string>(renderer_configuration, "title");
     spdlog::debug("Title: '{}'", configuration_title);
 
     m_window_width = toml::find<int>(renderer_configuration, "application", "window", "width");

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -443,10 +443,8 @@ void Application::update_mouse_input() {
     double current_cursor_x{0.0};
     double current_cursor_y{0.0};
 
-    m_window->cursor_pos(current_cursor_x, current_cursor_y);
-
-    double cursor_delta_x = current_cursor_x - m_cursor_x;
-    double cursor_delta_y = current_cursor_y - m_cursor_y;
+    double cursor_delta_x = cursor_pos[0] - m_cursor_x;
+    double cursor_delta_y = cursor_pos[1] - m_cursor_y;
 
     int state = m_window->is_button_pressed(GLFW_MOUSE_BUTTON_LEFT);
 

--- a/src/vulkan-renderer/frame_graph.cpp
+++ b/src/vulkan-renderer/frame_graph.cpp
@@ -517,7 +517,7 @@ void FrameGraph::render(int image_index, VkSemaphore signal_semaphore, VkSemapho
     for (const auto *stage : m_phys_stage_stack) {
         auto *cmd_buf = stage->m_command_buffers[image_index].get();
         submit_info.pCommandBuffers = &cmd_buf;
-        vkQueueSubmit(graphics_queue, 1, &submit_info, VK_NULL_HANDLE);
+        vkQueueSubmit(graphics_queue, 1, &submit_info, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/gpu_info.cpp
+++ b/src/vulkan-renderer/gpu_info.cpp
@@ -118,7 +118,7 @@ void VulkanGraphicsCardInfoViewer::print_instance_layers() {
         }
 
         // Loop through all available instance layers and print information about them.
-        for (auto instance_layer : instance_layers) {
+        for (const auto &instance_layer : instance_layers) {
             std::uint32_t spec_major = VK_VERSION_MAJOR(instance_layer.specVersion);
             std::uint32_t spec_minor = VK_VERSION_MINOR(instance_layer.specVersion);
             std::uint32_t spec_patch = VK_VERSION_PATCH(instance_layer.specVersion);
@@ -158,7 +158,7 @@ void VulkanGraphicsCardInfoViewer::print_instance_extensions() {
         }
 
         // Loop through all available instance extensions and print information about them.
-        for (auto extension : extensions) {
+        for (const auto &extension : extensions) {
             std::uint32_t spec_major = VK_VERSION_MAJOR(extension.specVersion);
             std::uint32_t spec_minor = VK_VERSION_MINOR(extension.specVersion);
             std::uint32_t spec_patch = VK_VERSION_PATCH(extension.specVersion);
@@ -198,7 +198,7 @@ void VulkanGraphicsCardInfoViewer::print_device_layers(const VkPhysicalDevice &g
         }
 
         // Loop through all available device layers and print information about them.
-        for (auto device_layer : device_layers) {
+        for (const auto &device_layer : device_layers) {
             std::uint32_t spec_major = VK_VERSION_MAJOR(device_layer.specVersion);
             std::uint32_t spec_minor = VK_VERSION_MINOR(device_layer.specVersion);
             std::uint32_t spec_patch = VK_VERSION_PATCH(device_layer.specVersion);
@@ -241,7 +241,7 @@ void VulkanGraphicsCardInfoViewer::print_device_extensions(const VkPhysicalDevic
         }
 
         // Loop through all available device extensions and print information about them.
-        for (auto device_extension : device_extensions) {
+        for (const auto &device_extension : device_extensions) {
             std::uint32_t spec_major = VK_VERSION_MAJOR(device_extension.specVersion);
             std::uint32_t spec_minor = VK_VERSION_MINOR(device_extension.specVersion);
             std::uint32_t spec_patch = VK_VERSION_PATCH(device_extension.specVersion);

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -252,7 +252,7 @@ void ImGUIOverlay::update() {
                                                              imgui_draw_data->TotalIdxCount);
     }
 
-    if ((m_imgui_mesh->get_vertex_buffer() == VK_NULL_HANDLE) || (m_vertex_count != imgui_draw_data->TotalVtxCount)) {
+    if ((m_imgui_mesh->get_vertex_buffer() == nullptr) || (m_vertex_count != imgui_draw_data->TotalVtxCount)) {
         m_imgui_mesh.reset();
 
         spdlog::debug("Creating ImGUI vertex buffer");
@@ -266,7 +266,7 @@ void ImGUIOverlay::update() {
         update_command_buffers = true;
     }
 
-    if ((m_imgui_mesh->get_index_buffer() == VK_NULL_HANDLE) ||
+    if ((m_imgui_mesh->get_index_buffer() == nullptr) ||
         (m_index_count < static_cast<std::uint32_t>(imgui_draw_data->TotalIdxCount))) {
         m_imgui_mesh.reset();
 

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -639,13 +639,15 @@ VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(const VkPhysi
     return std::nullopt;
 }
 
-void VulkanSettingsDecisionMaker::decide_swapchain_extent(const VkPhysicalDevice &graphics_card,
-                                                          const VkSurfaceKHR &surface, std::uint32_t &window_width,
-                                                          std::uint32_t &window_height, VkExtent2D &swapchain_extent) {
+SwapchainSettings VulkanSettingsDecisionMaker::decide_swapchain_extent(const VkPhysicalDevice &graphics_card,
+                                                                       const VkSurfaceKHR &surface,
+                                                                       std::uint32_t window_width,
+                                                                       std::uint32_t window_height) {
     assert(graphics_card);
     assert(surface);
 
     VkSurfaceCapabilitiesKHR surface_capabilities{};
+    SwapchainSettings updated_swapchain_settings{};
 
     if (vkGetPhysicalDeviceSurfaceCapabilitiesKHR(graphics_card, surface, &surface_capabilities) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!");
@@ -654,14 +656,15 @@ void VulkanSettingsDecisionMaker::decide_swapchain_extent(const VkPhysicalDevice
     if (surface_capabilities.currentExtent.width == std::numeric_limits<std::uint32_t>::max() &&
         surface_capabilities.currentExtent.height == std::numeric_limits<std::uint32_t>::max()) {
         // The size of the window dictates the swapchain's extent.
-        swapchain_extent.width = window_width;
-        swapchain_extent.height = window_height;
+        updated_swapchain_settings.swapchain_size.width = window_width;
+        updated_swapchain_settings.swapchain_size.height = window_height;
     } else {
         // If the surface size is defined, the swap chain size must match.
-        swapchain_extent = surface_capabilities.currentExtent;
-        window_width = surface_capabilities.currentExtent.width;
-        window_height = surface_capabilities.currentExtent.height;
+        updated_swapchain_settings.swapchain_size = surface_capabilities.currentExtent;
+        updated_swapchain_settings.window_size = surface_capabilities.currentExtent;
     }
+
+    return updated_swapchain_settings;
 }
 
 std::optional<std::uint32_t>

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -311,6 +311,17 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
 
 Device::Device(Device &&other) noexcept
     : m_device(std::exchange(other.m_device, nullptr)), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)),
+      m_allocator(other.m_allocator), m_gpu_name(std::move(other.m_gpu_name)), m_graphics_queue(other.m_graphics_queue),
+      m_present_queue(other.m_present_queue), m_transfer_queue(other.m_transfer_queue), m_surface(other.m_surface),
+      m_present_queue_family_index(other.m_present_queue_family_index),
+      m_graphics_queue_family_index(other.m_graphics_queue_family_index),
+      m_transfer_queue_family_index(other.m_transfer_queue_family_index),
+      m_vk_debug_marker_set_object_tag(other.m_vk_debug_marker_set_object_tag),
+      m_vk_debug_marker_set_object_name(other.m_vk_debug_marker_set_object_name),
+      m_vk_cmd_debug_marker_begin(other.m_vk_cmd_debug_marker_begin),
+      m_vk_cmd_debug_marker_end(other.m_vk_cmd_debug_marker_end),
+      m_vk_cmd_debug_marker_insert(other.m_vk_cmd_debug_marker_insert),
+      m_vk_set_debug_utils_object_name(other.m_vk_set_debug_utils_object_name),
       m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers) {}
 
 Device::~Device() {

--- a/src/vulkan-renderer/wrapper/mesh_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/mesh_buffer.cpp
@@ -78,7 +78,7 @@ MeshBuffer::MeshBuffer(const Device &device, const std::string &name, const VkDe
     : m_vertex_buffer(device, name, size_of_vertex_structure * number_of_vertices,
                       VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
       m_index_buffer(std::nullopt), m_number_of_vertices(static_cast<std::uint32_t>(number_of_vertices)),
-      m_number_of_indices(static_cast<std::uint32_t>(m_number_of_indices)), m_device(device) {
+      m_number_of_indices(0), m_device(device) {
     assert(device.device());
     assert(device.allocator());
     assert(!name.empty());
@@ -104,7 +104,6 @@ MeshBuffer::MeshBuffer(const Device &device, const std::string &name, const VkDe
 
     : m_vertex_buffer(device, name, size_of_vertex_structure * number_of_vertices,
                       VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
-      m_index_buffer(std::nullopt), m_number_of_indices(static_cast<std::uint32_t>(m_number_of_indices)),
-      m_device(device) {}
+      m_index_buffer(std::nullopt), m_number_of_indices(0), m_device(device) {}
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -82,7 +82,7 @@ void OnceCommandBuffer::end_recording_and_submit_command() {
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = m_command_buffer->ptr();
 
-    if (vkQueueSubmit(m_queue, 1, &submit_info, VK_NULL_HANDLE) != VK_SUCCESS) {
+    if (vkQueueSubmit(m_queue, 1, &submit_info, nullptr) != VK_SUCCESS) {
         throw std::runtime_error("Error: vkQueueSubmit failed for once command buffer!");
     }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -18,7 +18,7 @@ Swapchain::Swapchain(const Device &device, const VkSurfaceKHR surface, std::uint
     assert(device.device());
     assert(surface);
 
-    setup_swapchain(VK_NULL_HANDLE, window_width, window_height);
+    setup_swapchain(nullptr, window_width, window_height);
 }
 
 Swapchain::Swapchain(Swapchain &&other) noexcept
@@ -77,7 +77,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     swapchain_ci.presentMode = *present_mode;
 
     // Swapchain recreation can be accelerated a lot when storing the old swapchain.
-    if (old_swapchain != VK_NULL_HANDLE) {
+    if (old_swapchain != nullptr) {
         swapchain_ci.oldSwapchain = old_swapchain;
     }
 
@@ -149,7 +149,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
 std::uint32_t Swapchain::acquire_next_image(const Semaphore &semaphore) {
     std::uint32_t image_index;
     vkAcquireNextImageKHR(m_device.device(), m_swapchain, std::numeric_limits<std::uint64_t>::max(), semaphore.get(),
-                          VK_NULL_HANDLE, &image_index);
+                          nullptr, &image_index);
     return image_index;
 }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -33,8 +33,12 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
                                 std::uint32_t window_height) {
     VulkanSettingsDecisionMaker settings_decision_maker;
 
-    settings_decision_maker.decide_swapchain_extent(m_device.physical_device(), m_surface, window_width, window_height,
-                                                    m_extent);
+    auto swapchain_settings = settings_decision_maker.decide_swapchain_extent(m_device.physical_device(), m_surface,
+                                                                              window_width, window_height);
+
+    window_width = swapchain_settings.window_size.width;
+    window_height = swapchain_settings.window_size.height;
+    m_extent = swapchain_settings.swapchain_size;
 
     std::optional<VkPresentModeKHR> present_mode = settings_decision_maker.decide_which_presentation_mode_to_use(
         m_device.physical_device(), m_surface, m_vsync_enabled);

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -69,9 +69,17 @@ void Window::hide() {
     glfwHideWindow(m_window);
 }
 
-void Window::cursor_pos(double &pos_x, double &pos_y) {
+std::array<double, 2> Window::cursor_pos() {
     assert(m_window);
-    glfwGetCursorPos(m_window, &pos_x, &pos_y);
+    double cursor_pos_x{0.0};
+    double cursor_pos_y{0.0};
+
+    glfwGetCursorPos(m_window, &cursor_pos_x, &cursor_pos_y);
+
+    std::array<double, 2> cursor_pos;
+    cursor_pos[0] = cursor_pos_x;
+    cursor_pos[1] = cursor_pos_y;
+    return cursor_pos;
 }
 
 bool Window::is_button_pressed(int button) {


### PR DESCRIPTION
**There is no need to review the commits which improve documentation!**
See: https://github.com/inexorgame/vulkan-renderer/pull/248

This will fix the most important issues we have in our code. This brach is based on `hanni/enhance_documentation`. Once we squashed all the documentation commits, we must rebase this again.

I will another pull request in which I will fix the advanced issues.
See the full list: https://github.com/inexorgame/vulkan-renderer/issues/209.