### PR TITLE
Refactor Vulkan debug markers

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -103,38 +103,30 @@ public:
         return m_transfer_queue_family_index;
     }
 
-#ifndef NDEBUG
+    /// @brief Assign an internal Vulkan debug marker name to a Vulkan object.
+    /// This internal name can be seen in external debuggers like RenderDoc.
+    /// @note This method is only available in debug mode with ``VK_EXT_debug_marker`` device extension enabled.
+    /// @param object The Vulkan object.
+    /// @param object_type The Vulkan debug report object type.
+    /// @param name The internal name of the Vulkan object.
+    void set_debug_marker_name(void *object, VkDebugReportObjectTypeEXT object_type, const std::string &name) const;
 
-    /// For more information about Vulkan debugging tools check
-    /// https://www.saschawillems.de/blog/2016/05/28/tutorial-on-using-vulkans-vk_ext_debug_marker-with-renderdoc/
-    /// Also check our RenderDoc's official website: https://renderdoc.org/
+    /// @brief Assigns a block of memory to a Vulkan resource.
+    /// This memory block can be seen in external debuggers like RenderDoc.
+    /// @note This method is only available in debug mode with ``VK_EXT_debug_marker`` device extension enabled.
+    /// @param object The Vulkan object.
+    /// @param object_type The Vulkan debug report object type.
+    /// @param name The name of the memory block which will be connected to this object.
+    /// @param memory_size The size of the memory block in bytes.
+    /// @param memory_address The memory address to read from.
+    void set_memory_block_attachment(void *object, VkDebugReportObjectTypeEXT object_type, const std::uint64_t name,
+                                     const std::size_t memory_size, const void *memory_block) const;
 
-    /// @note Vulkan debug markers are only available in debug mode when VK_EXT_debug_marker device extension is used.
-    /// @todo Add overloaded methods like "set_image_name" which accept a specific type instead of a pointer. This
-    /// increases type-safety and would also remove the need for a "type" argument.
-
-    /// @brief Set the internal name of a Vulkan resource using vkDebugMarkerSetObjectNameEXT. This internal name can
-    /// be seen in external debuggers like RenderDoc.
-    /// @param object A pointer to the Vulkan object whose name will be set.
-    /// @param type The type of the Vulkan object.
-    /// @param name The internal name which will be assigned to the Vulkan object.
-    void set_object_name(std::uint64_t object, const VkDebugReportObjectTypeEXT type, const std::string &name) const;
-
-    /// @brief Assign a memory block for debugging to a Vulkan resource using vkDebugMarkerSetObjectTagEXT. This memory
-    /// block can later be seen in external debuggers like RenderDoc.
-    /// @param object A pointer to the Vulkan object to which a memory tag will be assigned.
-    /// @param type The type of the Vulkan object.
-    /// @param name The internal name of the object ag.
-    /// @param tag_size The size of the memory tag in bytes.
-    /// @param tag A pointer to the memory tag.
-    void set_object_tag(const std::uint64_t object, const VkDebugReportObjectTypeEXT type, const std::uint64_t name,
-                        const std::size_t tag_size, const void *tag) const;
-
-    /// @brief Set the color of the current rendering region using vkCmdDebugMarkerBeginEXT. This color can be seen in
-    /// external debuggers like RenderDoc.
-    /// @param command_buffer The command buffer which is associated to the debug region.
-    /// @param name The name of the debug region.
-    /// @param color An array of red, green, blue and alpha values for the debug region's color.
+    /// @param color [in] The rgba color of the rendering region.
+    /// @param name [in] The name of the rendering region.
+    /// @param command_buffer [in] The associated command buffer.
+    /// The rendering region will be visible in external debuggers like RenderDoc.
+    /// @brief Vulkan debug markers: Annotation of a rendering region.
     void bind_debug_region(const VkCommandBuffer command_buffer, const std::string &name,
                            const std::array<float, 4> color) const;
 
