### PR TITLE
Fix clang-tidy warnings and Microsoft code analysis warnings.

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -5,8 +5,6 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
-using namespace inexor::vulkan_renderer;
-
 int main(int argc, char *argv[]) {
     spdlog::init_thread_pool(8192, 2);
 
@@ -24,7 +22,7 @@ int main(int argc, char *argv[]) {
     spdlog::debug("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
     spdlog::debug("Parsing command line arguments.");
 
-    Application renderer(argc, argv);
+    inexor::vulkan_renderer::Application renderer(argc, argv);
     renderer.run();
     renderer.calculate_memory_budget();
     spdlog::debug("Window closed");

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -4,33 +4,32 @@
 
 namespace inexor::vulkan_renderer {
 
+enum class CameraType { LOOKAT, FIRSTPERSON };
+
 /// @brief A RAII wrapper class for camera position and movement.
 /// @todo Refactor method naming!
 class Camera {
-    float m_fov;
-    float m_z_near, m_z_far;
-
     /// @brief Update the view matrix.
     /// @note The view matrix should only be updated if necessary.
     void update_view_matrix();
 
-public:
-    // TODO: Why is so much stuff here public? refactor!
-
-    enum CameraType { LOOKAT, FIRSTPERSON };
     CameraType m_type{CameraType::LOOKAT};
 
-    glm::vec3 m_rotation{};
     glm::vec3 m_position{};
+    glm::vec3 m_rotation{};
 
-    float m_rotation_speed{1.0f};
     float m_movement_speed{1.0f};
+    float m_rotation_speed{1.0f};
+
+    float m_fov{0.0f};
+    float m_z_near{0.0f};
+    float m_z_far{0.0f};
 
     bool m_updated{false};
 
     struct {
-        glm::mat4 perspective;
-        glm::mat4 view;
+        glm::mat4 perspective = glm::mat4();
+        glm::mat4 view = glm::mat4();
     } m_matrices;
 
     struct {
@@ -39,6 +38,28 @@ public:
         bool up{false};
         bool down{false};
     } m_keys;
+
+public:
+    Camera() = default;
+    /// @brief Constructs a camera based on camera properties.
+    /// @param type The type of the camera.
+    /// @param position The camera's position.
+    /// @param rotation The camera's rotation.
+    /// @param movement_speed The movement speed of the camera.
+    /// @param rotation_speed The rotation speed of the camera.
+    /// @param fov The camera's field of view.
+    /// @param z_near The near clipping value.
+    /// @param z_far The far clipping value.
+    /// @param window_width The width of the window which is used to calculate aspect ratio.
+    /// @param window_height The height of the window which is used to calculate aspect ratio.
+    Camera(CameraType type, glm::vec3 position, glm::vec3 rotation, float movement_speed, float rotation_speed,
+           float fov, float z_near, float z_far, std::uint32_t window_width, std::uint32_t window_height);
+    Camera(const Camera &) = default;
+    Camera(Camera &&) noexcept;
+    ~Camera() = default;
+
+    Camera &operator=(const Camera &) = default;
+    Camera &operator=(Camera &&) = default;
 
     /// @brief Check if any of the following keys is pressed: W, A, S, D.
     bool moving();
@@ -85,6 +106,22 @@ public:
     /// @param delta_time The amount of time which passed since last update.
     /// @return Returns true if view or position has been changed.
     bool update_pad(glm::vec2 axis_left, glm::vec2 axis_right, float delta_time);
+
+    [[nodiscard]] glm::mat4 get_perspective() const {
+        return m_matrices.perspective;
+    }
+
+    [[nodiscard]] glm::mat4 get_view() const {
+        return m_matrices.view;
+    }
+
+    [[nodiscard]] float get_rotation_speed() const {
+        return m_rotation_speed;
+    }
+
+    [[nodiscard]] float get_movement_speed() const {
+        return m_movement_speed;
+    }
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/frame_graph.hpp
+++ b/include/inexor/vulkan-renderer/frame_graph.hpp
@@ -30,7 +30,13 @@ class FrameGraph;
 /// @brief Base class of all frame graph objects (resources and stages)
 /// @note This is just for internal use
 struct FrameGraphObject {
+    FrameGraphObject() = default;
+    FrameGraphObject(const FrameGraphObject &) = delete;
+    FrameGraphObject(FrameGraphObject &&) = delete;
     virtual ~FrameGraphObject() = default;
+
+    FrameGraphObject &operator=(const FrameGraphObject &) = delete;
+    FrameGraphObject &operator=(FrameGraphObject &&) = delete;
 
     /// @brief Casts this object to type `T`
     /// @return The object as type `T` or `nullptr` if the cast failed
@@ -56,6 +62,7 @@ protected:
 public:
     RenderResource(const RenderResource &) = delete;
     RenderResource(RenderResource &&) = delete;
+    ~RenderResource() override = default;
 
     RenderResource &operator=(const RenderResource &) = delete;
     RenderResource &operator=(RenderResource &&) = delete;
@@ -173,6 +180,7 @@ protected:
 public:
     RenderStage(const RenderStage &) = delete;
     RenderStage(RenderStage &&) = delete;
+    ~RenderStage() override = default;
 
     RenderStage &operator=(const RenderStage &) = delete;
     RenderStage &operator=(RenderStage &&) = delete;
@@ -210,6 +218,7 @@ public:
     explicit GraphicsStage(std::string &&name) : RenderStage(name) {}
     GraphicsStage(const GraphicsStage &) = delete;
     GraphicsStage(GraphicsStage &&) = delete;
+    ~GraphicsStage() override = default;
 
     GraphicsStage &operator=(const GraphicsStage &) = delete;
     GraphicsStage &operator=(GraphicsStage &&) = delete;
@@ -242,6 +251,7 @@ protected:
 public:
     PhysicalResource(const PhysicalResource &) = delete;
     PhysicalResource(PhysicalResource &&) = delete;
+    ~PhysicalResource() override = default;
 
     PhysicalResource &operator=(const PhysicalResource &) = delete;
     PhysicalResource &operator=(PhysicalResource &&) = delete;
@@ -291,6 +301,7 @@ public:
         : PhysicalResource(allocator, device), m_swapchain(swapchain) {}
     PhysicalBackBuffer(const PhysicalBackBuffer &) = delete;
     PhysicalBackBuffer(PhysicalBackBuffer &&) = delete;
+    ~PhysicalBackBuffer() override = default;
 
     PhysicalBackBuffer &operator=(const PhysicalBackBuffer &) = delete;
     PhysicalBackBuffer &operator=(PhysicalBackBuffer &&) = delete;

--- a/include/inexor/vulkan-renderer/imgui.hpp
+++ b/include/inexor/vulkan-renderer/imgui.hpp
@@ -65,14 +65,14 @@ public:
     ImGUIOverlay(ImGUIOverlay &&other) noexcept;
 
     ImGUIOverlay &operator=(const ImGUIOverlay &other) = delete;
-    ImGUIOverlay &operator=(ImGUIOverlay &&other) = default;
+    ImGUIOverlay &operator=(ImGUIOverlay &&other) = delete;
 
     [[nodiscard]] float get_scale() const {
         return m_scale;
     }
 
     void update();
-    void render(const std::uint32_t image_index);
+    void render(std::uint32_t image_index);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/octree_gpu_vertex.hpp
+++ b/include/inexor/vulkan-renderer/octree_gpu_vertex.hpp
@@ -24,8 +24,8 @@ namespace std {
 template <>
 struct hash<inexor::vulkan_renderer::OctreeGpuVertex> {
     std::size_t operator()(const inexor::vulkan_renderer::OctreeGpuVertex &vertex) const {
-        auto h1 = std::hash<glm::vec3>{}(vertex.position);
-        auto h2 = std::hash<glm::vec3>{}(vertex.color);
+        const auto h1 = std::hash<glm::vec3>{}(vertex.position);
+        const auto h2 = std::hash<glm::vec3>{}(vertex.color);
         return h1 ^ h2;
     }
 };

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -89,7 +89,13 @@ protected:
     void render_frame();
 
 public:
+    VulkanRenderer() = default;
+    VulkanRenderer(const VulkanRenderer &) = delete;
+    VulkanRenderer(VulkanRenderer &&) = delete;
     ~VulkanRenderer();
+
+    VulkanRenderer &operator=(const VulkanRenderer &) = delete;
+    VulkanRenderer &operator=(VulkanRenderer &&) = delete;
 
     /// @brief Run Vulkan memory allocator's memory statistics
     void calculate_memory_budget();

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -8,6 +8,12 @@
 
 namespace inexor::vulkan_renderer {
 
+/// @brief A wrapper class for swapchain settings.
+struct SwapchainSettings {
+    VkExtent2D window_size;
+    VkExtent2D swapchain_size;
+};
+
 /// @brief This class makes automatic decisions about setting up Vulkan.
 /// Examples:
 /// - Which graphics card will be used if more than one is available?
@@ -72,11 +78,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param surface The selected (window) surface.
     /// @param window_width The width of the window.
     /// @param window_height The height of the window.
-    /// @param swapchain_extent [out] The extent of the swapchain.
-    /// @todo Make this function return a std::optional<VkExtend2D> instead of using call by reference!
-    void decide_swapchain_extent(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
-                                 std::uint32_t &window_width, std::uint32_t &window_height,
-                                 VkExtent2D &swapchain_extent);
+    SwapchainSettings decide_swapchain_extent(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
+                                              std::uint32_t window_width, std::uint32_t window_height);
 
     /// @brief Automatically find the image transform, relative to the presentation engine's natural orientation,
     /// applied to the image content prior to presentation.
@@ -90,8 +93,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The composite alpha flag bits.
-    [[nodiscard]] VkCompositeAlphaFlagBitsKHR find_composite_alpha_format(const VkPhysicalDevice selected_graphics_card,
-                                                                          const VkSurfaceKHR surface);
+    [[nodiscard]] std::optional<VkCompositeAlphaFlagBitsKHR>
+    find_composite_alpha_format(VkPhysicalDevice selected_graphics_card, VkSurfaceKHR surface);
 
     /// @brief Automatically decide which presentation mode the presentation engine will be using.
     /// @note We can only use presentation modes that are available in the current system. The preferred presentation
@@ -162,8 +165,8 @@ struct VulkanSettingsDecisionMaker {
     /// @return A VkFormat value if a suitable depth buffer format could be found, std::nullopt otherwise.
     [[nodiscard]] std::optional<VkFormat> find_depth_buffer_format(const VkPhysicalDevice &graphics_card,
                                                                    const std::vector<VkFormat> &formats,
-                                                                   const VkImageTiling tiling,
-                                                                   const VkFormatFeatureFlags feature_flags);
+                                                                   VkImageTiling tiling,
+                                                                   VkFormatFeatureFlags feature_flags);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -16,7 +16,7 @@ class ResourceDescriptor;
 class CommandBuffer {
     VkCommandBuffer m_command_buffer{VK_NULL_HANDLE};
     const wrapper::Device &m_device;
-    const std::string m_name;
+    std::string m_name;
 
 public:
     /// @brief Default constructor.
@@ -31,7 +31,7 @@ public:
     ~CommandBuffer() = default;
 
     CommandBuffer &operator=(const CommandBuffer &) = delete;
-    CommandBuffer &operator=(CommandBuffer &&) = default;
+    CommandBuffer &operator=(CommandBuffer &&) = delete;
 
     /// @brief Call vkBeginCommandBuffer.
     /// @note Sometimes it's useful to pass VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT to specify that a command

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -21,7 +21,7 @@ public:
     /// because some wrappers require a queue family index which supports graphics bit, other require transfer bit.
     /// @param device The const reference to the device RAII wrapper class.
     /// @param queue_family_index The queue family index which is used by this command pool.
-    CommandPool(const Device &device, const std::uint32_t queue_family_index);
+    CommandPool(const Device &device, std::uint32_t queue_family_index);
 
     CommandPool(const CommandPool &) = delete;
     CommandPool(CommandPool &&) noexcept;
@@ -29,7 +29,7 @@ public:
     ~CommandPool();
 
     CommandPool &operator=(const CommandPool &) = delete;
-    CommandPool &operator=(CommandPool &&) = default;
+    CommandPool &operator=(CommandPool &&) = delete;
 
     [[nodiscard]] VkCommandPool get() const {
         return m_command_pool;

--- a/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
@@ -59,13 +59,14 @@ public:
         return m_mip_levels;
     }
 
-    [[nodiscard]] void *data() const {
-        return static_cast<void *>(m_texture_data);
+    [[nodiscard]] stbi_uc *data() const {
+        return m_texture_data;
     }
 
     [[nodiscard]] std::size_t data_size() const {
         // TODO: We will need to update this once we fully support mip levels.
-        return m_texture_width * m_texture_height * m_texture_channels;
+        return static_cast<std::size_t>(m_texture_width) * static_cast<std::size_t>(m_texture_height) *
+               static_cast<std::size_t>(m_texture_channels);
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -14,12 +14,12 @@ namespace inexor::vulkan_renderer::wrapper {
 class Device {
     VkDevice m_device;
     VkPhysicalDevice m_graphics_card;
-    VmaAllocator m_allocator;
-    std::string m_gpu_name;
+    VmaAllocator m_allocator{VK_NULL_HANDLE};
+    std::string m_gpu_name{""};
 
-    VkQueue m_graphics_queue;
-    VkQueue m_present_queue;
-    VkQueue m_transfer_queue;
+    VkQueue m_graphics_queue{nullptr};
+    VkQueue m_present_queue{nullptr};
+    VkQueue m_transfer_queue{nullptr};
     VkSurfaceKHR m_surface;
 
     std::uint32_t m_present_queue_family_index;
@@ -49,9 +49,9 @@ public:
     /// application's purpose, another graphics card will be selected automatically. See the details of the device
     /// selection mechanism!
     /// @todo Add overloaded constructors for VkPhysicalDeviceFeatures and requested device extensions in the future!
-    Device(const VkInstance instance, const VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
+    Device(VkInstance instance, VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
            bool prefer_distinct_transfer_queue,
-           const std::optional<std::uint32_t> preferred_physical_device_index = std::nullopt);
+           std::optional<std::uint32_t> preferred_physical_device_index = std::nullopt);
 
     Device(const Device &) = delete;
     Device(Device &&) noexcept;
@@ -59,13 +59,13 @@ public:
     ~Device();
 
     Device &operator=(const Device &) = delete;
-    Device &operator=(Device &&) = default;
+    Device &operator=(Device &&) = delete;
 
-    [[nodiscard]] const VkDevice device() const {
+    [[nodiscard]] VkDevice device() const {
         return m_device;
     }
 
-    [[nodiscard]] const VkPhysicalDevice physical_device() const {
+    [[nodiscard]] VkPhysicalDevice physical_device() const {
         return m_graphics_card;
     }
 
@@ -77,17 +77,17 @@ public:
         return m_gpu_name;
     }
 
-    [[nodiscard]] const VkQueue graphics_queue() const {
+    [[nodiscard]] VkQueue graphics_queue() const {
         return m_graphics_queue;
     }
 
-    [[nodiscard]] const VkQueue present_queue() const {
+    [[nodiscard]] VkQueue present_queue() const {
         return m_present_queue;
     }
 
     /// @note Transfer queues are the fastest way to copy data across the PCIe bus. They are heavily underutilized even
     /// in modern games. Transfer queues can be used asynchronously to graphics queuey.
-    [[nodiscard]] const VkQueue transfer_queue() const {
+    [[nodiscard]] VkQueue transfer_queue() const {
         return m_transfer_queue;
     }
 
@@ -119,28 +119,26 @@ public:
     /// @param name The name of the memory block which will be connected to this object.
     /// @param memory_size The size of the memory block in bytes.
     /// @param memory_address The memory address to read from.
-    void set_memory_block_attachment(void *object, VkDebugReportObjectTypeEXT object_type, const std::uint64_t name,
-                                     const std::size_t memory_size, const void *memory_block) const;
+    void set_memory_block_attachment(void *object, VkDebugReportObjectTypeEXT object_type, std::uint64_t name,
+                                     std::size_t memory_size, const void *memory_block) const;
 
     /// @param color [in] The rgba color of the rendering region.
     /// @param name [in] The name of the rendering region.
     /// @param command_buffer [in] The associated command buffer.
     /// The rendering region will be visible in external debuggers like RenderDoc.
     /// @brief Vulkan debug markers: Annotation of a rendering region.
-    void bind_debug_region(const VkCommandBuffer command_buffer, const std::string &name,
-                           const std::array<float, 4> color) const;
+    void bind_debug_region(VkCommandBuffer command_buffer, const std::string &name, std::array<float, 4> color) const;
 
     /// @brief Insert a debug markers into the current renderpass using vkCmdDebugMarkerInsertEXT. This debug markers
     /// can be seen in external debuggers like RenderDoc.
     /// @param command_buffer The command buffer which is associated to the debug marker.
     /// @param name The name of the debug marker.
     /// @param color An array of red, green, blue and alpha values for the debug region's color.
-    void insert_debug_marker(const VkCommandBuffer command_buffer, const std::string &name,
-                             const std::array<float, 4> color) const;
+    void insert_debug_marker(VkCommandBuffer command_buffer, const std::string &name, std::array<float, 4> color) const;
 
     /// @brief End the debug region of the current renderpass using vkCmdDebugMarkerEndEXT.
     /// @param command_buffer The command buffer which is associated to the debug marker.
-    void end_debug_region(const VkCommandBuffer command_buffer) const;
+    void end_debug_region(VkCommandBuffer command_buffer) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -13,7 +13,7 @@ class Device;
 /// @brief A RAII wrapper for VkFences.
 class Fence {
     const wrapper::Device &m_device;
-    const std::string m_name;
+    std::string m_name;
     VkFence m_fence;
 
 public:
@@ -22,7 +22,7 @@ public:
     /// @param name The internal debug marker name of the VkFence.
     /// @param in_signaled_state True if the VkFence will be constructored in signaled state, false otherwise.
     /// @warning Make sure to specify in_signaled_state correctly as needed, otherwise synchronization problems occur.
-    Fence(const wrapper::Device &device, const std::string &name, const bool in_signaled_state);
+    Fence(const wrapper::Device &device, const std::string &name, bool in_signaled_state);
 
     Fence(const Fence &) = delete;
     Fence(Fence &&) noexcept;
@@ -30,7 +30,7 @@ public:
     ~Fence();
 
     Fence &operator=(const Fence &) = delete;
-    Fence &operator=(Fence &&) = default;
+    Fence &operator=(Fence &&) = delete;
 
     [[nodiscard]] VkFence get() const {
         return m_fence;

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -14,7 +14,7 @@ class Swapchain;
 class Framebuffer {
     const wrapper::Device &m_device;
     VkFramebuffer m_framebuffer{VK_NULL_HANDLE};
-    const std::string m_name;
+    std::string m_name;
 
 public:
     /// @brief Default constructor.
@@ -32,7 +32,7 @@ public:
     ~Framebuffer();
 
     Framebuffer &operator=(const Framebuffer &) = delete;
-    Framebuffer &operator=(Framebuffer &&) = default;
+    Framebuffer &operator=(Framebuffer &&) = delete;
 
     [[nodiscard]] VkFramebuffer get() const {
         return m_framebuffer;

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -41,8 +41,7 @@ public:
     /// @param buffer_usage The buffer usage flags.
     /// @param memory_usage The VMA memory usage flags which specify the required memory allocation.
     GPUMemoryBuffer(const Device &device, const std::string &name, const VkDeviceSize &buffer_size, void *data,
-                    const std::size_t data_size, const VkBufferUsageFlags &buffer_usage,
-                    const VmaMemoryUsage &memory_usage);
+                    std::size_t data_size, const VkBufferUsageFlags &buffer_usage, const VmaMemoryUsage &memory_usage);
 
     GPUMemoryBuffer(const GPUMemoryBuffer &) = delete;
     GPUMemoryBuffer(GPUMemoryBuffer &&) noexcept;
@@ -50,25 +49,25 @@ public:
     virtual ~GPUMemoryBuffer();
 
     GPUMemoryBuffer &operator=(const GPUMemoryBuffer &) = delete;
-    GPUMemoryBuffer &operator=(GPUMemoryBuffer &&) = default;
+    GPUMemoryBuffer &operator=(GPUMemoryBuffer &&) = delete;
 
     [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 
-    [[nodiscard]] const VkBuffer buffer() const {
+    [[nodiscard]] VkBuffer buffer() const {
         return m_buffer;
     }
 
-    [[nodiscard]] const VmaAllocation allocation() const {
+    [[nodiscard]] VmaAllocation allocation() const {
         return m_allocation;
     }
 
-    [[nodiscard]] const VmaAllocationInfo allocation_info() const {
+    [[nodiscard]] VmaAllocationInfo allocation_info() const {
         return m_allocation_info;
     }
 
-    [[nodiscard]] const VmaAllocationCreateInfo allocation_create_info() const {
+    [[nodiscard]] VmaAllocationCreateInfo allocation_create_info() const {
         return m_allocation_ci;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
@@ -37,7 +37,7 @@ class GpuTexture {
     /// @brief Create the texture.
     /// @param texture_data A pointer to the texture data.
     /// @param texture_size The size of the texture.
-    void create_texture(void *texture_data, const std::size_t texture_size);
+    void create_texture(void *texture_data, std::size_t texture_size);
 
     /// @brief Transform the image layout.
     /// @param image The image.
@@ -64,8 +64,8 @@ public:
     /// @param texture_height The height of the texture.
     /// @param texture_size The size of the texture.
     /// @param name The internal debug marker name of the texture.
-    GpuTexture(const wrapper::Device &device, void *data, const std::size_t data_size, const int texture_width,
-               const int texture_height, const int texture_channels, const int mip_levels, std::string name);
+    GpuTexture(const wrapper::Device &device, void *data, std::size_t data_size, int texture_width, int texture_height,
+               int texture_channels, int mip_levels, std::string name);
 
     GpuTexture(const GpuTexture &) = delete;
     GpuTexture(GpuTexture &&) noexcept;
@@ -73,7 +73,7 @@ public:
     ~GpuTexture();
 
     GpuTexture &operator=(const GpuTexture &) = delete;
-    GpuTexture &operator=(GpuTexture &&) = default;
+    GpuTexture &operator=(GpuTexture &&) = delete;
 
     [[nodiscard]] std::string name() const {
         return m_name;

--- a/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/graphics_pipeline.hpp
@@ -27,11 +27,11 @@ public:
     /// @param window_width The width of the window.
     /// @param window_height The height of the window.
     /// @param name The internal debug marker name of the graphics pipeline.
-    GraphicsPipeline(const Device &device, const VkPipelineLayout pipeline_layout, const VkRenderPass render_pass,
+    GraphicsPipeline(const Device &device, VkPipelineLayout pipeline_layout, VkRenderPass render_pass,
                      const std::vector<VkPipelineShaderStageCreateInfo> &shader_stages,
                      const std::vector<VkVertexInputBindingDescription> &vertex_binding,
                      const std::vector<VkVertexInputAttributeDescription> &attribute_binding,
-                     const std::uint32_t window_width, const std::uint32_t window_height, const std::string &name);
+                     std::uint32_t window_width, std::uint32_t window_height, const std::string &name);
 
     GraphicsPipeline(const GraphicsPipeline &) = delete;
     GraphicsPipeline(GraphicsPipeline &&other) noexcept;
@@ -39,7 +39,7 @@ public:
     ~GraphicsPipeline();
 
     GraphicsPipeline &operator=(const GraphicsPipeline &) = delete;
-    GraphicsPipeline &operator=(GraphicsPipeline &&) noexcept = default;
+    GraphicsPipeline &operator=(GraphicsPipeline &&) = delete;
 
     [[nodiscard]] VkPipeline get() const {
         return graphics_pipeline;

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -28,9 +28,8 @@ public:
     /// @param sample_count The sample count.
     /// @param name The internal debug marker name of the VkImage.
     /// @param image_extent The width and height of the image.
-    Image(const Device &device, const VkFormat format, const VkImageUsageFlags image_usage,
-          const VkImageAspectFlags aspect_flags, const VkSampleCountFlagBits sample_count, const std::string &name,
-          const VkExtent2D image_extent);
+    Image(const Device &device, VkFormat format, VkImageUsageFlags image_usage, VkImageAspectFlags aspect_flags,
+          VkSampleCountFlagBits sample_count, const std::string &name, VkExtent2D image_extent);
 
     Image(const Image &) = delete;
     Image(Image &&) noexcept;
@@ -38,7 +37,7 @@ public:
     ~Image();
 
     Image &operator=(const Image &) = delete;
-    Image &operator=(Image &&) = default;
+    Image &operator=(Image &&) = delete;
 
     [[nodiscard]] VkFormat image_format() const {
         return m_format;

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -27,10 +27,9 @@ public:
     /// @param enable_renderdoc_layer True if renderdoc layer should be enabled, false otherwise.
     /// @param requested_instance_extensions The instance extensions which are requested.
     /// @param requested_instance_layers The instance layers which are requested.
-    Instance(const std::string &application_name, const std::string &engine_name,
-             const std::uint32_t application_version, const std::uint32_t engine_version,
-             const std::uint32_t vulkan_api_version, bool enable_validation_layers, bool enable_renderdoc_layer,
-             std::vector<std::string> requested_instance_extensions,
+    Instance(const std::string &application_name, const std::string &engine_name, std::uint32_t application_version,
+             std::uint32_t engine_version, std::uint32_t vulkan_api_version, bool enable_validation_layers,
+             bool enable_renderdoc_layer, std::vector<std::string> requested_instance_extensions,
              std::vector<std::string> requested_instance_layers);
 
     /// @brief Construct the Vulkan instance without the requested instance layers and instance extensions.
@@ -42,9 +41,9 @@ public:
     /// If the requested version of Vulkan API is not available, the creation of the instance will fail!
     /// @param enable_validation_layers True if validation layers should be enabled, false otherwise.
     /// @param enable_renderdoc_layer True if renderdoc layer should be enabled, false otherwise.
-    Instance(const std::string &application_name, const std::string &engine_name,
-             const std::uint32_t application_version, const std::uint32_t engine_version,
-             const std::uint32_t vulkan_api_version, bool enable_validation_layers, bool enable_renderdoc_layer);
+    Instance(const std::string &application_name, const std::string &engine_name, std::uint32_t application_version,
+             std::uint32_t engine_version, std::uint32_t vulkan_api_version, bool enable_validation_layers,
+             bool enable_renderdoc_layer);
 
     Instance(const Instance &) = delete;
     Instance(Instance &&) noexcept;
@@ -54,7 +53,7 @@ public:
     Instance &operator=(const Instance &) = delete;
     Instance &operator=(Instance &&) = default;
 
-    [[nodiscard]] const VkInstance instance() const {
+    [[nodiscard]] VkInstance instance() const {
         return m_instance;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -51,9 +51,9 @@ public:
     /// @param index_struct_size The size of the index structure, most likely std::uint32_t.
     /// @param index_count The number of indices in the index buffer.
     /// @param indices  A pointer to the index data.
-    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
-               const std::size_t number_of_vertices, void *vertices, const VkDeviceSize size_of_index_structure,
-               const std::size_t number_of_indices, void *indices);
+    MeshBuffer(const Device &device, const std::string &name, VkDeviceSize size_of_vertex_structure,
+               std::size_t number_of_vertices, void *vertices, VkDeviceSize size_of_index_structure,
+               std::size_t number_of_indices, void *indices);
 
     /// @brief Construct the mesh buffer and specify the size of the vertex buffer and index buffer.
     /// This constructor will does not yet copy any memory from the vertices or indices!
@@ -64,9 +64,8 @@ public:
     /// @note The size of the required memory will be calculated by vertex_struct_size * vertex_count.
     /// @param index_struct_size The size of the index structure, most likely std::uint32_t.
     /// @param index_count The number of indices in the index buffer.
-    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
-               const std::size_t number_of_vertices, const VkDeviceSize size_of_index_structure,
-               const std::size_t number_of_indices);
+    MeshBuffer(const Device &device, const std::string &name, VkDeviceSize size_of_vertex_structure,
+               std::size_t number_of_vertices, VkDeviceSize size_of_index_structure, std::size_t number_of_indices);
 
     /// @brief Construct the vertex buffer and copy the vertex data. The index buffer will not be used!
     /// @warning You should avoid using a vertex buffer without using an associated index buffer!
@@ -76,8 +75,8 @@ public:
     /// @param vertex_struct_size The size of the vertex structure.
     /// @param vertex_count The number of vertices in the vertex buffer.
     /// @param vertices A pointer to the vertex data.
-    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
-               const std::size_t number_of_vertices, void *vertices);
+    MeshBuffer(const Device &device, const std::string &name, VkDeviceSize size_of_vertex_structure,
+               std::size_t number_of_vertices, void *vertices);
 
     /// @brief Construct the vertex buffer and specify it's size. The index buffer will not be used!
     /// @warning You should avoid using a vertex buffer without using an associated index buffer!
@@ -86,14 +85,15 @@ public:
     /// @param name The internal debug marker name of the vertex buffer and index buffer.
     /// @param vertex_struct_size The size of the vertex structure.
     /// @param vertex_count The number of vertices in the vertex buffer.
-    MeshBuffer(const Device &device, const std::string &name, const VkDeviceSize size_of_vertex_structure,
-               const std::size_t number_of_vertices);
+    MeshBuffer(const Device &device, const std::string &name, VkDeviceSize size_of_vertex_structure,
+               std::size_t number_of_vertices);
 
     MeshBuffer(const MeshBuffer &) = delete;
     MeshBuffer(MeshBuffer &&buffer) noexcept;
+    ~MeshBuffer() = default;
 
     MeshBuffer &operator=(const MeshBuffer &) = delete;
-    MeshBuffer &operator=(MeshBuffer &&) = default;
+    MeshBuffer &operator=(MeshBuffer &&) = delete;
 
     [[nodiscard]] VkBuffer get_vertex_buffer() const {
         return m_vertex_buffer.buffer();

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -21,7 +21,7 @@ class OnceCommandBuffer {
     const Device &m_device;
     // We must store the VkQueue separately since we don't know from
     // the context of the use of this OnceCommandBuffer which queue to use!
-    const VkQueue m_queue;
+    VkQueue m_queue;
     CommandPool m_command_pool;
     std::unique_ptr<CommandBuffer> m_command_buffer;
 
@@ -36,7 +36,7 @@ public:
     /// @warn We can't determine the queue and queue family index to use automatically using the device wrapper
     /// reference because we might choose a queue which is unsuitable for the requested purpose!
     /// This is the reason we must specify the queue and queue family index in the constructor.
-    OnceCommandBuffer(const Device &device, const VkQueue queue, const std::uint32_t queue_family_index);
+    OnceCommandBuffer(const Device &device, VkQueue queue, std::uint32_t queue_family_index);
 
     OnceCommandBuffer(const OnceCommandBuffer &) = delete;
     OnceCommandBuffer(OnceCommandBuffer &&) noexcept;
@@ -44,7 +44,7 @@ public:
     ~OnceCommandBuffer();
 
     OnceCommandBuffer &operator=(const OnceCommandBuffer &) = delete;
-    OnceCommandBuffer &operator=(OnceCommandBuffer &&) = default;
+    OnceCommandBuffer &operator=(OnceCommandBuffer &&) = delete;
 
     /// @brief Create the command buffer.
     /// @note We are not merging this into the constructor because we need to be able to call this function separately.

--- a/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/renderpass.hpp
@@ -24,7 +24,7 @@ public:
     /// @param subpass_description The subpass description.
     /// @param name The internal debug marker name of the VkRenderPass.
     RenderPass(const Device &device, const std::vector<VkAttachmentDescription> &attachments,
-               const std::vector<VkSubpassDependency> &dependencies, const VkSubpassDescription subpass_description,
+               const std::vector<VkSubpassDependency> &dependencies, VkSubpassDescription subpass_description,
                const std::string &name);
 
     RenderPass(const RenderPass &) = delete;
@@ -33,7 +33,7 @@ public:
     ~RenderPass();
 
     RenderPass &operator=(const RenderPass &) = delete;
-    RenderPass &operator=(RenderPass &&) noexcept = default;
+    RenderPass &operator=(RenderPass &&) = delete;
 
     [[nodiscard]] VkRenderPass get() const {
         return renderpass;

--- a/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/resource_descriptor.hpp
@@ -11,7 +11,7 @@ class Device;
 
 /// @brief RAII wrapper class for resource descriptors.
 class ResourceDescriptor {
-    const std::string m_name;
+    std::string m_name;
     const Device &m_device;
     VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
     VkDescriptorSetLayout m_descriptor_set_layout{VK_NULL_HANDLE};
@@ -38,7 +38,7 @@ public:
     ~ResourceDescriptor();
 
     ResourceDescriptor &operator=(const ResourceDescriptor &) = delete;
-    ResourceDescriptor &operator=(ResourceDescriptor &&) noexcept = default;
+    ResourceDescriptor &operator=(ResourceDescriptor &&) = delete;
 
     [[nodiscard]] const auto &descriptor_sets() const {
         return m_descriptor_sets;

--- a/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/semaphore.hpp
@@ -12,7 +12,7 @@ class Device;
 class Semaphore {
     const Device &m_device;
     VkSemaphore m_semaphore;
-    const std::string m_name;
+    std::string m_name;
 
 public:
     /// @brief Default constructor.
@@ -24,7 +24,7 @@ public:
     ~Semaphore();
 
     Semaphore &operator=(const Semaphore &) = delete;
-    Semaphore &operator=(Semaphore &&) = default;
+    Semaphore &operator=(Semaphore &&) = delete;
 
     [[nodiscard]] VkSemaphore get() const {
         return m_semaphore;

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -12,8 +12,8 @@ class Device;
 /// @brief RAII wrapper class for VkShaderModules.
 class Shader {
     const Device &m_device;
-    const std::string m_name;
-    const std::string m_entry_point;
+    std::string m_name;
+    std::string m_entry_point;
     VkShaderStageFlagBits m_type;
     VkShaderModule m_shader_module;
 
@@ -43,7 +43,7 @@ public:
     ~Shader();
 
     Shader &operator=(const Shader &) = delete;
-    Shader &operator=(Shader &&) = default;
+    Shader &operator=(Shader &&) = delete;
 
     [[nodiscard]] const std::string &name() const {
         return m_name;

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -32,7 +32,7 @@ public:
     ~StagingBuffer() = default;
 
     StagingBuffer &operator=(const StagingBuffer &) = delete;
-    StagingBuffer &operator=(StagingBuffer &&) = default;
+    StagingBuffer &operator=(StagingBuffer &&) = delete;
 
     /// @brief Call vkCmdCopyBuffer inside of the once command buffer.
     /// @param tarbuffer The memory buffer to copy.

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -22,7 +22,7 @@ class Swapchain {
     std::vector<VkImage> m_swapchain_images;
     std::vector<VkImageView> m_swapchain_image_views;
     std::uint32_t m_swapchain_image_count;
-    const std::string m_name;
+    std::string m_name;
     bool m_vsync_enabled;
 
     /// @brief Set up the swapchain.
@@ -30,7 +30,7 @@ class Swapchain {
     /// @note Swapchain recreation can be speeded up drastically when passing the old swapchian.
     /// @param window_width The width of the window.
     /// @param window_height The height of the window.
-    void setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width, std::uint32_t window_height);
+    void setup_swapchain(VkSwapchainKHR old_swapchain, std::uint32_t window_width, std::uint32_t window_height);
 
 public:
     /// @brief Default constructor.
@@ -40,8 +40,8 @@ public:
     /// @param window_height The height of the window.
     /// @param enable_vsync True if vertical synchronization is requested, false otherwise.
     /// @param name The internal debug marker name of the VkSwapchainKHR.
-    Swapchain(const Device &device, const VkSurfaceKHR surface, std::uint32_t window_width, std::uint32_t window_height,
-              const bool enable_vsync, const std::string &name);
+    Swapchain(const Device &device, VkSurfaceKHR surface, std::uint32_t window_width, std::uint32_t window_height,
+              bool enable_vsync, const std::string &name);
 
     Swapchain(const Swapchain &) = delete;
     Swapchain(Swapchain &&) noexcept;
@@ -49,7 +49,7 @@ public:
     ~Swapchain();
 
     Swapchain &operator=(const Swapchain &) = delete;
-    Swapchain &operator=(Swapchain &&) = default;
+    Swapchain &operator=(Swapchain &&) = delete;
 
     /// @brief Call vkAcquireNextImageKHR.
     /// @param semaphore A semaphore to signal once image acquisition has completed.

--- a/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
@@ -27,15 +27,15 @@ public:
     UniformBuffer(const UniformBuffer &) = delete;
     UniformBuffer(UniformBuffer &&) noexcept;
 
-    ~UniformBuffer() = default;
+    ~UniformBuffer() override = default;
 
     UniformBuffer &operator=(const UniformBuffer &) = delete;
-    UniformBuffer &operator=(UniformBuffer &&) = default;
+    UniformBuffer &operator=(UniformBuffer &&) = delete;
 
     /// @brief Update uniform buffer data.
     /// @param data A pointer to the uniform buffer data.
     /// @param size The size of the uniform buffer memory to copy.
-    void update(void *data, const std::size_t size);
+    void update(void *data, std::size_t size);
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -3,6 +3,7 @@
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.h>
 
+#include <array>
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
@@ -10,8 +11,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief RAII wrapper class for GLFW windows.
 class Window {
     GLFWwindow *m_window;
-    std::uint32_t m_width;
-    std::uint32_t m_height;
+    std::uint32_t m_width{0};
+    std::uint32_t m_height{0};
 
 public:
     /// @brief Default constructor.
@@ -20,8 +21,7 @@ public:
     /// @param height The height of the window.
     /// @param visible True if the window is visible after creation, false otherwise.
     /// @param resizable True if the window should be resizable, false otherwise.
-    Window(const std::string &title, const std::uint32_t width, const std::uint32_t height, const bool visible,
-           const bool resizable);
+    Window(const std::string &title, std::uint32_t width, std::uint32_t height, bool visible, bool resizable);
 
     Window(const Window &) = delete;
     Window(Window &&) noexcept;
@@ -53,10 +53,8 @@ public:
     /// @brief Call glfwHideWindow.
     void hide();
 
-    /// @brief Set the cursor position.
-    /// @param pos_x The x cursor position.
-    /// @param pos_y The y cursor position.
-    void cursor_pos(double &pos_x, double &pos_y);
+    /// @brief Returns the cursor position.
+    std::array<double, 2> cursor_pos();
 
     /// @brief Check if a specifiy button is pressed.
     /// @param button The button to check.

--- a/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
@@ -17,7 +17,7 @@ public:
     /// @brief Default constructor.
     /// @param instance The Vulkan instance which will be associated with this surface.
     /// @param window The window which will be associated with this surface.
-    WindowSurface(const VkInstance instance, GLFWwindow *window);
+    WindowSurface(VkInstance instance, GLFWwindow *window);
 
     WindowSurface(const WindowSurface &) = delete;
     WindowSurface(WindowSurface &&) noexcept;
@@ -29,10 +29,6 @@ public:
 
     [[nodiscard]] VkSurfaceKHR get() const {
         return m_surface;
-    }
-
-    const VkSurfaceKHR *operator&() const {
-        return &m_surface;
     }
 };
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -45,7 +45,7 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     auto renderer_configuration = toml::parse(file_name);
 
     // Search for the title of the configuration file and print it to debug output.
-    auto configuration_title = toml::find<std::string>(renderer_configuration, "title");
+    const auto &configuration_title = toml::find<std::string>(renderer_configuration, "title");
     spdlog::debug("Title: '{}'", configuration_title);
 
     m_window_width = toml::find<int>(renderer_configuration, "application", "window", "width");
@@ -58,9 +58,9 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     spdlog::debug("Application name: '{}'", m_application_name);
     spdlog::debug("Engine name: '{}'", m_engine_name);
 
-    int application_version_major = toml::find<int>(renderer_configuration, "application", "version", "major");
-    int application_version_minor = toml::find<int>(renderer_configuration, "application", "version", "minor");
-    int application_version_patch = toml::find<int>(renderer_configuration, "application", "version", "patch");
+    const int application_version_major = toml::find<int>(renderer_configuration, "application", "version", "major");
+    const int application_version_minor = toml::find<int>(renderer_configuration, "application", "version", "minor");
+    const int application_version_patch = toml::find<int>(renderer_configuration, "application", "version", "patch");
     spdlog::debug("Application version {}.{}.{}", application_version_major, application_version_minor,
                   application_version_patch);
 
@@ -68,9 +68,12 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     m_application_version =
         VK_MAKE_VERSION(application_version_major, application_version_minor, application_version_patch);
 
-    int engine_version_major = toml::find<int>(renderer_configuration, "application", "engine", "version", "major");
-    int engine_version_minor = toml::find<int>(renderer_configuration, "application", "engine", "version", "minor");
-    int engine_version_patch = toml::find<int>(renderer_configuration, "application", "engine", "version", "patch");
+    const int engine_version_major =
+        toml::find<int>(renderer_configuration, "application", "engine", "version", "major");
+    const int engine_version_minor =
+        toml::find<int>(renderer_configuration, "application", "engine", "version", "minor");
+    const int engine_version_patch =
+        toml::find<int>(renderer_configuration, "application", "engine", "version", "patch");
     spdlog::debug("Engine version {}.{}.{}", engine_version_major, engine_version_minor, engine_version_patch);
 
     // Generate an std::uint32_t value from the major, minor and patch version info.
@@ -118,7 +121,7 @@ void Application::load_textures() {
     assert(m_device->allocator());
 
     // TODO: Refactor! use key from TOML file as name!
-    std::size_t texture_number = 1;
+    const std::size_t texture_number = 1;
 
     // Insert the new texture into the list of textures.
     std::string texture_name = "unnamed texture";
@@ -138,7 +141,7 @@ void Application::load_shaders() {
         spdlog::error("No vertex shaders to load!");
     }
 
-    auto total_number_of_shaders = m_vertex_shader_files.size() + m_fragment_shader_files.size();
+    const auto total_number_of_shaders = m_vertex_shader_files.size() + m_fragment_shader_files.size();
 
     // Loop through the list of vertex shaders and initialise all of them.
     for (const auto &vertex_shader_file : m_vertex_shader_files) {
@@ -238,7 +241,7 @@ Application::Application(int argc, char **argv) {
 
     // If the user specified command line argument "--no-validation", the Khronos validation instance layer will be
     // disabled. For debug builds, this is not advisable! Always use validation layers during development!
-    auto disable_validation = cla_parser.arg<bool>("--no-validation");
+    const auto disable_validation = cla_parser.arg<bool>("--no-validation");
     if (disable_validation.value_or(false)) {
         spdlog::warn("--no-validation specified, disabling validation layers.");
         enable_khronos_validation_instance_layer = false;
@@ -310,7 +313,7 @@ Application::Application(int argc, char **argv) {
 
     // If the user specified command line argument "--nostats", no information will be
     // displayed about all the graphics cards which are available on the system.
-    auto hide_gpu_stats = cla_parser.arg<bool>("--no-stats");
+    const auto hide_gpu_stats = cla_parser.arg<bool>("--no-stats");
     if (hide_gpu_stats.value_or(false)) {
         spdlog::debug("--no-stats specified, no extended information about graphics cards will be shown.");
         display_graphics_card_info = false;
@@ -318,7 +321,7 @@ Application::Application(int argc, char **argv) {
 
     // If the user specified command line argument "--vsync", the presentation engine waits
     // for the next vertical blanking period to update the current image.
-    auto enable_vertical_synchronisation = cla_parser.arg<bool>("--vsync");
+    const auto enable_vertical_synchronisation = cla_parser.arg<bool>("--vsync");
     if (enable_vertical_synchronisation.value_or(false)) {
         spdlog::debug("V-sync enabled!");
         m_vsync_enabled = true;
@@ -342,7 +345,7 @@ Application::Application(int argc, char **argv) {
     bool use_distinct_data_transfer_queue = true;
 
     // Ignore distinct data transfer queue
-    auto forbid_distinct_data_transfer_queue = cla_parser.arg<bool>("--no-separate-data-queue");
+    const auto forbid_distinct_data_transfer_queue = cla_parser.arg<bool>("--no-separate-data-queue");
     if (forbid_distinct_data_transfer_queue.value_or(false)) {
         spdlog::warn("Command line argument --no-separate-data-queue specified.");
         spdlog::warn("This will force the application to avoid using a distinct queue for data transfer to GPU.");
@@ -359,7 +362,7 @@ Application::Application(int argc, char **argv) {
 
     // Check if Vulkan debug markers should be disabled.
     // Those are only available if RenderDoc instance layer is enabled!
-    auto no_vulkan_debug_markers = cla_parser.arg<bool>("--no-vk-debug-markers");
+    const auto no_vulkan_debug_markers = cla_parser.arg<bool>("--no-vk-debug-markers");
     if (no_vulkan_debug_markers.value_or(false)) {
         spdlog::warn("--no-vk-debug-markers specified, disabling useful debug markers!");
         enable_debug_marker_device_extension = false;
@@ -424,15 +427,15 @@ Application::Application(int argc, char **argv) {
 }
 
 void Application::update_uniform_buffers() {
-    float time = m_time_step.time_step_since_initialisation();
+    const float time = m_time_step.time_step_since_initialisation();
 
     UniformBufferObject ubo{};
 
     // Rotate the model as a function of time.
     ubo.model = glm::rotate(glm::mat4(1.0f), /*time */ glm::radians(90.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 
-    ubo.view = m_game_camera.m_matrices.view;
-    ubo.proj = m_game_camera.m_matrices.perspective;
+    ubo.view = m_game_camera.get_view();
+    ubo.proj = m_game_camera.get_perspective();
     ubo.proj[1][1] *= -1;
 
     // TODO: Don't use vector of uniform buffers.
@@ -440,25 +443,22 @@ void Application::update_uniform_buffers() {
 }
 
 void Application::update_mouse_input() {
-    double current_cursor_x{0.0};
-    double current_cursor_y{0.0};
+    const auto cursor_position = m_window->cursor_pos();
 
-    m_window->cursor_pos(current_cursor_x, current_cursor_y);
+    const double cursor_delta_x = cursor_position[0] - m_cursor_x;
+    const double cursor_delta_y = cursor_position[1] - m_cursor_y;
 
-    double cursor_delta_x = current_cursor_x - m_cursor_x;
-    double cursor_delta_y = current_cursor_y - m_cursor_y;
-
-    int state = m_window->is_button_pressed(GLFW_MOUSE_BUTTON_LEFT);
+    const int state = m_window->is_button_pressed(GLFW_MOUSE_BUTTON_LEFT);
 
     if (state == GLFW_PRESS) {
-        m_game_camera.rotate(glm::vec3(cursor_delta_y * m_game_camera.m_rotation_speed,
-                                       -cursor_delta_x * m_game_camera.m_rotation_speed, 0.0f));
+        m_game_camera.rotate(glm::vec3(cursor_delta_y * m_game_camera.get_rotation_speed(),
+                                       -cursor_delta_x * m_game_camera.get_rotation_speed(), 0.0f));
     }
 
     m_window->is_button_pressed(GLFW_MOUSE_BUTTON_RIGHT);
 
-    m_cursor_x = current_cursor_x;
-    m_cursor_y = current_cursor_y;
+    m_cursor_x = cursor_position[0];
+    m_cursor_y = cursor_position[1];
 }
 
 void Application::update_imgui_overlay() {

--- a/src/vulkan-renderer/bezier_curve.cpp
+++ b/src/vulkan-renderer/bezier_curve.cpp
@@ -63,13 +63,13 @@ void BezierCurve::add_input_point(const glm::vec3 &position, const float weight)
 BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precision) {
     BezierOutputPoint temp_output;
 
-    std::uint32_t n = static_cast<std::uint32_t>(m_input_points.size() - 1);
+    const std::uint32_t n = static_cast<std::uint32_t>(m_input_points.size() - 1);
 
     // Calculate the coordinates of the output points of the bezier curve.
     for (std::size_t i = 0; i < m_input_points.size(); i++) {
         auto current_point = m_input_points[i];
 
-        std::uint32_t index = static_cast<std::uint32_t>(i);
+        const std::uint32_t index = static_cast<std::uint32_t>(i);
 
         // Compute bezier curve coordinates using bernstein polynomials.
         temp_output.pos.x += bernstein_polynomial(n, index, curve_precision, current_point.pos.x);
@@ -88,7 +88,7 @@ BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precis
         auto current_point = m_input_points[i];
         auto next_point = m_input_points[i + 1];
 
-        std::uint32_t index = static_cast<std::uint32_t>(i);
+        const std::uint32_t index = static_cast<std::uint32_t>(i);
 
         // Compute bezier curve point's first derivative.
         temp_output.tangent.x += bernstein_polynomial(n - 1, index, curve_precision, current_point.pos.x);
@@ -102,7 +102,7 @@ BezierOutputPoint BezierCurve::calculate_point_on_curve(const float curve_precis
     // Calculate a relative normal vector.
     // Please note that there is an infinite amount of normal vectors from vector a to b.
 
-    float length = glm::length(temp_output.tangent);
+    const float length = glm::length(temp_output.tangent);
     temp_output.normal = glm::vec3(-temp_output.tangent.y / length, temp_output.tangent.x / length, 0);
 
     // Do not normalize tangent vectors before you have copied the normal vector! They will be incorrect!
@@ -125,10 +125,10 @@ void BezierCurve::calculate_bezier_curve(const float curve_precision) {
         m_curve_generated = false;
     }
 
-    float curve_precision_interval = 1.0f / curve_precision;
+    const float curve_precision_interval = 1.0f / curve_precision;
 
     for (float position_on_curve = 0.0f; position_on_curve <= 1.0f; position_on_curve += curve_precision_interval) {
-        BezierOutputPoint temp_output = calculate_point_on_curve(position_on_curve);
+        const BezierOutputPoint temp_output = calculate_point_on_curve(position_on_curve);
         m_output_points.push_back(temp_output);
     }
 

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -4,6 +4,15 @@
 
 namespace inexor::vulkan_renderer {
 
+Camera::Camera(const CameraType type, const glm::vec3 position, const glm::vec3 rotation, const float movement_speed,
+               const float rotation_speed, const float fov, const float z_near, const float z_far,
+               const std::uint32_t window_width, const std::uint32_t window_height)
+    : m_type(type), m_position(position), m_rotation(rotation), m_movement_speed(movement_speed),
+      m_rotation_speed(rotation_speed), m_fov(fov), m_z_near(z_near), m_z_far(z_far) {
+    set_perspective(m_fov, static_cast<float>(window_width) / static_cast<float>(window_height), m_z_near, m_z_far);
+    update_view_matrix();
+}
+
 void Camera::update_view_matrix() {
     glm::mat4 rot_m = glm::mat4(1.0f);
     glm::mat4 trans_m;
@@ -75,7 +84,7 @@ void Camera::update(float delta_time) {
         cam_front.z = cos(glm::radians(m_rotation.x)) * cos(glm::radians(m_rotation.y));
         cam_front = glm::normalize(cam_front);
 
-        float move_speed = delta_time * m_movement_speed;
+        const float move_speed = delta_time * m_movement_speed;
 
         if (m_keys.up) {
             m_position += cam_front * move_speed;
@@ -110,17 +119,17 @@ bool Camera::update_pad(glm::vec2 axis_left, glm::vec2 axis_right, float delta_t
         cam_front.z = cos(glm::radians(m_rotation.x)) * cos(glm::radians(m_rotation.y));
         cam_front = glm::normalize(cam_front);
 
-        float move_speed = delta_time * m_movement_speed * 2.0f;
-        float rot_speed = delta_time * m_rotation_speed * 50.0f;
+        const float move_speed = delta_time * m_movement_speed * 2.0f;
+        const float rot_speed = delta_time * m_rotation_speed * 50.0f;
 
         // Move
         if (fabsf(axis_left.y) > dead_zone) {
-            float pos = (fabsf(axis_left.y) - dead_zone) / range;
+            const float pos = (fabsf(axis_left.y) - dead_zone) / range;
             m_position -= cam_front * pos * ((axis_left.y < 0.0f) ? -1.0f : 1.0f) * move_speed;
             ret_val = true;
         }
         if (fabsf(axis_left.x) > dead_zone) {
-            float pos = (fabsf(axis_left.x) - dead_zone) / range;
+            const float pos = (fabsf(axis_left.x) - dead_zone) / range;
             m_position += glm::normalize(glm::cross(cam_front, glm::vec3(0.0f, 1.0f, 0.0f))) * pos *
                           ((axis_left.x < 0.0f) ? -1.0f : 1.0f) * move_speed;
             ret_val = true;
@@ -128,12 +137,12 @@ bool Camera::update_pad(glm::vec2 axis_left, glm::vec2 axis_right, float delta_t
 
         // Rotate
         if (fabsf(axis_right.x) > dead_zone) {
-            float pos = (fabsf(axis_right.x) - dead_zone) / range;
+            const float pos = (fabsf(axis_right.x) - dead_zone) / range;
             m_rotation.y += pos * ((axis_right.x < 0.0f) ? -1.0f : 1.0f) * rot_speed;
             ret_val = true;
         }
         if (fabsf(axis_right.y) > dead_zone) {
-            float pos = (fabsf(axis_right.y) - dead_zone) / range;
+            const float pos = (fabsf(axis_right.y) - dead_zone) / range;
             m_rotation.x -= pos * ((axis_right.y < 0.0f) ? -1.0f : 1.0f) * rot_speed;
             ret_val = true;
         }

--- a/src/vulkan-renderer/fps_counter.cpp
+++ b/src/vulkan-renderer/fps_counter.cpp
@@ -3,7 +3,7 @@
 namespace inexor::vulkan_renderer {
 
 std::optional<std::uint32_t> FPSCounter::update() {
-    auto current_time = std::chrono::high_resolution_clock::now();
+    const auto current_time = std::chrono::high_resolution_clock::now();
 
     auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
 

--- a/src/vulkan-renderer/frame_graph.cpp
+++ b/src/vulkan-renderer/frame_graph.cpp
@@ -267,7 +267,7 @@ void FrameGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGra
         }
 
         // We use std::unordered_map::at() here to ensure that a binding value exists for buffer_resource.
-        std::uint32_t binding = stage->m_buffer_bindings.at(buffer_resource);
+        const std::uint32_t binding = stage->m_buffer_bindings.at(buffer_resource);
         for (auto attribute_binding : buffer_resource->m_vertex_attributes) {
             attribute_binding.binding = binding;
             attribute_bindings.push_back(attribute_binding);
@@ -406,7 +406,7 @@ void FrameGraph::compile(const RenderResource &target) {
             assert(buffer_resource->m_usage != BufferUsage::INVALID);
             auto *phys = create<PhysicalBuffer>(buffer_resource, m_device.allocator(), m_device.device());
 
-            bool is_uploading_data = buffer_resource->m_data != nullptr;
+            const bool is_uploading_data = buffer_resource->m_data != nullptr;
             alloc_ci.flags |= is_uploading_data ? VMA_ALLOCATION_CREATE_MAPPED_BIT : 0U;
             alloc_ci.usage = is_uploading_data ? VMA_MEMORY_USAGE_CPU_TO_GPU : VMA_MEMORY_USAGE_GPU_ONLY;
 

--- a/src/vulkan-renderer/gpu_info.cpp
+++ b/src/vulkan-renderer/gpu_info.cpp
@@ -24,9 +24,9 @@ void VulkanGraphicsCardInfoViewer::print_driver_vulkan_version() {
     }
 
     // Extract major, minor and patch version of the Vulkan API available.
-    std::uint16_t api_major_version = VK_VERSION_MAJOR(api_version);
-    std::uint16_t api_minor_version = VK_VERSION_MINOR(api_version);
-    std::uint16_t api_version_patch = VK_VERSION_PATCH(api_version);
+    const std::uint16_t api_major_version = VK_VERSION_MAJOR(api_version);
+    const std::uint16_t api_minor_version = VK_VERSION_MINOR(api_version);
+    const std::uint16_t api_version_patch = VK_VERSION_PATCH(api_version);
 
     spdlog::debug(
         "------------------------------------------------------------------------------------------------------------");
@@ -83,9 +83,9 @@ void VulkanGraphicsCardInfoViewer::print_physical_device_queue_families(const Vk
                 spdlog::debug("VK_QUEUE_PROTECTED_BIT");
             }
 
-            std::uint32_t width = queue_family_properties[i].minImageTransferGranularity.width;
-            std::uint32_t height = queue_family_properties[i].minImageTransferGranularity.width;
-            std::uint32_t depth = queue_family_properties[i].minImageTransferGranularity.depth;
+            const std::uint32_t width = queue_family_properties[i].minImageTransferGranularity.width;
+            const std::uint32_t height = queue_family_properties[i].minImageTransferGranularity.width;
+            const std::uint32_t depth = queue_family_properties[i].minImageTransferGranularity.depth;
 
             spdlog::debug("Min Image Timestamp Granularity: {}, {}, {}", width, height, depth);
         }
@@ -118,10 +118,10 @@ void VulkanGraphicsCardInfoViewer::print_instance_layers() {
         }
 
         // Loop through all available instance layers and print information about them.
-        for (auto instance_layer : instance_layers) {
-            std::uint32_t spec_major = VK_VERSION_MAJOR(instance_layer.specVersion);
-            std::uint32_t spec_minor = VK_VERSION_MINOR(instance_layer.specVersion);
-            std::uint32_t spec_patch = VK_VERSION_PATCH(instance_layer.specVersion);
+        for (const auto &instance_layer : instance_layers) {
+            const std::uint32_t spec_major = VK_VERSION_MAJOR(instance_layer.specVersion);
+            const std::uint32_t spec_minor = VK_VERSION_MINOR(instance_layer.specVersion);
+            const std::uint32_t spec_patch = VK_VERSION_PATCH(instance_layer.specVersion);
 
             spdlog::debug("Name: {}", instance_layer.layerName);
             spdlog::debug("Spec Version: {}", spec_major, spec_minor, spec_patch);
@@ -158,10 +158,10 @@ void VulkanGraphicsCardInfoViewer::print_instance_extensions() {
         }
 
         // Loop through all available instance extensions and print information about them.
-        for (auto extension : extensions) {
-            std::uint32_t spec_major = VK_VERSION_MAJOR(extension.specVersion);
-            std::uint32_t spec_minor = VK_VERSION_MINOR(extension.specVersion);
-            std::uint32_t spec_patch = VK_VERSION_PATCH(extension.specVersion);
+        for (const auto &extension : extensions) {
+            const std::uint32_t spec_major = VK_VERSION_MAJOR(extension.specVersion);
+            const std::uint32_t spec_minor = VK_VERSION_MINOR(extension.specVersion);
+            const std::uint32_t spec_patch = VK_VERSION_PATCH(extension.specVersion);
 
             spdlog::debug("Spec version: {}.{}.{}\t Name: {}", spec_major, spec_minor, spec_patch,
                           extension.extensionName);
@@ -198,10 +198,10 @@ void VulkanGraphicsCardInfoViewer::print_device_layers(const VkPhysicalDevice &g
         }
 
         // Loop through all available device layers and print information about them.
-        for (auto device_layer : device_layers) {
-            std::uint32_t spec_major = VK_VERSION_MAJOR(device_layer.specVersion);
-            std::uint32_t spec_minor = VK_VERSION_MINOR(device_layer.specVersion);
-            std::uint32_t spec_patch = VK_VERSION_PATCH(device_layer.specVersion);
+        for (const auto &device_layer : device_layers) {
+            const std::uint32_t spec_major = VK_VERSION_MAJOR(device_layer.specVersion);
+            const std::uint32_t spec_minor = VK_VERSION_MINOR(device_layer.specVersion);
+            const std::uint32_t spec_patch = VK_VERSION_PATCH(device_layer.specVersion);
 
             spdlog::debug("Name: {}", device_layer.layerName);
             spdlog::debug("Spec Version: {}", spec_major, spec_minor, spec_patch);
@@ -241,10 +241,10 @@ void VulkanGraphicsCardInfoViewer::print_device_extensions(const VkPhysicalDevic
         }
 
         // Loop through all available device extensions and print information about them.
-        for (auto device_extension : device_extensions) {
-            std::uint32_t spec_major = VK_VERSION_MAJOR(device_extension.specVersion);
-            std::uint32_t spec_minor = VK_VERSION_MINOR(device_extension.specVersion);
-            std::uint32_t spec_patch = VK_VERSION_PATCH(device_extension.specVersion);
+        for (const auto &device_extension : device_extensions) {
+            const std::uint32_t spec_major = VK_VERSION_MAJOR(device_extension.specVersion);
+            const std::uint32_t spec_minor = VK_VERSION_MINOR(device_extension.specVersion);
+            const std::uint32_t spec_patch = VK_VERSION_PATCH(device_extension.specVersion);
 
             spdlog::debug("Spec version: {}.{}.{}\t Name: {}", spec_major, spec_minor, spec_patch,
                           device_extension.extensionName);
@@ -388,19 +388,19 @@ void VulkanGraphicsCardInfoViewer::print_graphics_card_info(const VkPhysicalDevi
     spdlog::debug("Graphics card: {}", graphics_card_properties.deviceName);
 
     // Get the major, minor and patch version of the Vulkan API version.
-    std::uint32_t vulkan_api_version = graphics_card_properties.apiVersion;
-    std::uint32_t vulkan_version_major = VK_VERSION_MAJOR(vulkan_api_version);
-    std::uint32_t vulkan_version_minor = VK_VERSION_MINOR(vulkan_api_version);
-    std::uint32_t vulkan_version_patch = VK_VERSION_MAJOR(vulkan_api_version);
+    const std::uint32_t vulkan_api_version = graphics_card_properties.apiVersion;
+    const std::uint32_t vulkan_version_major = VK_VERSION_MAJOR(vulkan_api_version);
+    const std::uint32_t vulkan_version_minor = VK_VERSION_MINOR(vulkan_api_version);
+    const std::uint32_t vulkan_version_patch = VK_VERSION_MAJOR(vulkan_api_version);
 
     // The Vulkan version which is supported by the graphics card.
     spdlog::debug("Vulkan API supported version: {}.{}.{}", vulkan_version_major, vulkan_version_minor,
                   vulkan_version_patch);
 
     // Get the major, minor and patch version of the driver version.
-    std::uint32_t driver_version_major = VK_VERSION_MAJOR(graphics_card_properties.driverVersion);
-    std::uint32_t driver_version_minor = VK_VERSION_MINOR(graphics_card_properties.driverVersion);
-    std::uint32_t driver_version_patch = VK_VERSION_PATCH(graphics_card_properties.driverVersion);
+    const std::uint32_t driver_version_major = VK_VERSION_MAJOR(graphics_card_properties.driverVersion);
+    const std::uint32_t driver_version_minor = VK_VERSION_MINOR(graphics_card_properties.driverVersion);
+    const std::uint32_t driver_version_patch = VK_VERSION_PATCH(graphics_card_properties.driverVersion);
 
     // The driver version.
     // Always keep your graphics drivers up to date!
@@ -443,7 +443,7 @@ void VulkanGraphicsCardInfoViewer::print_graphics_card_memory_properties(const V
     for (std::size_t i = 0; i < graphics_card_memory_properties.memoryTypeCount; i++) {
         spdlog::debug("[{}] Heap index: {}", i, graphics_card_memory_properties.memoryTypes[i].heapIndex);
 
-        auto &property_flag = graphics_card_memory_properties.memoryTypes[i].propertyFlags;
+        const auto &property_flag = graphics_card_memory_properties.memoryTypes[i].propertyFlags;
 
         if (property_flag & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
             spdlog::debug("VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT");
@@ -476,7 +476,7 @@ void VulkanGraphicsCardInfoViewer::print_graphics_card_memory_properties(const V
         spdlog::debug("Heap [{}], memory size: {}", i,
                       graphics_card_memory_properties.memoryHeaps[i].size / (1000 * 1000));
 
-        auto &property_flag = graphics_card_memory_properties.memoryHeaps[i].flags;
+        const auto &property_flag = graphics_card_memory_properties.memoryHeaps[i].flags;
 
         if (property_flag & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
             spdlog::debug("VK_MEMORY_HEAP_DEVICE_LOCAL_BIT ");

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -106,7 +106,9 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
         constexpr int FONT_TEXTURE_CHANNELS{4};
         constexpr int FONT_MIP_LEVELS{1};
 
-        VkDeviceSize upload_size = font_texture_width * font_texture_height * FONT_TEXTURE_CHANNELS;
+        VkDeviceSize upload_size = static_cast<VkDeviceSize>(font_texture_width) *
+                                   static_cast<VkDeviceSize>(font_texture_height) *
+                                   static_cast<VkDeviceSize>(FONT_TEXTURE_CHANNELS);
 
         m_imgui_texture = std::make_unique<wrapper::GpuTexture>(
             m_device, font_texture_data, upload_size, font_texture_width, font_texture_height, FONT_TEXTURE_CHANNELS,
@@ -238,8 +240,8 @@ void ImGUIOverlay::update() {
         return;
     }
 
-    VkDeviceSize vertex_buffer_size = imgui_draw_data->TotalVtxCount * sizeof(ImDrawVert);
-    VkDeviceSize index_buffer_size = imgui_draw_data->TotalIdxCount * sizeof(ImDrawIdx);
+    const VkDeviceSize vertex_buffer_size = imgui_draw_data->TotalVtxCount * sizeof(ImDrawVert);
+    const VkDeviceSize index_buffer_size = imgui_draw_data->TotalIdxCount * sizeof(ImDrawIdx);
 
     if ((vertex_buffer_size == 0) || (index_buffer_size == 0)) {
         return;
@@ -294,7 +296,7 @@ void ImGUIOverlay::update() {
             index_buffer_address += cmd_list->IdxBuffer.Size;
         }
 
-        ImGuiIO &io = ImGui::GetIO();
+        const ImGuiIO &io = ImGui::GetIO();
 
         spdlog::debug("Creating frame buffers for ImGUI");
 

--- a/src/vulkan-renderer/io/byte_stream.cpp
+++ b/src/vulkan-renderer/io/byte_stream.cpp
@@ -29,7 +29,7 @@ void ByteStreamReader::check_end(const std::size_t size) const {
 ByteStreamReader::ByteStreamReader(const ByteStream &stream) : m_stream(stream), m_iter(stream.buffer().begin()) {}
 
 void ByteStreamReader::skip(const std::size_t size) {
-    std::size_t skip = std::min(
+    const std::size_t skip = std::min(
         size, std::size_t(std::distance<std::vector<std::uint8_t>::const_iterator>(m_iter, m_stream.buffer().end())));
     std::advance(m_iter, skip);
 }

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -84,13 +84,10 @@ void VulkanRenderer::recreate_swapchain() {
     m_image_available_semaphore = std::make_unique<wrapper::Semaphore>(*m_device, "Image available semaphore");
     m_rendering_finished_semaphore = std::make_unique<wrapper::Semaphore>(*m_device, "Rendering finished semaphore");
 
-    m_game_camera.m_type = Camera::CameraType::LOOKAT;
-    m_game_camera.m_rotation_speed = 0.25f;
-    m_game_camera.m_movement_speed = 0.1f;
-    m_game_camera.set_position({0.0f, 0.0f, 5.0f});
-    m_game_camera.set_rotation({0.0f, 0.0f, 0.0f});
-    m_game_camera.set_perspective(45.0f, static_cast<float>(m_window->width()) / static_cast<float>(m_window->height()),
-                                  0.1f, 256.0f);
+    Camera new_camera(CameraType::LOOKAT, {0.0f, 0.0f, 5.0f}, {0.0f, 0.0f, 0.0f}, 0.1f, 0.25f, 45.0f, 0.1f, 256.0f,
+                      m_window->width(), m_window->height());
+
+    m_game_camera = new_camera;
 
     m_imgui_overlay.reset();
     m_imgui_overlay = std::make_unique<ImGUIOverlay>(*m_device, *m_swapchain);

--- a/src/vulkan-renderer/time_step.cpp
+++ b/src/vulkan-renderer/time_step.cpp
@@ -9,7 +9,7 @@ TimeStep::TimeStep() {
 }
 
 float TimeStep::time_step() {
-    auto current_time = std::chrono::high_resolution_clock::now();
+    const auto current_time = std::chrono::high_resolution_clock::now();
 
     auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
 

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -27,8 +27,8 @@ CommandBuffer::CommandBuffer(const wrapper::Device &device, VkCommandPool comman
 }
 
 CommandBuffer::CommandBuffer(CommandBuffer &&other) noexcept
-    : m_command_buffer(std::exchange(other.m_command_buffer, nullptr)), m_device(other.m_device), m_name(other.m_name) {
-}
+    : m_command_buffer(std::exchange(other.m_command_buffer, nullptr)), m_device(other.m_device),
+      m_name(std::move(other.m_name)) {}
 
 void CommandBuffer::begin(VkCommandBufferUsageFlags flags) const {
     auto begin_info = make_info<VkCommandBufferBeginInfo>();

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -311,7 +311,7 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
 
 Device::Device(Device &&other) noexcept
     : m_device(std::exchange(other.m_device, nullptr)), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)),
-      m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers) {}
+      m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers), m_surface(other.m_surface) {}
 
 Device::~Device() {
     if (m_allocator != nullptr) {

--- a/src/vulkan-renderer/wrapper/mesh_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/mesh_buffer.cpp
@@ -78,7 +78,7 @@ MeshBuffer::MeshBuffer(const Device &device, const std::string &name, const VkDe
     : m_vertex_buffer(device, name, size_of_vertex_structure * number_of_vertices,
                       VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
       m_index_buffer(std::nullopt), m_number_of_vertices(static_cast<std::uint32_t>(number_of_vertices)),
-      m_number_of_indices(static_cast<std::uint32_t>(m_number_of_indices)), m_device(device) {
+      m_number_of_indices(0), m_device(device) {
     assert(device.device());
     assert(device.allocator());
     assert(!name.empty());
@@ -104,7 +104,6 @@ MeshBuffer::MeshBuffer(const Device &device, const std::string &name, const VkDe
 
     : m_vertex_buffer(device, name, size_of_vertex_structure * number_of_vertices,
                       VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_ONLY),
-      m_index_buffer(std::nullopt), m_number_of_indices(static_cast<std::uint32_t>(m_number_of_indices)),
-      m_device(device) {}
+      m_index_buffer(std::nullopt), m_number_of_indices(0), m_device(device) {}
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -69,9 +69,11 @@ void Window::hide() {
     glfwHideWindow(m_window);
 }
 
-void Window::cursor_pos(double &pos_x, double &pos_y) {
+std::array<double, 2> Window::cursor_pos() {
     assert(m_window);
-    glfwGetCursorPos(m_window, &pos_x, &pos_y);
+    std::array<double, 2> cursor_position{0.0, 0.0};
+    glfwGetCursorPos(m_window, &cursor_position[0], &cursor_position[1]);
+    return cursor_position;
 }
 
 bool Window::is_button_pressed(int button) {


### PR DESCRIPTION
This pull request fixes most clang-tidy warnings and Microsoft code analysis warnings.
Closes https://github.com/inexorgame/vulkan-renderer/issues/209.