### PR TITLE
Added configurable window modes

### DIFF
--- a/configuration/renderer.toml
+++ b/configuration/renderer.toml
@@ -22,6 +22,7 @@ minor = 0
 patch = 0
 
 [application.window]
+mode = "windowed"
 width = 800
 height = 800
 name = "Inexor-Vulkan-Renderer"

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -50,6 +50,7 @@ protected:
 
     std::uint32_t m_window_width{0};
     std::uint32_t m_window_height{0};
+    wrapper::Window::Mode m_window_mode{wrapper::Window::Mode::WINDOWED};
 
     std::string m_window_title;
 

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -10,9 +10,14 @@ namespace inexor::vulkan_renderer::wrapper {
 
 /// @brief RAII wrapper class for GLFW windows.
 class Window {
+public:
+    enum class Mode { WINDOWED, FULLSCREEN, WINDOWED_FULLSCREEN };
+
+private:
     GLFWwindow *m_window{nullptr};
     std::uint32_t m_width{0};
     std::uint32_t m_height{0};
+    Mode m_mode{Mode::WINDOWED};
 
 public:
     /// @brief Default constructor.
@@ -21,7 +26,8 @@ public:
     /// @param height The height of the window.
     /// @param visible True if the window is visible after creation, false otherwise.
     /// @param resizable True if the window should be resizable, false otherwise.
-    Window(const std::string &title, std::uint32_t width, std::uint32_t height, bool visible, bool resizable);
+    Window(const std::string &title, std::uint32_t width, std::uint32_t height, bool visible, bool resizable,
+           Mode mode);
     Window(const Window &) = delete;
     Window(Window &&) noexcept;
     ~Window();
@@ -81,6 +87,10 @@ public:
 
     [[nodiscard]] std::uint32_t height() const {
         return m_height;
+    }
+
+    [[nodiscard]] Mode mode() const {
+        return m_mode;
     }
 };
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -70,6 +70,19 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     const auto &configuration_title = toml::find<std::string>(renderer_configuration, "title");
     spdlog::debug("Title: '{}'", configuration_title);
 
+    using WindowMode = ::inexor::vulkan_renderer::wrapper::Window::Mode;
+    const auto &wmodestr = toml::find<std::string>(renderer_configuration, "application", "window", "mode");
+    if (wmodestr == "windowed") {
+        m_window_mode = WindowMode::WINDOWED;
+    } else if (wmodestr == "windowed_fullscreen") {
+        m_window_mode = WindowMode::WINDOWED_FULLSCREEN;
+    } else if (wmodestr == "fullscreen") {
+        m_window_mode = WindowMode::FULLSCREEN;
+    } else {
+        spdlog::warn("Invalid application window mode: {}", wmodestr);
+        m_window_mode = WindowMode::WINDOWED;
+    }
+
     m_window_width = toml::find<int>(renderer_configuration, "application", "window", "width");
     m_window_height = toml::find<int>(renderer_configuration, "application", "window", "height");
     m_window_title = toml::find<std::string>(renderer_configuration, "application", "window", "name");
@@ -397,7 +410,8 @@ Application::Application(int argc, char **argv) {
                                                      m_engine_version, VK_API_VERSION_1_1, m_enable_validation_layers,
                                                      enable_renderdoc_instance_layer);
 
-    m_window = std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true);
+    m_window =
+        std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true, m_window_mode);
 
     m_input_data = std::make_unique<input::KeyboardMouseInputData>();
 


### PR DESCRIPTION
References issue #291 

This commit adds a new TOML variable which changes the window mode to use on start-up.

The TOML configuration file uses strings to indicate which mode should be used

- windowed
- windowed-fullscreen
- fullscreen

- [x] Ability to change window mode on start-up
~~Ability to change window mode during runtime~~ (moved to https://github.com/inexorgame/vulkan-renderer/issues/328)

Feedback welcome of course