### PR TITLE
[octree] Add rotation function

### DIFF
--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -44,6 +44,20 @@ public:
     /// Cube Type.
     enum class Type { EMPTY = 0b00U, SOLID = 0b01U, NORMAL = 0b10U, OCTANT = 0b11U };
 
+    /// IDs of the children and edges which will be swapped to receive the rotation.
+    /// To achieve a 90 degree rotation the 0th index have to be swapped with the 1st and the 1st with the 2nd, etc.
+    struct RotationAxis {
+        using ChildType = std::array<std::array<std::size_t, 4>, 2>;
+        using EdgeType = std::array<std::array<std::size_t, 4>, 3>;
+        using Type = std::pair<ChildType, EdgeType>;
+        /// IDs of the children / edges which will be swapped to receive the rotation around X axis.
+        static constexpr Type X{{{{0, 1, 3, 2}, {4, 5, 7, 6}}}, {{{2, 4, 11, 1}, {5, 7, 8, 10}, {0, 9, 6, 3}}}};
+        /// IDs of the children / edges which will be swapped to receive the rotation around Y axis.
+        static constexpr Type Y{{{{0, 4, 5, 1}, {2, 6, 7, 3}}}, {{{0, 5, 9, 2}, {3, 8, 6, 11}, {1, 10, 7, 4}}}};
+        /// IDs of the children / edges which will be swapped to receive the rotation around Z axis.
+        static constexpr Type Z{{{{0, 2, 6, 4}, {1, 3, 7, 5}}}, {{{1, 3, 10, 0}, {4, 6, 7, 9}, {2, 11, 8, 5}}}};
+    };
+
 private:
     Type m_type{Type::SOLID};
     float m_size{32};
@@ -67,6 +81,10 @@ private:
     [[nodiscard]] std::weak_ptr<Cube> root() const noexcept;
     /// Get the vertices of this cube. Use only on geometry cubes.
     [[nodiscard]] std::array<glm::vec3, 8> vertices() const noexcept;
+
+    /// Optimized implementations of 90°, 180° and 270° rotations.
+    template <int Rotations>
+    void rotate(const RotationAxis::Type &axis);
 
 public:
     Cube() = default;
@@ -105,6 +123,11 @@ public:
     /// Indent a specific edge by steps.
     /// @param positive_direction Indent in  positive axis direction.
     void indent(std::uint8_t edge_id, bool positive_direction, std::uint8_t steps);
+
+    /// Rotate the cube 90° clockwise around the given axis. Repeats with the given rotations.
+    /// @param axis Only one index should be one.
+    /// @param rotations Value does not need to be adjusted beforehand. (e.g. mod 4)
+    void rotate(const RotationAxis::Type &axis, int rotations);
 
     /// TODO: in special cases some polygons have no surface, if completely surrounded by others
     /// \warning Will update the cache even if it is considered as valid.

--- a/include/inexor/vulkan-renderer/world/indentation.hpp
+++ b/include/inexor/vulkan-renderer/world/indentation.hpp
@@ -39,6 +39,8 @@ public:
     void indent_start(std::int8_t steps) noexcept;
     /// Positive steps into the direction of start.
     void indent_end(std::int8_t steps) noexcept;
+    /// Mirror the indentation, such that the distance from 0 to start and distance from end to max switches
+    void mirror() noexcept;
 
     [[nodiscard]] std::uint8_t uid() const;
 };

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -197,6 +197,7 @@ void Application::load_octree_geometry() {
         child->indent(11, true, 5);
         child->indent(1, false, 2);
     }
+    cube->childs()[0]->rotate(world::Cube::RotationAxis::Z, 2);
 
     for (const auto &polygons : cube->polygons(true)) {
         glm::vec3 color = {

--- a/src/vulkan-renderer/world/indentation.cpp
+++ b/src/vulkan-renderer/world/indentation.cpp
@@ -68,6 +68,12 @@ void Indentation::indent_end(std::int8_t steps) noexcept {
     this->set_end(this->m_end - steps);
 }
 
+void Indentation::mirror() noexcept {
+    std::uint8_t new_start = end();
+    m_end = Indentation::MAX - m_start;
+    m_start = new_start;
+}
+
 std::uint8_t Indentation::uid() const {
     return static_cast<std::uint8_t>(10 * m_start + offset() - (std::pow(m_start, 2) + m_start) / 2);
 }


### PR DESCRIPTION
Related to: #230.
Changes:
- the `child`/ `childs` -> `children` refactor will be done in another PR after this one.
- I used a template function to distiguish between the 90/180/270 degree rotations.

There were some other ideas which can be done:
- The public function of the rotate function can be done differently:

(current version, but uses the function below behind the scenes)
```c++
void rotate(const RotationAxis::Type &axis, int rotations);
```
(this is used behind the function shown above, but can replaced as the public version)
```c++
template <int Rotations>
void rotate(const RotationAxis::Type &axis);
```
This is another version which is possible, the `RotationAxis` will be an enum here.
But this will use the template function above behind the scenes.
```c++
template <RotationAxis Axis, int Rotations>
void rotate();
``` 

If you have some other notes or impression do not hesitate to write it down, there were so many options to achieve this rotation function.