@@ -149,8 +141,6 @@ public:
     /// @brief End the debug region of the current renderpass using vkCmdDebugMarkerEndEXT.
     /// @param command_buffer The command buffer which is associated to the debug marker.
     void end_debug_region(const VkCommandBuffer command_buffer) const;
-
-#endif
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/frame_graph.cpp
+++ b/src/vulkan-renderer/frame_graph.cpp
@@ -121,10 +121,8 @@ void FrameGraph::build_pipeline_layout(const RenderStage *stage, PhysicalStage *
         throw std::runtime_error("Failed to create pipeline layout!");
     }
 
-#ifndef NDEBUG
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(phys->m_pipeline_layout),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, stage->m_name + " pipeline layout");
-#endif
+    m_device.set_debug_marker_name(phys->m_pipeline_layout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT,
+                                   stage->m_name + " pipeline layout");
 }
 
 void FrameGraph::record_command_buffers(const RenderStage *stage, PhysicalStage *phys) const {

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -22,11 +22,8 @@ CommandBuffer::CommandBuffer(const wrapper::Device &device, VkCommandPool comman
         throw std::runtime_error("Failed to allocate command buffer!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_command_buffer),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_command_buffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, m_name);
 }
 
 CommandBuffer::CommandBuffer(CommandBuffer &&other) noexcept

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -23,10 +23,8 @@ Fence::Fence(const wrapper::Device &device, const std::string &name, const bool 
         throw std::runtime_error("Error: vkCreateFence failed!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_fence), VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_fence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, m_name);
 
     spdlog::debug("Created fence {} successfully.", m_name);
 }

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -27,11 +27,8 @@ Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const s
         throw std::runtime_error("Failed to create framebuffer " + m_name + "!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_framebuffer),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_framebuffer, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, m_name);
 
     spdlog::debug("Created framebuffer {} successfully.", m_name);
 }

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -41,23 +41,8 @@ GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, 
         throw std::runtime_error("Error: GPU memory buffer allocation for " + name + " failed!");
     }
 
-    // Try to find the Vulkan debug marker function.
-    auto *vkDebugMarkerSetObjectNameEXT = reinterpret_cast<PFN_vkDebugMarkerSetObjectNameEXT>(
-        vkGetDeviceProcAddr(m_device.device(), "vkDebugMarkerSetObjectNameEXT"));
-
-    if (vkDebugMarkerSetObjectNameEXT != nullptr) {
-        // Since the function vkDebugMarkerSetObjectNameEXT has been found, we can assign an internal name for
-        // debugging.
-        auto name_info = make_info<VkDebugMarkerObjectNameInfoEXT>();
-        name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;
-        name_info.object = reinterpret_cast<std::uint64_t>(m_buffer);
-        name_info.pObjectName = name.c_str();
-
-        spdlog::debug("Assigning internal name '{}' to GPU memory buffer.", name);
-        if (vkDebugMarkerSetObjectNameEXT(m_device.device(), &name_info) != VK_SUCCESS) {
-            throw std::runtime_error("Error: vkDebugMarkerSetObjectNameEXT failed for GPU memory buffer " + name + "!");
-        }
-    }
+    // Assign an internal debug marker name to this buffer.
+    m_device.set_debug_marker_name(m_buffer, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
 }
 
 GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &buffer_size,

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -192,11 +192,8 @@ void GpuTexture::create_texture_sampler() {
         throw std::runtime_error("Error: vkCreateSampler failed for texture " + m_name + " !");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_sampler), VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT,
-                             m_name);
-#endif
+    m_device.set_debug_marker_name(m_sampler, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, m_name);
 
     spdlog::debug("Image sampler {} created successfully.", m_name);
 }

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -47,10 +47,8 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
         throw std::runtime_error("Error: vmaCreateImage failed for image " + m_name + "!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_image), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_image, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, m_name);
 
     auto image_view_ci = make_info<VkImageViewCreateInfo>();
     image_view_ci.image = m_image;
@@ -66,11 +64,8 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
         throw std::runtime_error("Error: vkCreateImageView failed for image view " + m_name + "!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_image_view), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT,
-                             m_name);
-#endif
+    m_device.set_debug_marker_name(m_image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
 }
 
 Image::Image(Image &&other) noexcept

--- a/src/vulkan-renderer/wrapper/resource_descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/resource_descriptor.cpp
@@ -49,11 +49,8 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
         throw std::runtime_error("Error: vkCreateDescriptorPool failed for descriptor " + m_name + " !");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_descriptor_pool),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_descriptor_pool, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, m_name);
 
     spdlog::debug("Created descriptor pool for descriptor {} successfully.", m_name);
 
