### PR TITLE
Use glfw callbacks instead of polling events manually

### DIFF
--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "inexor/vulkan-renderer/input/keyboard_mouse_data.hpp"
 #include "inexor/vulkan-renderer/renderer.hpp"
 
 #include <GLFW/glfw3.h>
@@ -10,20 +11,27 @@
 #include <string>
 #include <vector>
 
+// forward declarations
+namespace inexor::vulkan_renderer::input {
+class KeyboardMouseInputData;
+}
+
 namespace inexor::vulkan_renderer {
 
 class Application : public VulkanRenderer {
     std::string m_application_name;
     std::string m_engine_name;
 
-    std::uint32_t m_application_version{};
-    std::uint32_t m_engine_version{};
+    std::uint32_t m_application_version;
+    std::uint32_t m_engine_version;
 
     std::vector<std::string> m_vertex_shader_files;
     std::vector<std::string> m_fragment_shader_files;
     std::vector<std::string> m_texture_files;
     std::vector<std::string> m_shader_files;
     std::vector<std::string> m_gltf_model_files;
+
+    std::unique_ptr<input::KeyboardMouseInputData> m_input_data;
 
     /// @brief Load the configuration of the renderer from a TOML configuration file.
     /// @brief file_name The TOML configuration file.
@@ -32,16 +40,42 @@ class Application : public VulkanRenderer {
     void load_textures();
     void load_shaders();
     void load_octree_geometry();
+    void setup_window_and_input_callbacks();
     void update_imgui_overlay();
     void check_application_specific_features();
     void update_uniform_buffers();
-    void update_mouse_input();
-
-    // TODO: Refactor!
-    double m_cursor_x, m_cursor_y;
+    void process_mouse_input();
+    // TODO: Implement a method for processing keyboard input.
 
 public:
     Application(int argc, char **argv);
+
+    /// @brief Call glfwSetFramebufferSizeCallback.
+    /// @param window The window whose framebuffer was resized.
+    /// @param width The new width, in pixels, of the framebuffer.
+    /// @param height The new height, in pixels, of the framebuffer.
+    void frame_buffer_resize_callback(GLFWwindow *window, int width, int height);
+
+    /// @brief Call glfwSetKeyCallback.
+    /// @param window The window that received the event.
+    /// @param key The keyboard key that was pressed or released.
+    /// @param scancode The system-specific scancode of the key.
+    /// @param action GLFW_PRESS, GLFW_RELEASE or GLFW_REPEAT.
+    /// @param mods Bit field describing which modifier keys were held down.
+    void key_callback(GLFWwindow *window, int key, int scancode, int action, int mods);
+
+    /// @brief Call glfwSetCursorPosCallback.
+    /// @param window The window that received the event.
+    /// @param xpos The new x-coordinate, in screen coordinates, of the cursor.
+    /// @param ypos The new y-coordinate, in screen coordinates, of the cursor.
+    void cursor_position_callback(GLFWwindow *window, double xpos, double ypos);
+
+    /// @brief Call glfwSetMouseButtonCallback.
+    /// @param window The window that received the event.
+    /// @param button The mouse button that was pressed or released.
+    /// @param action One of GLFW_PRESS or GLFW_RELEASE.
+    /// @param mods Bit field describing which modifier keys were held down.
+    void mouse_button_callback(GLFWwindow *window, int button, int action, int mods);
 
     void run();
 };

--- a/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
+++ b/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <array>
+#include <unordered_map>
+
+namespace inexor::vulkan_renderer::input {
+
+/// @brief A wrapper for keyboard and mouse input data.
+/// @warning Not thread safe!
+class KeyboardMouseInputData {
+    std::array<std::int64_t, 2> m_previous_cursor_pos{0, 0};
+    std::array<std::int64_t, 2> m_current_cursor_pos{0, 0};
+    std::unordered_map<std::int32_t, bool> m_pressed_keys;
+    std::unordered_map<std::int32_t, bool> m_pressed_mouse_buttons;
+
+public:
+    KeyboardMouseInputData();
+    KeyboardMouseInputData(const KeyboardMouseInputData &) = delete;
+    KeyboardMouseInputData(KeyboardMouseInputData &&) = delete;
+
+    ~KeyboardMouseInputData() = default;
+
+    KeyboardMouseInputData &operator=(const KeyboardMouseInputData &) = delete;
+    KeyboardMouseInputData &operator=(KeyboardMouseInputData &&) = delete;
+
+    /// @brief Change the key's state to pressed.
+    /// @param button The key which was pressed.
+    void press_key(std::int32_t key);
+
+    /// @brief Change the key's state to unpressed.
+    /// @param button The key which was released.
+    void release_key(std::int32_t button);
+
+    /// @brief Change the mouse button's state to pressed.
+    /// @param button The mouse button which was pressed.
+    void press_mouse_button(std::int32_t button);
+
+    /// @brief Change the mouse button's state to unpressed.
+    /// @param button The mouse button which was released.
+    void release_mouse_button(std::int32_t button);
+
+    /// @brief Set the current cursor position.
+    /// @param cursor_pos_x The current x-coordinate of the cursor.
+    /// @param cursor_pos_y The current y-coordinate of the cursor.
+    void set_cursor_pos(double cursor_pos_x, double coursor_pos_y);
+
+    /// @return Return a std::array of size 2 which contains the x-position in index 0 and y-position in index 1.
+    [[nodiscard]] std::array<std::int64_t, 2> get_cursor_pos();
+
+    /// @brief Check if the given mouse button is currently pressed.
+    /// @param mouse_button The mouse button index.
+    /// @returm True if the mouse button is pressed, false otherwise.
+    [[nodiscard]] bool is_mouse_button_pressed(std::int32_t mouse_button);
+
+    /// @brief Check if the given key is currently pressed.
+    /// @param key The key index.
+    /// @retur True if the key is pressed, false otherwise.
+    [[nodiscard]] bool is_key_pressed(std::int32_t key);
+
+    /// @brief Calculate the change in x- and y-position of the cursor.
+    /// @return A std::array of size 2 which contains the change in x-position in index 0
+    /// and the change in y-position in index 1.
+    [[nodiscard]] std::array<double, 2> calculate_cursor_position_delta();
+};
+
+} // namespace inexor::vulkan_renderer::input

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -11,8 +11,8 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @brief RAII wrapper class for GLFW windows.
 class Window {
     GLFWwindow *m_window;
-    std::uint32_t m_width{0};
-    std::uint32_t m_height{0};
+    std::uint32_t m_width;
+    std::uint32_t m_height;
 
 public:
     /// @brief Default constructor.
@@ -22,10 +22,8 @@ public:
     /// @param visible True if the window is visible after creation, false otherwise.
     /// @param resizable True if the window should be resizable, false otherwise.
     Window(const std::string &title, std::uint32_t width, std::uint32_t height, bool visible, bool resizable);
-
     Window(const Window &) = delete;
     Window(Window &&) noexcept;
-
     ~Window();
 
     Window &operator=(const Window &) = delete;
@@ -47,20 +45,23 @@ public:
     /// @param frame_buffer_resize_callback The window resize callback.
     void set_resize_callback(GLFWframebuffersizefun frame_buffer_resize_callback);
 
+    /// @brief Call glfwSetKeyCallback.
+    /// @param key_input_callback The keyboard input callback.
+    void set_keyboard_button_callback(GLFWkeyfun keyboard_button_callback);
+
+    /// @brief Call glfwSetCursorPosCallback.
+    /// @param cursor_pos_callback They cursor position callback.
+    void set_cursor_position_callback(GLFWcursorposfun cursor_pos_callback);
+
+    /// @brief Call glfwSetMouseButtonCallback.
+    /// @param mouse_button_callback The mouse button callback.
+    void set_mouse_button_callback(GLFWmousebuttonfun mouse_button_callback);
+
     /// @brief Call glfwShowWindow.
     void show();
 
     /// @brief Call glfwHideWindow.
     void hide();
-
-    /// @brief Returns the cursor position.
-    std::array<double, 2> cursor_pos();
-
-    /// @brief Check if a specifiy button is pressed.
-    /// @param button The button to check.
-    /// @return ``true`` if the button is pressed.
-    /// @todo: Use a callback instead!
-    bool is_button_pressed(int button);
 
     /// @brief Call glfwPollEvents.
     void poll();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/settings_decision_maker.cpp
     vulkan-renderer/time_step.cpp
 
+	vulkan-renderer/input/keyboard_mouse_data.cpp
+
     vulkan-renderer/io/byte_stream.cpp
     vulkan-renderer/io/octree_parser.cpp
 

--- a/src/vulkan-renderer/input/keyboard_mouse_data.cpp
+++ b/src/vulkan-renderer/input/keyboard_mouse_data.cpp
@@ -1,0 +1,51 @@
+#include "inexor/vulkan-renderer/input/keyboard_mouse_data.hpp"
+
+namespace inexor::vulkan_renderer::input {
+
+KeyboardMouseInputData::KeyboardMouseInputData() {}
+
+void KeyboardMouseInputData::press_key(std::int32_t key) {
+    m_pressed_keys[key] = true;
+}
+
+void KeyboardMouseInputData::release_key(std::int32_t key) {
+    m_pressed_keys[key] = false;
+}
+
+void KeyboardMouseInputData::press_mouse_button(std::int32_t button) {
+    m_pressed_mouse_buttons[button] = true;
+}
+
+void KeyboardMouseInputData::release_mouse_button(std::int32_t button) {
+    m_pressed_mouse_buttons[button] = false;
+}
+
+void KeyboardMouseInputData::set_cursor_pos(double cursor_pos_x, double cursor_pos_y) {
+    m_current_cursor_pos[0] = static_cast<std::int64_t>(cursor_pos_x);
+    m_current_cursor_pos[1] = static_cast<std::int64_t>(cursor_pos_y);
+}
+
+std::array<std::int64_t, 2> KeyboardMouseInputData::get_cursor_pos() {
+    return m_current_cursor_pos;
+}
+
+[[nodiscard]] bool KeyboardMouseInputData::is_mouse_button_pressed(std::int32_t mouse_button) {
+    return m_pressed_mouse_buttons[mouse_button];
+}
+
+[[nodiscard]] bool KeyboardMouseInputData::is_key_pressed(std::int32_t key) {
+    return m_pressed_keys[key];
+}
+
+[[nodiscard]] std::array<double, 2> KeyboardMouseInputData::calculate_cursor_position_delta() {
+    // Calculate the change in cursor position in x- and y-axis.
+    const std::array<double, 2> m_cursor_pos_delta{
+        static_cast<double>(m_current_cursor_pos[0]) - static_cast<double>(m_previous_cursor_pos[0]),
+        static_cast<double>(m_current_cursor_pos[1]) - static_cast<double>(m_previous_cursor_pos[1])};
+
+    m_previous_cursor_pos = m_current_cursor_pos;
+
+    return m_cursor_pos_delta;
+}
+
+} // namespace inexor::vulkan_renderer::input

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -54,22 +54,27 @@ void Window::set_resize_callback(GLFWframebuffersizefun frame_buffer_resize_call
     glfwSetFramebufferSizeCallback(m_window, frame_buffer_resize_callback);
 }
 
+void Window::set_keyboard_button_callback(GLFWkeyfun keyboard_button_callback) {
+    assert(keyboard_button_callback);
+    glfwSetKeyCallback(m_window, keyboard_button_callback);
+}
+
+void Window::set_cursor_position_callback(GLFWcursorposfun cursor_pos_callback) {
+    assert(cursor_pos_callback);
+    glfwSetCursorPosCallback(m_window, cursor_pos_callback);
+}
+
+void Window::set_mouse_button_callback(GLFWmousebuttonfun mouse_button_callback) {
+    assert(mouse_button_callback);
+    glfwSetMouseButtonCallback(m_window, mouse_button_callback);
+}
+
 void Window::show() {
     glfwShowWindow(m_window);
 }
 
 void Window::hide() {
     glfwHideWindow(m_window);
-}
-
-std::array<double, 2> Window::cursor_pos() {
-    std::array<double, 2> cursor_position{0.0, 0.0};
-    glfwGetCursorPos(m_window, &cursor_position[0], &cursor_position[1]);
-    return cursor_position;
-}
-
-bool Window::is_button_pressed(int button) {
-    return glfwGetMouseButton(m_window, button);
 }
 
 void Window::poll() {


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/273.

## Introduction
This PR fixes the following issues:
* [X] Use a callback for window resize events (see [glfwSetFramebufferSizeCallback](https://www.glfw.org/docs/3.0/group__window.html#ga3203461a5303bf289f2e05f854b2f7cf)).
* [X] Use a callback for cursor updates (see [glfwSetCursorPosCallback](https://www.glfw.org/docs/3.1/group__input.html#ga7dad39486f2c7591af7fb25134a2501d)).
* [X] Use a callback for mouse button events (see [glfwSetMouseButtonCallback](https://www.glfw.org/docs/3.3/group__input.html#ga6ab84420974d812bee700e45284a723c)).
* [X] Use a callback for keyboard button events (see [glfwSetKeyCallback](https://www.glfw.org/docs/3.3/group__input.html#ga1caf18159767e761185e49a3be019f8d)).
* [X] Don't use static global callbacks! Use class methods for callback handling.

## The problem with static global functions vs. class methods
You can't use a class method in glfw3 because it is a C-style API. This means you can't directly pass a class method into one of the previously mentioned glfw functions. You can find more in [this stackoverflow post](https://stackoverflow.com/questions/7676971/pointing-to-a-function-that-is-a-class-member-glfw-setkeycallback). However, we go around this issue by storing the pointer to the application's instance in the glfw window user pointer. Then we set up the callbacks in lambdas, which get this pointer and redirect the event to the class method for callback handling. This is a strange way of doing it, but it's the way how it's done in the official Vulkan demos as well. Again: This is a glfw issue, since it's a C-style API on purpose. The problem is that we want to use modern C++ with glfw. The code looks like this:

```cpp
void Application::setup_window_callbacks() {
    spdlog::debug("Storing GLFW window user pointer.");

    m_window->set_user_ptr(this);

    spdlog::debug("Setting up framebuffer resize callback.");

    auto lambda_frame_buffer_resize_callback = [](GLFWwindow *window, int width, int height) {
        const auto app = static_cast<Application *>(glfwGetWindowUserPointer(window));
        app->frame_buffer_resize_callback(window, width, height);
        app->m_window_resized = true;
    };

    m_window->set_resize_callback(lambda_frame_buffer_resize_callback);

    spdlog::debug("Setting up keyboard button callback.");

    auto lambda_key_callback = [](GLFWwindow *window, int key, int scancode, int action, int mods) {
        const auto app = static_cast<Application *>(glfwGetWindowUserPointer(window));
        app->key_callback(window, key, scancode, action, mods);
    };

    m_window->set_keyboard_button_callback(lambda_key_callback);

    spdlog::debug("Setting up cursor position callback.");

    auto lambda_cursor_position_callback = [](GLFWwindow *window, double xpos, double ypos) {
        const auto app = static_cast<Application *>(glfwGetWindowUserPointer(window));
        app->cursor_position_callback(window, xpos, ypos);
    };

    m_window->set_cursor_position_callback(lambda_cursor_position_callback);

    spdlog::debug("Setting up mouse button callback.");

    auto lambda_mouse_button_callback = [](GLFWwindow *window, int button, int action, int mods) {
        const auto app = static_cast<Application *>(glfwGetWindowUserPointer(window));
        app->mouse_button_callback(window, button, action, mods);
    };

    m_window->set_mouse_button_callback(lambda_mouse_button_callback);
}
```

It is still better in my opinion to encapsulate callbacks into the Application class directly instead of using a global static method.
