### PR TITLE
[wrapper] Make sure to zero-out VMA structs

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -19,8 +19,8 @@ protected:
     VkBuffer m_buffer{VK_NULL_HANDLE};
     VkDeviceSize m_buffer_size{0};
     VmaAllocation m_allocation{VK_NULL_HANDLE};
-    VmaAllocationInfo m_allocation_info;
-    VmaAllocationCreateInfo m_allocation_ci;
+    VmaAllocationInfo m_allocation_info{};
+    VmaAllocationCreateInfo m_allocation_ci{};
 
 public:
     /// @brief Construct the GPU memory buffer without specifying the actual data to fill in, only the memory size.


### PR DESCRIPTION
This was giving VMA uninitialised data, which was sometimes causing
segfaults.