@@ -68,11 +65,9 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
         throw std::runtime_error("Error: vkCreateDescriptorSetLayout failed for descriptor " + m_name + " !");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_descriptor_set_layout),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_descriptor_set_layout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT,
+                                   m_name);
 
     spdlog::debug("Created descriptor sets for descriptor {} successfully.", m_name);
 
@@ -91,13 +86,10 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
         throw std::runtime_error("Error: vkAllocateDescriptorSets failed for descriptor " + m_name + " !");
     }
 
-#ifndef NDEBUG
     for (const auto &descriptor_set : m_descriptor_sets) {
         // Assign an internal name using Vulkan debug markers.
-        m_device.set_object_name(reinterpret_cast<std::uint64_t>(descriptor_set),
-                                 VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, m_name);
+        m_device.set_debug_marker_name(descriptor_set, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, m_name);
     }
-#endif
 
     for (std::size_t k = 0; k < swapchain_image_count; k++) {
         for (std::size_t j = 0; j < m_write_descriptor_sets.size(); j++) {

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -20,11 +20,8 @@ Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(d
         throw std::runtime_error("Error: vkCreateSemaphore failed for " + name + " !");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_semaphore), VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,
-                             name);
-#endif
+    m_device.set_debug_marker_name(m_semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
 
     spdlog::debug("Created semaphore successfully.");
 }

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -58,11 +58,8 @@ Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std
         throw std::runtime_error("Error: vkCreateShaderModule failed for shader " + name + "!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_shader_module),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
-#endif
+    m_device.set_debug_marker_name(m_shader_module, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
 }
 
 Shader::Shader(Shader &&other) noexcept

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -106,11 +106,8 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
         throw std::runtime_error("Error: vkGetSwapchainImagesKHR failed!");
     }
 
-#ifndef NDEBUG
     // Assign an internal name using Vulkan debug markers.
-    m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_swapchain),
-                             VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, m_name);
-#endif
+    m_device.set_debug_marker_name(m_swapchain, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, m_name);
 
     spdlog::debug("Creating {} swapchain image views.", m_swapchain_image_count);
 
@@ -138,11 +135,8 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
             throw std::runtime_error("Error: vkCreateImageView failed!");
         }
 
-#ifndef NDEBUG
         // Assign an internal name using Vulkan debug markers.
-        m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_swapchain_image_views[i]),
-                                 VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
-#endif
+        m_device.set_debug_marker_name(m_swapchain_image_views[i], VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
     }
 
     spdlog::debug("Created {} swapchain image views successfully.", m_swapchain_image_count);


### PR DESCRIPTION
In this pull request, I removed the old `set_object_name` method and overloaded the wrapper which assigns an internal name to Vulkan resources using `PFN_vkDebugMarkerSetObjectNameEXT`. This simplifies the interface and reduces the need to use a `reinterpret_cast` as argument every function call. This means we don't need to pass a pointer to the method, furter improving type safety.

**Old code example:**
* Uses `reinterpret_cast` in every method call, bad!
* User needs to specify `VK_DEBUG_REPORT...` type in every method call, bad!
```cpp
m_device.set_object_name(reinterpret_cast<std::uint64_t>(m_fence), VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, m_name);
```

**New code example:**
* Less arguments, good.
* Improved type safety.
```cpp
m_device.set_debug_marker_name(m_fence, m_name);
```

Currently, I am overloading the `set_debug_marker_name` method. This means we have a lot of similar code which only differs in some small parts. However, overloading this into a template might makes it more complicated than it needs to be, but I am open for discussion about this :)