### PR TITLE
Warning Cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -471,16 +471,12 @@ CheckOptions:
     value:           CamelCase
   - key:             modernize-make-shared.IgnoreMacros
     value:           '1'
-  - key:             modernize-make-shared.IncludeStyle
-    value:           '0'
   - key:             modernize-make-shared.MakeSmartPtrFunction
     value:           'std::make_shared'
   - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
     value:           memory
   - key:             modernize-make-unique.IgnoreMacros
     value:           '1'
-  - key:             modernize-make-unique.IncludeStyle
-    value:           '0'
   - key:             modernize-make-unique.MakeSmartPtrFunction
     value:           'std::make_unique'
   - key:             modernize-make-unique.MakeSmartPtrFunctionHeader

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 ---
 Checks: >
+  -clang-diagnostic-*,
   bugprone-argument-comment,
   bugprone-assert-side-effect,
   bugprone-bad-signal-to-kill-thread,

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,84 @@
+name: Static Analysis
+on: [push, pull_request]
+
+env:
+  inexor_vulkan_version: "1.2.131.1"
+  inexor_vulkan_sdk: "$GITHUB_WORKSPACE/../vulkan_sdk/"
+
+jobs:
+  clang-tidy:
+    name: Clang Tidy
+    runs-on: ubuntu-latest
+    container: ubuntu:rolling
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+      inexor_conan_path: "$HOME/.local/bin"
+    steps:
+      - name: Update environment
+        run: |
+          # Update package lists
+          apt update -qq
+
+          # Install tools
+          apt install -y \
+            clang-tidy \
+            cmake \
+            curl \
+            libgl1-mesa-dev \
+            libx11-dev \
+            libx11-xcb-dev \
+            libxcb-dri3-dev \
+            libxcb-icccm4-dev \
+            libxcb-image0-dev \
+            libxcb-keysyms1-dev \
+            libxcb-randr0-dev \
+            libxcb-render-util0-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-sync-dev \
+            libxcb-util-dev \
+            libxcb-xfixes0-dev \
+            libxcb-xinerama0-dev \
+            libxcb-xkb-dev \
+            parallel \
+            pkg-config \
+            python3 \
+            python3-pip \
+            xkb-data \
+            xorg-dev
+
+          pip3 install wheel setuptools
+          pip3 install conan mako
+
+      - name: Install Vulkan SDK
+        run: |
+          # Download Vulkan SDK
+          curl -LS -o vulkansdk.tar.gz \
+            https://sdk.lunarg.com/sdk/download/${{ env.inexor_vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ env.inexor_vulkan_version }}.tar.gz
+          # Create Vulkan SDK directory and extract
+          mkdir "${{ env.inexor_vulkan_sdk }}"
+          tar xfz vulkansdk.tar.gz -C "${{ env.inexor_vulkan_sdk }}"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure CMake
+        run: |
+          export CC=gcc
+          export CXX=g++
+          export PATH="${{ env.inexor_conan_path }}":$PATH
+          export VULKAN_SDK="${{ env.inexor_vulkan_sdk }}/${{ env.inexor_vulkan_version }}/x86_64"
+          export PATH=$VULKAN_SDK/bin:$PATH
+          export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
+          export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
+          cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Run clang-tidy
+        run: |
+          find example src \
+            -name '*.cpp' \
+            -print0 |
+          parallel -0 \
+            clang-tidy -p build --header-filter=inexor/ --quiet {} 2>/dev/null |
+          tee output
+          if [ -s output ]; then exit 1; fi

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -54,12 +54,6 @@ class Application : public VulkanRenderer {
 public:
     Application(int argc, char **argv);
 
-    /// @brief Call glfwSetFramebufferSizeCallback.
-    /// @param window The window whose framebuffer was resized.
-    /// @param width The new width, in pixels, of the framebuffer.
-    /// @param height The new height, in pixels, of the framebuffer.
-    void frame_buffer_resize_callback(GLFWwindow *window, int width, int height);
-
     /// @brief Call glfwSetKeyCallback.
     /// @param window The window that received the event.
     /// @param key The keyboard key that was pressed or released.

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -14,7 +14,7 @@
 // forward declarations
 namespace inexor::vulkan_renderer::input {
 class KeyboardMouseInputData;
-}
+} // namespace inexor::vulkan_renderer::input
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -33,6 +33,8 @@ class Application : public VulkanRenderer {
 
     std::unique_ptr<input::KeyboardMouseInputData> m_input_data;
 
+    bool m_enable_validation_layers = true;
+
     // If the user specified command line argument "--stop-on-validation-message", the program will call std::abort();
     // after reporting a validation layer (error) message.
     bool m_stop_on_validation_message{false};
@@ -44,12 +46,12 @@ class Application : public VulkanRenderer {
     void load_textures();
     void load_shaders();
     void load_octree_geometry();
+    void setup_vulkan_debug_callback();
     void setup_window_and_input_callbacks();
     void update_imgui_overlay();
     void check_application_specific_features();
     void update_uniform_buffers();
     void process_mouse_input();
-    // TODO: Implement a method for processing keyboard input.
 
 public:
     Application(int argc, char **argv);

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -28,7 +28,6 @@ class Application : public VulkanRenderer {
     std::vector<std::string> m_vertex_shader_files;
     std::vector<std::string> m_fragment_shader_files;
     std::vector<std::string> m_texture_files;
-    std::vector<std::string> m_shader_files;
     std::vector<std::string> m_gltf_model_files;
 
     std::unique_ptr<input::KeyboardMouseInputData> m_input_data;

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -65,9 +65,9 @@ public:
 
     /// @brief Call glfwSetCursorPosCallback.
     /// @param window The window that received the event.
-    /// @param xpos The new x-coordinate, in screen coordinates, of the cursor.
-    /// @param ypos The new y-coordinate, in screen coordinates, of the cursor.
-    void cursor_position_callback(GLFWwindow *window, double xpos, double ypos);
+    /// @param x_pos The new x-coordinate, in screen coordinates, of the cursor.
+    /// @param y_pos The new y-coordinate, in screen coordinates, of the cursor.
+    void cursor_position_callback(GLFWwindow *window, double x_pos, double y_pos);
 
     /// @brief Call glfwSetMouseButtonCallback.
     /// @param window The window that received the event.
@@ -78,9 +78,9 @@ public:
 
     /// @brief Call camera's process_mouse_scroll method.
     /// @param window The window that received the event.
-    /// @param xoffset The change of x-offset of the mouse wheel.
-    /// @param yoffset The change of y-offset of the mouse wheel.
-    void mouse_scroll_callback(GLFWwindow *window, double xoffset, double yoffset);
+    /// @param x_offset The change of x-offset of the mouse wheel.
+    /// @param y_offset The change of y-offset of the mouse wheel.
+    void mouse_scroll_callback(GLFWwindow *window, double x_offset, double y_offset);
 
     void run();
 };

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -68,18 +68,18 @@ class BezierCurve {
 
     std::vector<BezierOutputPoint> m_output_points;
 
-    uint32_t binomial_coefficient(uint32_t n, const uint32_t k);
+    uint32_t binomial_coefficient(uint32_t n, uint32_t k);
 
-    float bernstein_polynomial(uint32_t n, uint32_t k, const float curve_precision, const float coordinate_value);
+    float bernstein_polynomial(uint32_t n, uint32_t k, float curve_precision, float coordinate_value);
 
-    BezierOutputPoint calculate_point_on_curve(const float curve_precision);
+    BezierOutputPoint calculate_point_on_curve(float curve_precision);
 
 public:
     void add_input_point(const BezierInputPoint &input_point);
 
-    void add_input_point(const glm::vec3 &position, const float weight = 1.0f);
+    void add_input_point(const glm::vec3 &position, float weight = 1.0f);
 
-    void calculate_bezier_curve(const float curve_precision);
+    void calculate_bezier_curve(float curve_precision);
 
     [[nodiscard]] std::vector<BezierOutputPoint> output_points();
 

--- a/include/inexor/vulkan-renderer/bezier_curve.hpp
+++ b/include/inexor/vulkan-renderer/bezier_curve.hpp
@@ -68,9 +68,9 @@ class BezierCurve {
 
     std::vector<BezierOutputPoint> m_output_points;
 
-    uint32_t binomial_coefficient(uint32_t n, uint32_t k);
+    static uint32_t binomial_coefficient(uint32_t n, uint32_t k);
 
-    float bernstein_polynomial(uint32_t n, uint32_t k, float curve_precision, float coordinate_value);
+    static float bernstein_polynomial(uint32_t n, uint32_t k, float curve_precision, float coordinate_value);
 
     BezierOutputPoint calculate_point_on_curve(float curve_precision);
 
@@ -79,7 +79,7 @@ public:
 
     void add_input_point(const glm::vec3 &position, float weight = 1.0f);
 
-    void calculate_bezier_curve(float curve_precision);
+    void calculate_bezier_curve(std::uint32_t curve_segments);
 
     [[nodiscard]] std::vector<BezierOutputPoint> output_points();
 
@@ -89,7 +89,9 @@ public:
 
     void clear();
 
-    [[nodiscard]] bool is_curve_generated();
+    [[nodiscard]] bool is_curve_generated() const {
+        return m_curve_generated;
+    }
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/fps_counter.hpp
+++ b/include/inexor/vulkan-renderer/fps_counter.hpp
@@ -8,7 +8,7 @@ namespace inexor::vulkan_renderer {
 
 /// @brief A class for counting frames per seconds.
 class FPSCounter {
-    std::size_t m_frames{0};
+    std::uint32_t m_frames{0};
 
     std::chrono::time_point<std::chrono::high_resolution_clock> m_last_time;
 

--- a/include/inexor/vulkan-renderer/imgui.hpp
+++ b/include/inexor/vulkan-renderer/imgui.hpp
@@ -59,14 +59,12 @@ public:
     /// @param device A reference to the device wrapper.
     /// @param swapchain A reference to the swapchain.
     ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapchain &swapchain);
-
+    ImGUIOverlay(const ImGUIOverlay &) = delete;
+    ImGUIOverlay(ImGUIOverlay &&) noexcept = delete;
     ~ImGUIOverlay();
 
-    ImGUIOverlay(const ImGUIOverlay &) = delete;
-    ImGUIOverlay(ImGUIOverlay &&other) noexcept;
-
-    ImGUIOverlay &operator=(const ImGUIOverlay &other) = delete;
-    ImGUIOverlay &operator=(ImGUIOverlay &&other) = delete;
+    ImGUIOverlay &operator=(const ImGUIOverlay &) = delete;
+    ImGUIOverlay &operator=(ImGUIOverlay &&) = delete;
 
     [[nodiscard]] float get_scale() const {
         return m_scale;

--- a/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
+++ b/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
@@ -26,12 +26,12 @@ public:
     KeyboardMouseInputData &operator=(KeyboardMouseInputData &&) = delete;
 
     /// @brief Change the key's state to pressed.
-    /// @param button The key which was pressed.
+    /// @param key The key which was pressed.
     void press_key(std::int32_t key);
 
     /// @brief Change the key's state to unpressed.
-    /// @param button The key which was released.
-    void release_key(std::int32_t button);
+    /// @param key The key which was released.
+    void release_key(std::int32_t key);
 
     /// @brief Change the mouse button's state to pressed.
     /// @param button The mouse button which was pressed.
@@ -44,7 +44,7 @@ public:
     /// @brief Set the current cursor position.
     /// @param cursor_pos_x The current x-coordinate of the cursor.
     /// @param cursor_pos_y The current y-coordinate of the cursor.
-    void set_cursor_pos(double cursor_pos_x, double coursor_pos_y);
+    void set_cursor_pos(double cursor_pos_x, double cursor_pos_y);
 
     /// @return Return a std::array of size 2 which contains the x-position in index 0 and y-position in index 1.
     [[nodiscard]] std::array<std::int64_t, 2> get_cursor_pos() const;

--- a/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
+++ b/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
@@ -17,10 +17,9 @@ class KeyboardMouseInputData {
     bool mouse_buttons_updated{false};
 
 public:
-    KeyboardMouseInputData();
+    KeyboardMouseInputData() = default;
     KeyboardMouseInputData(const KeyboardMouseInputData &) = delete;
     KeyboardMouseInputData(KeyboardMouseInputData &&) = delete;
-
     ~KeyboardMouseInputData() = default;
 
     KeyboardMouseInputData &operator=(const KeyboardMouseInputData &) = delete;

--- a/include/inexor/vulkan-renderer/render_graph.hpp
+++ b/include/inexor/vulkan-renderer/render_graph.hpp
@@ -41,11 +41,11 @@ struct RenderGraphObject {
     /// @brief Casts this object to type `T`
     /// @return The object as type `T` or `nullptr` if the cast failed
     template <typename T>
-    T *as();
+    [[nodiscard]] T *as();
 
     /// @copydoc as
     template <typename T>
-    const T *as() const;
+    [[nodiscard]] const T *as() const;
 };
 
 /// @brief A single resource in the render graph
@@ -441,12 +441,12 @@ public:
 };
 
 template <typename T>
-T *RenderGraphObject::as() {
+[[nodiscard]] T *RenderGraphObject::as() {
     return dynamic_cast<T *>(this);
 }
 
 template <typename T>
-const T *RenderGraphObject::as() const {
+[[nodiscard]] const T *RenderGraphObject::as() const {
     return dynamic_cast<const T *>(this);
 }
 

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -55,9 +55,6 @@ protected:
 
     FPSCounter m_fps_counter;
 
-    // TODO: Refactor this!
-    VkDescriptorBufferInfo m_uniform_buffer_info;
-
     bool m_vsync_enabled{false};
 
     std::unique_ptr<Camera> m_camera;

--- a/include/inexor/vulkan-renderer/settings_decision_maker.hpp
+++ b/include/inexor/vulkan-renderer/settings_decision_maker.hpp
@@ -27,7 +27,7 @@ struct VulkanSettingsDecisionMaker {
     /// @todo Implement additional graphics card rating criteria if desired.
     /// @param graphics_card The graphics card which will be rated.
     /// @return The graphics card's score which is greater or equal to 0.
-    [[nodiscard]] std::size_t rate_graphics_card(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] static std::size_t rate_graphics_card(VkPhysicalDevice graphics_card);
 
     /// @brief Automatically decide if a graphics card is suitable for this application's purposes.
     /// In order to be a suitable graphcs card for Inexor's purposes, it must fulfill the following criteria:
@@ -38,12 +38,12 @@ struct VulkanSettingsDecisionMaker {
     /// @return ``true`` if the graphics card is suitable.
     /// @warning When implementing additional graphics card suitability criteria, do not return false for graphics cards
     /// which are not VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU!
-    [[nodiscard]] bool is_graphics_card_suitable(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface);
+    [[nodiscard]] static bool is_graphics_card_suitable(VkPhysicalDevice graphics_card, VkSurfaceKHR surface);
 
     /// @brief Gets the VkPhysicalDeviceType of a graphics card.
     /// @param graphics_card The graphics card.
     /// @return The type of the graphics card.
-    [[nodiscard]] VkPhysicalDeviceType graphics_card_type(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] static VkPhysicalDeviceType graphics_card_type(VkPhysicalDevice graphics_card);
 
     /// @brief Automatically select the best graphics card considering all available ones.
     /// Please take a look at Inexor's advanced device selection mechanism which is build into this method.
@@ -54,46 +54,45 @@ struct VulkanSettingsDecisionMaker {
     /// @param surface The selected (window) surface.
     /// @param preferred_graphics_card_index The preferred graphics card (by array index).
     /// @return A physical device which was chosen if a suitable one could be found, std::nullopt otherwise.
-    [[nodiscard]] std::optional<VkPhysicalDevice>
-    decide_which_graphics_card_to_use(const VkInstance &vulkan_instance, const VkSurfaceKHR &surface,
-                                      const std::optional<std::uint32_t> &preferred_graphics_card_index = std::nullopt);
+    [[nodiscard]] static std::optional<VkPhysicalDevice>
+    decide_which_graphics_card_to_use(VkInstance vulkan_instance, VkSurfaceKHR surface,
+                                      std::optional<std::uint32_t> preferred_gpu_index = std::nullopt);
 
     /// @brief Automatically decide how many images will be used in the swap chain.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The number of images that will be used in swap chain.
-    [[nodiscard]] std::uint32_t decide_how_many_images_in_swapchain_to_use(const VkPhysicalDevice &graphics_card,
-                                                                           const VkSurfaceKHR &surface);
+    [[nodiscard]] static std::uint32_t decide_how_many_images_in_swapchain_to_use(VkPhysicalDevice graphics_card,
+                                                                                  VkSurfaceKHR surface);
 
     /// @brief Automatically decide whcih surface color to use in swapchain.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The surface format for swapchain if any could be determined, std::nullopt otherwise.
-    [[nodiscard]] std::optional<VkSurfaceFormatKHR>
-    decide_which_surface_color_format_in_swapchain_to_use(const VkPhysicalDevice &graphics_card,
-                                                          const VkSurfaceKHR &surface);
+    [[nodiscard]] static std::optional<VkSurfaceFormatKHR>
+    decide_which_surface_color_format_in_swapchain_to_use(VkPhysicalDevice graphics_card, VkSurfaceKHR surface);
 
     /// @brief Automatically decide which width and height to use as swapchain extent.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @param window_width The width of the window.
     /// @param window_height The height of the window.
-    SwapchainSettings decide_swapchain_extent(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
-                                              std::uint32_t window_width, std::uint32_t window_height);
+    SwapchainSettings static decide_swapchain_extent(VkPhysicalDevice graphics_card, VkSurfaceKHR surface,
+                                                     std::uint32_t window_width, std::uint32_t window_height);
 
     /// @brief Automatically find the image transform, relative to the presentation engine's natural orientation,
     /// applied to the image content prior to presentation.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The image transform flags.
-    [[nodiscard]] VkSurfaceTransformFlagsKHR
-    decide_which_image_transformation_to_use(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface);
+    [[nodiscard]] static VkSurfaceTransformFlagsKHR
+    decide_which_image_transformation_to_use(VkPhysicalDevice graphics_card, VkSurfaceKHR surface);
 
     /// @brief Find a supported composite alpha format.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The composite alpha flag bits.
-    [[nodiscard]] std::optional<VkCompositeAlphaFlagBitsKHR>
+    [[nodiscard]] static std::optional<VkCompositeAlphaFlagBitsKHR>
     find_composite_alpha_format(VkPhysicalDevice selected_graphics_card, VkSurfaceKHR surface);
 
     /// @brief Automatically decide which presentation mode the presentation engine will be using.
@@ -106,9 +105,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param surface The selected (window) surface.
     /// @param vsync True if vertical synchronization is desired, false otherwise.
     /// @return The presentation mode which will be used by the presentation engine.
-    [[nodiscard]] std::optional<VkPresentModeKHR>
-    decide_which_presentation_mode_to_use(const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface,
-                                          bool vsync = false);
+    [[nodiscard]] static std::optional<VkPresentModeKHR>
+    decide_which_presentation_mode_to_use(VkPhysicalDevice graphics_card, VkSurfaceKHR surface, bool vsync = false);
 
     /// @brief Decide which graphics queue family index to use in case it is not possible to use one for both graphics
     /// and presentation.
@@ -116,7 +114,7 @@ struct VulkanSettingsDecisionMaker {
     /// presentation!
     /// @param graphics_card The selected graphics card.
     /// @return The index of the queue family which can be used for graphics.
-    [[nodiscard]] std::optional<std::uint32_t> find_graphics_queue_family(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] static std::optional<std::uint32_t> find_graphics_queue_family(VkPhysicalDevice graphics_card);
 
     /// @brief Decide which presentation queue family index to use in case it is not possible to use one for both
     /// graphics and presentation.
@@ -125,17 +123,16 @@ struct VulkanSettingsDecisionMaker {
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The index of the queue family which can be used for presentation.
-    [[nodiscard]] std::optional<std::uint32_t> find_presentation_queue_family(const VkPhysicalDevice &graphics_card,
-                                                                              const VkSurfaceKHR &surface);
+    [[nodiscard]] static std::optional<std::uint32_t> find_presentation_queue_family(VkPhysicalDevice graphics_card,
+                                                                                     VkSurfaceKHR surface);
 
     /// @brief Check if there is a queue family (index) which can be used for both graphics and presentation.
     /// @param graphics_card The selected graphics card.
     /// @param surface The selected (window) surface.
     /// @return The queue family index which can be used for both graphics and presentation (if existent), std::nullopt
     /// otherwise.
-    [[nodiscard]] std::optional<std::uint32_t>
-    find_queue_family_for_both_graphics_and_presentation(const VkPhysicalDevice &graphics_card,
-                                                         const VkSurfaceKHR &surface);
+    [[nodiscard]] static std::optional<std::uint32_t>
+    find_queue_family_for_both_graphics_and_presentation(VkPhysicalDevice graphics_card, VkSurfaceKHR surface);
 
     /// @brief Find a queue family which has VK_QUEUE_TRANSFER_BIT, but not VK_QUEUE_GRAPHICS_BIT.
     /// @warning It might be the case that there is no distinct queue family available on your system!
@@ -143,8 +140,8 @@ struct VulkanSettingsDecisionMaker {
     /// has VK_QUEUE_TRANSFER_BIT (besides other flags).
     /// @param graphics_card The selected graphics card.
     /// @return The index of the queue family which can be used exclusively  for data transfer.
-    [[nodiscard]] std::optional<std::uint32_t>
-    find_distinct_data_transfer_queue_family(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] static std::optional<std::uint32_t>
+    find_distinct_data_transfer_queue_family(VkPhysicalDevice graphics_card);
 
     /// @brief Find a queue family which supports VK_QUEUE_TRANSFER_BIT.
     /// @warning You should try to find a distinct queue family first using find_distinct_data_transfer_queue_family!
@@ -154,8 +151,8 @@ struct VulkanSettingsDecisionMaker {
     /// @param graphics_card The selected graphics card.
     /// @return The index of the queue family which can be used for data transfer.
     /// @return A queue family index which can be used for data transfer if any could be found, std::nullopt otherwise.
-    [[nodiscard]] std::optional<std::uint32_t>
-    find_any_data_transfer_queue_family(const VkPhysicalDevice &graphics_card);
+    [[nodiscard]] static std::optional<std::uint32_t>
+    find_any_data_transfer_queue_family(VkPhysicalDevice graphics_card);
 
     /// @brief Find a suitable depth buffer format.
     /// @param graphics_card The selected graphics card.
@@ -163,10 +160,10 @@ struct VulkanSettingsDecisionMaker {
     /// @param tiling The desired depth buffer's image tiling.
     /// @param feature_flags The desired depth buffer's feature flags.
     /// @return A VkFormat value if a suitable depth buffer format could be found, std::nullopt otherwise.
-    [[nodiscard]] std::optional<VkFormat> find_depth_buffer_format(const VkPhysicalDevice &graphics_card,
-                                                                   const std::vector<VkFormat> &formats,
-                                                                   VkImageTiling tiling,
-                                                                   VkFormatFeatureFlags feature_flags);
+    [[nodiscard]] static std::optional<VkFormat> find_depth_buffer_format(VkPhysicalDevice graphics_card,
+                                                                          const std::vector<VkFormat> &formats,
+                                                                          VkImageTiling tiling,
+                                                                          VkFormatFeatureFlags feature_flags);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/tools/cla_parser.hpp
+++ b/include/inexor/vulkan-renderer/tools/cla_parser.hpp
@@ -37,7 +37,7 @@ public:
     explicit CommandLineArgumentValue(std::string value) : m_value(std::move(value)) {}
 
     template <typename T>
-    T as() const;
+    [[nodiscard]] T as() const;
 };
 
 /// @brief A simple command line argument parser.

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -21,11 +21,13 @@ public:
 
     ~File() = default;
 
-    /// @brief Return the size of the file.
-    [[nodiscard]] const std::size_t file_size() const;
+    [[nodiscard]] std::size_t file_size() const {
+        return m_file_size;
+    }
 
-    /// @brief Return the file's data.
-    [[nodiscard]] const std::vector<char> &file_data() const;
+    [[nodiscard]] const std::vector<char> &file_data() const {
+        return m_file_data;
+    }
 
     /// @brief Load the entire file into memory.
     /// @param file_name The name of the file.

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -19,8 +19,6 @@ private:
 public:
     File() = default;
 
-    ~File() = default;
-
     [[nodiscard]] std::size_t file_size() const {
         return m_file_size;
     }

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -100,7 +100,7 @@ public:
     /// Get child.
     std::shared_ptr<Cube> operator[](std::size_t idx);
     /// Get child.
-    const std::shared_ptr<const Cube> operator[](std::size_t idx) const;
+    std::shared_ptr<const Cube> operator[](std::size_t idx) const; // NOLINT
 
     /// Clone a cube, which has no relations to the current one or its children.
     /// It will be a root cube.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -95,6 +95,8 @@ public:
     Cube(Cube &&rhs) noexcept;
     ~Cube() = default;
     Cube &operator=(Cube rhs);
+    Cube &operator=(Cube &&) = delete;
+
     /// Get child.
     std::shared_ptr<Cube> operator[](std::size_t idx);
     /// Get child.

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -39,7 +39,7 @@ public:
     /// Cube edges.
     static constexpr std::size_t EDGES{12};
     /// Cube Type.
-    enum class Type { EMPTY = 0b00U, SOLID = 0b01U, NORMAL = 0b10U, OCTANT = 0b11U };
+    enum class Type { EMPTY = 0b00u, SOLID = 0b01u, NORMAL = 0b10u, OCTANT = 0b11u };
 
     /// IDs of the children and edges which will be swapped to receive the rotation.
     /// To achieve a 90 degree rotation the 0th index have to be swapped with the 1st and the 1st with the 2nd, etc.
@@ -58,7 +58,7 @@ public:
 private:
     Type m_type{Type::SOLID};
     float m_size{32};
-    glm::vec3 m_position{0.0F, 0.0F, 0.0F};
+    glm::vec3 m_position{0.0f, 0.0f, 0.0f};
 
     /// Root cube is empty.
     std::weak_ptr<Cube> m_parent{};

--- a/include/inexor/vulkan-renderer/world/indentation.hpp
+++ b/include/inexor/vulkan-renderer/world/indentation.hpp
@@ -36,9 +36,9 @@ public:
     [[nodiscard]] std::uint8_t offset() const noexcept;
 
     /// Positive steps into the direction of end.
-    void indent_start(std::int8_t steps) noexcept;
+    void indent_start(std::uint8_t steps) noexcept;
     /// Positive steps into the direction of start.
-    void indent_end(std::int8_t steps) noexcept;
+    void indent_end(std::uint8_t steps) noexcept;
     /// Mirror the indentation, such that the distance from 0 to start and distance from end to max switches
     void mirror() noexcept;
 

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -23,7 +23,7 @@ public:
     /// @param device The const reference to the device RAII wrapper class.
     /// @param command_pool The command pool from which the command buffer will be allocated.
     /// @param name The internal debug marker name of the command buffer. This must not be an empty string.
-    CommandBuffer(const wrapper::Device &device, VkCommandPool command_pool, const std::string &name);
+    CommandBuffer(const wrapper::Device &device, VkCommandPool command_pool, std::string name);
 
     CommandBuffer(const CommandBuffer &) = delete;
     CommandBuffer(CommandBuffer &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
@@ -45,8 +45,8 @@ public:
     /// @param shader_stage The shader stage the uniform buffer will be used in, most likely the vertex shader.
     /// @return A const reference to this DescriptorBuilder instance.
     template <typename T>
-    DescriptorBuilder &add_uniform_buffer(const VkBuffer uniform_buffer, const std::uint32_t binding,
-                                          const VkShaderStageFlagBits shader_stage = VK_SHADER_STAGE_VERTEX_BIT);
+    DescriptorBuilder &add_uniform_buffer(VkBuffer uniform_buffer, std::uint32_t binding,
+                                          VkShaderStageFlagBits shader_stage = VK_SHADER_STAGE_VERTEX_BIT);
 
     /// @brief Adds a combined image sampler to the descriptor container.
     /// @param image_sampler The pointer to the combined image sampler.
@@ -54,9 +54,9 @@ public:
     /// @param binding The binding index which will be used in the SPIR-V shader.
     /// @param shader_stage The shader stage the uniform buffer will be used in, most likely the fragment shader.
     /// @return A const reference to this DescriptorBuilder instance.
-    DescriptorBuilder &
-    add_combined_image_sampler(const VkSampler image_sampler, const VkImageView image_view, const std::uint32_t binding,
-                               const VkShaderStageFlagBits shader_stage = VK_SHADER_STAGE_FRAGMENT_BIT);
+    DescriptorBuilder &add_combined_image_sampler(VkSampler image_sampler, VkImageView image_view,
+                                                  std::uint32_t binding,
+                                                  VkShaderStageFlagBits shader_stage = VK_SHADER_STAGE_FRAGMENT_BIT);
 
     /// @brief Builds the resource descriptor.
     /// @param name The internal name of the resource descriptor.

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -47,9 +47,9 @@ public:
     /// @brief Check if a certain device layer is available for a specific graphics card.
     /// @note Vulkan device layers were deprecated, essentially making all layers instance layers.
     /// @param graphics_card The graphics card.
-    /// @param extension The name of the device layer.
+    /// @param layer_name The name of the device layer.
     /// @return ``true`` if the requested device layer is available.
-    [[nodiscard]] static bool is_layer_supported(VkPhysicalDevice graphics_card, const std::string &extension);
+    [[nodiscard]] static bool is_layer_supported(VkPhysicalDevice graphics_card, const std::string &layer_name);
 
     /// @brief Check if a swapchain is available for a specific graphics card.
     /// @param graphics_card The graphics card.

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -24,7 +24,7 @@ public:
     /// @param swapchain The associated swapchain.
     /// @param name The internal debug marker name of the VkFramebuffer.
     Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
-                const Swapchain &swapchain, const std::string &name);
+                const Swapchain &swapchain, std::string name);
 
     Framebuffer(const Framebuffer &) = delete;
     Framebuffer(Framebuffer &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
@@ -41,10 +41,9 @@ class GpuTexture {
 
     /// @brief Transform the image layout.
     /// @param image The image.
-    /// @param format The image format.
     /// @param old_layout The old image layout.
     /// @param new_layout The new image layout.
-    void transition_image_layout(VkImage image, VkFormat format, VkImageLayout old_layout, VkImageLayout new_layout);
+    void transition_image_layout(VkImage image, VkImageLayout old_layout, VkImageLayout new_layout);
 
     /// @brief Create the texture sampler.
     void create_texture_sampler();

--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -36,8 +36,8 @@ public:
     /// @param requested_instance_layers The instance layers which are requested.
     Instance(const std::string &application_name, const std::string &engine_name, std::uint32_t application_version,
              std::uint32_t engine_version, std::uint32_t vulkan_api_version, bool enable_validation_layers,
-             bool enable_renderdoc_layer, std::vector<std::string> requested_instance_extensions,
-             std::vector<std::string> requested_instance_layers);
+             bool enable_renderdoc_layer, const std::vector<std::string> &requested_instance_extensions,
+             const std::vector<std::string> &requested_instance_layers);
 
     /// @brief Construct the Vulkan instance without the requested instance layers and instance extensions.
     /// @param application_name The Vulkan application's internal application name.

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -125,7 +125,7 @@ public:
 
         staging_buffer_for_vertices.upload_data_to_gpu(m_vertex_buffer);
 
-        if (indices.size() > 0) {
+        if (!indices.empty()) {
             VkDeviceSize indices_memory_size = sizeof(IndexType) * indices.size();
 
             StagingBuffer staging_buffer_for_indices(m_device, name, index_buffer_size,

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -89,7 +89,7 @@ public:
         : m_vertex_buffer(device, name, sizeof(VertexType) * vertex_count,
                           VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                           VMA_MEMORY_USAGE_CPU_ONLY),
-          m_index_buffer(std::nullopt), m_number_of_vertices(vertex_count), m_number_of_indices(0), m_device(device) {
+          m_index_buffer(std::nullopt), m_number_of_vertices(vertex_count), m_device(device) {
 
         assert(device.device());
         assert(device.allocator());

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -173,6 +173,8 @@ public:
           m_number_of_vertices(other.m_number_of_vertices), m_number_of_indices(other.m_number_of_indices),
           m_device(other.m_device) {}
 
+    ~MeshBuffer() = default;
+
     MeshBuffer &operator=(const MeshBuffer &) = delete;
     MeshBuffer &operator=(MeshBuffer &&) = delete;
 

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -23,8 +23,8 @@ public:
     /// @param buffer_size The size of the memory buffer to copy.
     /// @param data A pointer to the memory buffer.
     /// @param data_size The size of the memory buffer to copy.
-    StagingBuffer(const Device &device, const std::string &name, const VkDeviceSize buffer_size, void *data,
-                  const std::size_t data_size);
+    StagingBuffer(const Device &device, const std::string &name, VkDeviceSize buffer_size, void *data,
+                  std::size_t data_size);
 
     StagingBuffer(const StagingBuffer &) = delete;
     StagingBuffer(StagingBuffer &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/staging_buffer.hpp
@@ -12,7 +12,7 @@ class Device;
 /// @brief RAII wrapper class for staging buffers.
 /// A staging buffer is a buffer which is used for copying data.
 /// Using a staging buffer is the most efficient way to copy memory from RAM to GPU.
-class StagingBuffer : public GPUMemoryBuffer {
+class StagingBuffer final : public GPUMemoryBuffer {
     const Device &m_device;
     OnceCommandBuffer m_command_buffer_for_copying;
 
@@ -25,11 +25,9 @@ public:
     /// @param data_size The size of the memory buffer to copy.
     StagingBuffer(const Device &device, const std::string &name, VkDeviceSize buffer_size, void *data,
                   std::size_t data_size);
-
     StagingBuffer(const StagingBuffer &) = delete;
     StagingBuffer(StagingBuffer &&) noexcept;
-
-    ~StagingBuffer() = default;
+    ~StagingBuffer() override = default;
 
     StagingBuffer &operator=(const StagingBuffer &) = delete;
     StagingBuffer &operator=(StagingBuffer &&) = delete;

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -16,8 +16,8 @@ class Swapchain {
     const wrapper::Device &m_device;
     VkSurfaceKHR m_surface{VK_NULL_HANDLE};
     VkSwapchainKHR m_swapchain{VK_NULL_HANDLE};
-    VkSurfaceFormatKHR m_surface_format;
-    VkExtent2D m_extent;
+    VkSurfaceFormatKHR m_surface_format{};
+    VkExtent2D m_extent{};
 
     std::vector<VkImage> m_swapchain_images;
     std::vector<VkImageView> m_swapchain_image_views;

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -41,7 +41,7 @@ public:
     /// @param enable_vsync True if vertical synchronization is requested, false otherwise.
     /// @param name The internal debug marker name of the VkSwapchainKHR.
     Swapchain(const Device &device, VkSurfaceKHR surface, std::uint32_t window_width, std::uint32_t window_height,
-              bool enable_vsync, const std::string &name);
+              bool enable_vsync, std::string name);
 
     Swapchain(const Swapchain &) = delete;
     Swapchain(Swapchain &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -78,11 +78,11 @@ public:
         return m_window;
     }
 
-    [[nodiscard]] int width() const {
+    [[nodiscard]] std::uint32_t width() const {
         return m_width;
     }
 
-    [[nodiscard]] int height() const {
+    [[nodiscard]] std::uint32_t height() const {
         return m_height;
     }
 };

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -68,7 +68,7 @@ public:
     void hide();
 
     /// @brief Call glfwPollEvents.
-    void poll();
+    static void poll();
 
     /// @brief Check if the window is about to close.
     /// @return ``true`` if the window will be closed.

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -64,9 +64,6 @@ public:
     /// @brief Call glfwShowWindow.
     void show();
 
-    /// @brief Call glfwHideWindow.
-    void hide();
-
     /// @brief Call glfwPollEvents.
     static void poll();
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -18,10 +18,6 @@
 
 namespace inexor::vulkan_renderer {
 
-void Application::frame_buffer_resize_callback(GLFWwindow *window, int width, int height) {
-    spdlog::debug("Frame buffer resize callback called. window width: {}, height: {}", width, height);
-}
-
 void Application::key_callback(GLFWwindow *window, int key, int scancode, int action, int mods) {
     switch (action) {
     case GLFW_PRESS:
@@ -245,7 +241,7 @@ void Application::setup_window_and_input_callbacks() {
 
     auto lambda_frame_buffer_resize_callback = [](GLFWwindow *window, int width, int height) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
-        app->frame_buffer_resize_callback(window, width, height);
+        spdlog::debug("Frame buffer resize callback called. window width: {}, height: {}", width, height);
         app->m_window_resized = true;
     };
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -141,9 +141,6 @@ void Application::load_textures() {
     assert(m_device->physical_device());
     assert(m_device->allocator());
 
-    // TODO: Refactor! use key from TOML file as name!
-    const std::size_t texture_number = 1;
-
     // Insert the new texture into the list of textures.
     std::string texture_name = "unnamed texture";
 
@@ -161,8 +158,6 @@ void Application::load_shaders() {
     if (m_vertex_shader_files.empty()) {
         spdlog::error("No vertex shaders to load!");
     }
-
-    const auto total_number_of_shaders = m_vertex_shader_files.size() + m_fragment_shader_files.size();
 
     // Loop through the list of vertex shaders and initialise all of them.
     for (const auto &vertex_shader_file : m_vertex_shader_files) {

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -30,6 +30,8 @@ void Application::key_callback(GLFWwindow *window, int key, int scancode, int ac
     case GLFW_RELEASE:
         m_input_data->release_key(key);
         break;
+    default:
+        break;
     }
 }
 
@@ -44,6 +46,8 @@ void Application::mouse_button_callback(GLFWwindow *window, int button, int acti
         break;
     case GLFW_RELEASE:
         m_input_data->release_mouse_button(button);
+        break;
+    default:
         break;
     }
 }

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -18,7 +18,7 @@
 
 namespace inexor::vulkan_renderer {
 
-void Application::key_callback(GLFWwindow *window, int key, int scancode, int action, int mods) {
+void Application::key_callback(GLFWwindow *, int key, int, int action, int) {
     switch (action) {
     case GLFW_PRESS:
         m_input_data->press_key(key);
@@ -31,11 +31,11 @@ void Application::key_callback(GLFWwindow *window, int key, int scancode, int ac
     }
 }
 
-void Application::cursor_position_callback(GLFWwindow *window, double xpos, double ypos) {
+void Application::cursor_position_callback(GLFWwindow *, double xpos, double ypos) {
     m_input_data->set_cursor_pos(xpos, ypos);
 }
 
-void Application::mouse_button_callback(GLFWwindow *window, int button, int action, int mods) {
+void Application::mouse_button_callback(GLFWwindow *, int button, int action, int) {
     switch (action) {
     case GLFW_PRESS:
         m_input_data->press_mouse_button(button);
@@ -48,7 +48,7 @@ void Application::mouse_button_callback(GLFWwindow *window, int button, int acti
     }
 }
 
-void Application::mouse_scroll_callback(GLFWwindow *window, double xoffset, double yoffset) {
+void Application::mouse_scroll_callback(GLFWwindow *, double, double yoffset) {
     m_camera->change_zoom(static_cast<float>(yoffset));
 }
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -18,7 +18,7 @@
 
 namespace inexor::vulkan_renderer {
 
-void Application::key_callback(GLFWwindow *, int key, int, int action, int) {
+void Application::key_callback(GLFWwindow * /*window*/, int key, int, int action, int /*mods*/) {
     switch (action) {
     case GLFW_PRESS:
         m_input_data->press_key(key);
@@ -31,11 +31,11 @@ void Application::key_callback(GLFWwindow *, int key, int, int action, int) {
     }
 }
 
-void Application::cursor_position_callback(GLFWwindow *, double xpos, double ypos) {
-    m_input_data->set_cursor_pos(xpos, ypos);
+void Application::cursor_position_callback(GLFWwindow * /*window*/, double x_pos, double y_pos) {
+    m_input_data->set_cursor_pos(x_pos, y_pos);
 }
 
-void Application::mouse_button_callback(GLFWwindow *, int button, int action, int) {
+void Application::mouse_button_callback(GLFWwindow * /*window*/, int button, int action, int /*mods*/) {
     switch (action) {
     case GLFW_PRESS:
         m_input_data->press_mouse_button(button);
@@ -48,8 +48,8 @@ void Application::mouse_button_callback(GLFWwindow *, int button, int action, in
     }
 }
 
-void Application::mouse_scroll_callback(GLFWwindow *, double, double yoffset) {
-    m_camera->change_zoom(static_cast<float>(yoffset));
+void Application::mouse_scroll_callback(GLFWwindow * /*window*/, double /*x_offset*/, double y_offset) {
+    m_camera->change_zoom(static_cast<float>(y_offset));
 }
 
 void Application::load_toml_configuration_file(const std::string &file_name) {

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -227,7 +227,7 @@ void Application::check_application_specific_features() {
     vkGetPhysicalDeviceFeatures(m_device->physical_device(), &graphics_card_features);
 
     // Check if anisotropic filtering is available!
-    if (!graphics_card_features.samplerAnisotropy) {
+    if (graphics_card_features.samplerAnisotropy != VK_TRUE) {
         spdlog::warn("The selected graphics card does not support anisotropic filtering!");
     } else {
         spdlog::debug("The selected graphics card does support anisotropic filtering.");
@@ -364,11 +364,11 @@ Application::Application(int argc, char **argv) {
                 +[](VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT object_type, std::uint64_t object,
                     std::size_t location, std::int32_t message_code, const char *layer_prefix, const char *message,
                     void *user_data) {
-                    if (flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
+                    if ((flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) != 0) {
                         spdlog::info(message);
-                    } else if (flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
+                    } else if ((flags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) != 0) {
                         spdlog::debug(message);
-                    } else if (flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
+                    } else if ((flags & VK_DEBUG_REPORT_ERROR_BIT_EXT) != 0) {
                         spdlog::error(message);
                     } else {
                         // This also deals with VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT.
@@ -376,7 +376,7 @@ Application::Application(int argc, char **argv) {
                     }
 
                     // Check if --stop-on-validation-message is enabled.
-                    if (static_cast<bool>(user_data)) {
+                    if (user_data != nullptr) {
                         // This feature stops command lines from overflooding with messages in case many validation
                         // layer messages are reported in a short amount of time.
                         spdlog::critical("Command line argument --stop-on-validation-message is enabled.");
@@ -393,7 +393,7 @@ Application::Application(int argc, char **argv) {
             auto vkCreateDebugReportCallbackEXT = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>( // NOLINT
                 vkGetInstanceProcAddr(m_instance->instance(), "vkCreateDebugReportCallbackEXT"));
 
-            if (vkCreateDebugReportCallbackEXT) {
+            if (vkCreateDebugReportCallbackEXT != nullptr) {
                 if (const auto result = vkCreateDebugReportCallbackEXT(m_instance->instance(), &debug_report_ci,
                                                                        nullptr, &m_debug_report_callback);
                     result != VK_SUCCESS) {

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -126,4 +126,4 @@ void Camera::update(const float delta_time) {
     }
 }
 
-}; // namespace inexor::vulkan_renderer
+} // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/fps_counter.cpp
+++ b/src/vulkan-renderer/fps_counter.cpp
@@ -8,7 +8,7 @@ std::optional<std::uint32_t> FPSCounter::update() {
     auto time_duration = std::chrono::duration<float, std::chrono::seconds::period>(current_time - m_last_time).count();
 
     if (time_duration >= m_fps_update_interval) {
-        auto fps_value = static_cast<std::uint32_t>(m_frames / time_duration);
+        auto fps_value = static_cast<std::uint32_t>(static_cast<float>(m_frames) / time_duration);
 
         m_last_time = current_time;
         m_frames = 0;

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -266,15 +266,16 @@ void ImGUIOverlay::update() {
 
     if (update_command_buffers) {
 
+        // TOOD: Implement update_vertex_buffer() and update_index_buffer().
         auto *vertex_buffer_address = static_cast<ImDrawVert *>(m_imgui_mesh->get_vertex_buffer_address());
         auto *index_buffer_address = static_cast<ImDrawIdx *>(m_imgui_mesh->get_index_buffer_address());
 
         for (std::size_t i = 0; i < imgui_draw_data->CmdListsCount; i++) {
-            const ImDrawList *cmd_list = imgui_draw_data->CmdLists[i];
+            const ImDrawList *cmd_list = imgui_draw_data->CmdLists[i]; // NOLINT
             std::memcpy(vertex_buffer_address, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
             std::memcpy(index_buffer_address, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
-            vertex_buffer_address += cmd_list->VtxBuffer.Size;
-            index_buffer_address += cmd_list->IdxBuffer.Size;
+            vertex_buffer_address += cmd_list->VtxBuffer.Size; // NOLINT
+            index_buffer_address += cmd_list->IdxBuffer.Size;  // NOLINT
         }
 
         const ImGuiIO &io = ImGui::GetIO();
@@ -341,7 +342,7 @@ void ImGUIOverlay::update() {
             std::int32_t index_offset{0};
 
             for (int32_t i = 0; i < imgui_draw_data->CmdListsCount; i++) {
-                const ImDrawList *cmd_list = imgui_draw_data->CmdLists[i];
+                const ImDrawList *cmd_list = imgui_draw_data->CmdLists[i]; // NOLINT
                 for (int32_t j = 0; j < cmd_list->CmdBuffer.Size; j++) {
                     const ImDrawCmd *imgui_draw_command = &cmd_list->CmdBuffer[j];
                     vkCmdDrawIndexed(m_command_buffers[k]->get(), imgui_draw_command->ElemCount, 1, index_offset,

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -339,7 +339,7 @@ void ImGUIOverlay::update() {
                                  VK_INDEX_TYPE_UINT16);
 
             std::int32_t vertex_offset{0};
-            std::int32_t index_offset{0};
+            std::uint32_t index_offset{0};
 
             for (int32_t i = 0; i < imgui_draw_data->CmdListsCount; i++) {
                 const ImDrawList *cmd_list = imgui_draw_data->CmdLists[i]; // NOLINT

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -10,19 +10,6 @@
 
 namespace inexor::vulkan_renderer {
 
-ImGUIOverlay::ImGUIOverlay(ImGUIOverlay &&other) noexcept
-    : m_device(other.m_device), m_swapchain(other.m_swapchain), m_scale(other.m_scale),
-      m_imgui_mesh(std::exchange(other.m_imgui_mesh, nullptr)),
-      m_imgui_texture(std::exchange(other.m_imgui_texture, nullptr)),
-      m_renderpass(std::exchange(other.m_renderpass, nullptr)),
-      m_vert_shader(std::exchange(other.m_vert_shader, nullptr)),
-      m_frag_shader(std::exchange(other.m_frag_shader, nullptr)),
-      m_command_pool(std::exchange(other.m_command_pool, nullptr)),
-      m_descriptor(std::exchange(other.m_descriptor, nullptr)), m_pipeline(std::exchange(other.m_pipeline, nullptr)),
-      m_subpass(other.m_subpass), m_vertex_count(other.m_vertex_count), m_index_count(other.m_index_count),
-      m_shaders(other.m_shaders), m_command_buffers(std::move(other.m_command_buffers)),
-      m_framebuffers(std::move(other.m_framebuffers)), m_push_const_block(other.m_push_const_block) {}
-
 ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapchain &swapchain)
     : m_device(device), m_swapchain(swapchain) {
     assert(device.device());

--- a/src/vulkan-renderer/input/keyboard_mouse_data.cpp
+++ b/src/vulkan-renderer/input/keyboard_mouse_data.cpp
@@ -2,8 +2,6 @@
 
 namespace inexor::vulkan_renderer::input {
 
-KeyboardMouseInputData::KeyboardMouseInputData() {}
-
 void KeyboardMouseInputData::press_key(const std::int32_t key) {
     m_pressed_keys[key] = true;
     keyboard_updated = true;

--- a/src/vulkan-renderer/io/byte_stream.cpp
+++ b/src/vulkan-renderer/io/byte_stream.cpp
@@ -67,7 +67,7 @@ template <>
 std::array<world::Indentation, 12> ByteStreamReader::read() {
     check_end(9);
     std::array<world::Indentation, 12> indentations;
-    auto writer = indentations.begin();
+    auto writer = indentations.begin(); // NOLINT
     const auto end = m_iter + 9;
     while (m_iter != end) {
         *writer++ = world::Indentation(*m_iter >> 2u);
@@ -103,7 +103,7 @@ void ByteStreamWriter::write(const world::Cube::Type &value) {
 
 template <>
 void ByteStreamWriter::write(const std::array<world::Indentation, 12> &value) {
-    for (auto iter = value.begin(); iter != value.end(); iter++) {
+    for (auto iter = value.begin(); iter != value.end(); iter++) { // NOLINT
         write<std::uint8_t>((iter->uid() << 2u) | ((++iter)->uid() >> 4));
         write<std::uint8_t>((iter->uid() << 4u) | ((++iter)->uid() >> 2));
         write<std::uint8_t>((iter->uid() << 6u) | ((++iter)->uid()));

--- a/src/vulkan-renderer/io/byte_stream.cpp
+++ b/src/vulkan-renderer/io/byte_stream.cpp
@@ -47,7 +47,7 @@ std::uint8_t ByteStreamReader::read() {
 template <>
 std::uint32_t ByteStreamReader::read() {
     check_end(4);
-    return (*m_iter++ << 0U) | (*m_iter++ << 8U) | (*m_iter++ << 16U) | (*m_iter++ << 24U);
+    return (*m_iter++ << 0u) | (*m_iter++ << 8u) | (*m_iter++ << 16u) | (*m_iter++ << 24u);
 }
 
 template <>
@@ -70,10 +70,10 @@ std::array<world::Indentation, 12> ByteStreamReader::read() {
     auto writer = indentations.begin();
     const auto end = m_iter + 9;
     while (m_iter != end) {
-        *writer++ = world::Indentation(*m_iter >> 2U);
-        *writer++ = world::Indentation(((*m_iter & 0b00000011U) << 4U) | (*(++m_iter) >> 4U));
-        *writer++ = world::Indentation(((*m_iter & 0b00001111U) << 2U) | (*(++m_iter) >> 6U));
-        *writer++ = world::Indentation(*m_iter++ & 0b00111111U);
+        *writer++ = world::Indentation(*m_iter >> 2u);
+        *writer++ = world::Indentation(((*m_iter & 0b00000011u) << 4u) | (*(++m_iter) >> 4u));
+        *writer++ = world::Indentation(((*m_iter & 0b00001111u) << 2u) | (*(++m_iter) >> 6u));
+        *writer++ = world::Indentation(*m_iter++ & 0b00111111u);
     }
     return indentations;
 }
@@ -85,9 +85,9 @@ void ByteStreamWriter::write(const std::uint8_t &value) {
 
 template <>
 void ByteStreamWriter::write(const std::uint32_t &value) {
-    m_buffer.emplace_back(value >> 24U);
-    m_buffer.emplace_back(value >> 16U);
-    m_buffer.emplace_back(value >> 8U);
+    m_buffer.emplace_back(value >> 24u);
+    m_buffer.emplace_back(value >> 16u);
+    m_buffer.emplace_back(value >> 8u);
     m_buffer.emplace_back(value);
 }
 
@@ -104,9 +104,9 @@ void ByteStreamWriter::write(const world::Cube::Type &value) {
 template <>
 void ByteStreamWriter::write(const std::array<world::Indentation, 12> &value) {
     for (auto iter = value.begin(); iter != value.end(); iter++) {
-        write<std::uint8_t>((iter->uid() << 2U) | ((++iter)->uid() >> 4));
-        write<std::uint8_t>((iter->uid() << 4U) | ((++iter)->uid() >> 2));
-        write<std::uint8_t>((iter->uid() << 6U) | ((++iter)->uid()));
+        write<std::uint8_t>((iter->uid() << 2u) | ((++iter)->uid() >> 4));
+        write<std::uint8_t>((iter->uid() << 4u) | ((++iter)->uid() >> 2));
+        write<std::uint8_t>((iter->uid() << 6u) | ((++iter)->uid()));
     }
 }
 } // namespace inexor::vulkan_renderer::io

--- a/src/vulkan-renderer/io/nxoc_parser.cpp
+++ b/src/vulkan-renderer/io/nxoc_parser.cpp
@@ -10,7 +10,7 @@
 
 namespace inexor::vulkan_renderer::io {
 template <>
-ByteStream NXOCParser::serialize_impl<0>(const std::shared_ptr<const world::Cube> cube) {
+ByteStream NXOCParser::serialize_impl<0>(const std::shared_ptr<const world::Cube> cube) { // NOLINT
     ByteStreamWriter writer;
     writer.write<std::string>("Inexor Octree");
     writer.write<std::uint32_t>(0);
@@ -66,7 +66,7 @@ ByteStream NXOCParser::serialize(const std::shared_ptr<const world::Cube> cube, 
     if (cube == nullptr) {
         throw std::invalid_argument("cube cannot be a nullptr.");
     }
-    switch (version) {
+    switch (version) { // NOLINT
     case 0:
         return serialize_impl<0>(cube);
     default:
@@ -80,7 +80,7 @@ std::shared_ptr<world::Cube> NXOCParser::deserialize(const ByteStream &stream) {
         throw IoException("Wrong identifier.");
     }
     const auto version = reader.read<std::uint32_t>();
-    switch (version) {
+    switch (version) { // NOLINT
     case 0:
         return deserialize_impl<0>(stream);
     default:

--- a/src/vulkan-renderer/io/nxoc_parser.cpp
+++ b/src/vulkan-renderer/io/nxoc_parser.cpp
@@ -32,7 +32,7 @@ ByteStream NXOCParser::serialize_impl<0>(const std::shared_ptr<const world::Cube
 
     iter_func(cube);
     return writer;
-};
+}
 
 template <>
 std::shared_ptr<world::Cube> NXOCParser::deserialize_impl<0>(const ByteStream &stream) {
@@ -71,7 +71,7 @@ ByteStream NXOCParser::serialize(const std::shared_ptr<const world::Cube> cube, 
         return serialize_impl<0>(cube);
     default:
         throw IoException("Unsupported octree version.");
-    };
+    }
 }
 
 std::shared_ptr<world::Cube> NXOCParser::deserialize(const ByteStream &stream) {
@@ -85,6 +85,6 @@ std::shared_ptr<world::Cube> NXOCParser::deserialize(const ByteStream &stream) {
         return deserialize_impl<0>(stream);
     default:
         throw IoException("Unsupported octree version.");
-    };
+    }
 }
 } // namespace inexor::vulkan_renderer::io

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -145,7 +145,7 @@ void RenderGraph::record_command_buffers(const RenderStage *stage, PhysicalStage
             std::array<VkClearValue, 2> clear_values{};
             if (graphics_stage->m_clears_screen) {
                 clear_values[0].color = {0, 0, 0, 0};
-                clear_values[1].depthStencil = {1.0F, 0};
+                clear_values[1].depthStencil = {1.0f, 0};
                 render_pass_bi.clearValueCount = static_cast<std::uint32_t>(clear_values.size());
                 render_pass_bi.pClearValues = clear_values.data();
             }
@@ -308,12 +308,12 @@ void RenderGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGr
     auto rasterization_state = wrapper::make_info<VkPipelineRasterizationStateCreateInfo>();
     rasterization_state.cullMode = VK_CULL_MODE_BACK_BIT;
     rasterization_state.frontFace = VK_FRONT_FACE_CLOCKWISE;
-    rasterization_state.lineWidth = 1.0F;
+    rasterization_state.lineWidth = 1.0f;
     rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
 
     // TODO(GH-203): Support multisampling again.
     auto multisample_state = wrapper::make_info<VkPipelineMultisampleStateCreateInfo>();
-    multisample_state.minSampleShading = 1.0F;
+    multisample_state.minSampleShading = 1.0f;
     multisample_state.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
     VkPipelineColorBlendAttachmentState blend_attachment{};
@@ -330,7 +330,7 @@ void RenderGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGr
     VkViewport viewport{};
     viewport.width = static_cast<float>(m_swapchain.extent().width);
     viewport.height = static_cast<float>(m_swapchain.extent().height);
-    viewport.maxDepth = 1.0F;
+    viewport.maxDepth = 1.0f;
 
     // TODO: Custom scissors?
     auto viewport_state = wrapper::make_info<VkPipelineViewportStateCreateInfo>();
@@ -413,7 +413,7 @@ void RenderGraph::compile(const RenderResource &target) {
             auto *phys = create<PhysicalBuffer>(buffer_resource, m_device.allocator(), m_device.device());
 
             const bool is_uploading_data = buffer_resource->m_data != nullptr;
-            alloc_ci.flags |= is_uploading_data ? VMA_ALLOCATION_CREATE_MAPPED_BIT : 0U;
+            alloc_ci.flags |= is_uploading_data ? VMA_ALLOCATION_CREATE_MAPPED_BIT : 0u;
             alloc_ci.usage = is_uploading_data ? VMA_MEMORY_USAGE_CPU_TO_GPU : VMA_MEMORY_USAGE_GPU_ONLY;
 
             auto buffer_ci = wrapper::make_info<VkBufferCreateInfo>();

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -145,7 +145,7 @@ void VulkanRenderer::calculate_memory_budget() {
 
     std::string memory_dump_file_name = "vma-dumps/dump.json";
     std::ofstream vma_memory_dump(memory_dump_file_name, std::ios::out);
-    vma_memory_dump.write(vma_stats_string, strlen(vma_stats_string));
+    vma_memory_dump.write(vma_stats_string, strlen(vma_stats_string)); // NOLINT
     vma_memory_dump.close();
 
     vmaFreeStatsString(m_device->allocator(), vma_stats_string);

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -99,8 +99,8 @@ void VulkanRenderer::render_frame() {
     }
 
     const auto image_index = m_swapchain->acquire_next_image(*m_image_available_semaphore);
-    m_render_graph->render(image_index, m_rendering_finished_semaphore->get(), m_image_available_semaphore->get(),
-                           m_device->graphics_queue());
+    m_render_graph->render(static_cast<int>(image_index), m_rendering_finished_semaphore->get(),
+                           m_image_available_semaphore->get(), m_device->graphics_queue());
 
     m_imgui_overlay->render(image_index);
 

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -55,7 +55,9 @@ void VulkanRenderer::setup_render_graph() {
 }
 
 void VulkanRenderer::generate_octree_indices() {
+    const auto old_vertex_count = m_octree_vertices.size();
     auto old_vertices = std::move(m_octree_vertices);
+    m_octree_vertices.clear();
     std::unordered_map<OctreeGpuVertex, std::uint16_t> vertex_map;
     for (auto &vertex : old_vertices) {
         // TODO: Use std::unordered_map::contains() when we switch to C++ 20.
@@ -66,7 +68,7 @@ void VulkanRenderer::generate_octree_indices() {
         }
         m_octree_indices.push_back(vertex_map.at(vertex));
     }
-    spdlog::trace("Reduced octree by {} vertices", old_vertices.size() - m_octree_vertices.size());
+    spdlog::trace("Reduced octree by {} vertices", old_vertices.size() - old_vertex_count);
 }
 
 void VulkanRenderer::recreate_swapchain() {

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -410,9 +410,9 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
 
             // Neither the integrated GPU nor the discrete GPU are suitable!
             return std::nullopt;
-        } else {
-            spdlog::debug("Only discrete GPUs available, no integrated graphics.");
         }
+        
+        spdlog::debug("Only discrete GPUs available, no integrated graphics.");
     }
 
     /// ATTEMPT 4

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -229,7 +229,7 @@ std::size_t VulkanSettingsDecisionMaker::rate_graphics_card(const VkPhysicalDevi
     for (std::size_t i = 0; i < graphics_card_memory_properties.memoryHeapCount; i++) {
         const auto &propertyFlag = graphics_card_memory_properties.memoryHeaps[i].flags;
 
-        if (propertyFlag & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+        if ((propertyFlag & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0) {
             // Use real GPU memory as score.
             graphics_card_score += graphics_card_memory_properties.memoryHeaps[i].size / (1000 * 1000);
         }
@@ -411,7 +411,7 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
             // Neither the integrated GPU nor the discrete GPU are suitable!
             return std::nullopt;
         }
-        
+
         spdlog::debug("Only discrete GPUs available, no integrated graphics.");
     }
 
@@ -514,7 +514,7 @@ VulkanSettingsDecisionMaker::decide_which_image_transformation_to_use(const VkPh
         throw VulkanException("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!", result);
     }
 
-    if (surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+    if ((surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) != 0) {
         // We prefer a non-rotated transform.
         pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
     } else {
@@ -543,7 +543,7 @@ VulkanSettingsDecisionMaker::find_composite_alpha_format(const VkPhysicalDevice 
     }
 
     for (auto &composite_alpha_flag : composite_alpha_flags) {
-        if (surface_capabilities.supportedCompositeAlpha & composite_alpha_flag) {
+        if ((surface_capabilities.supportedCompositeAlpha & composite_alpha_flag) != 0) {
             return composite_alpha_flag;
             break;
         };
@@ -703,7 +703,7 @@ VulkanSettingsDecisionMaker::find_graphics_queue_family(const VkPhysicalDevice &
     for (std::size_t i = 0; i < available_queue_families.size(); i++) {
         if (available_queue_families[i].queueCount > 0) {
             // Check if this queue family supports graphics.
-            if (available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            if ((available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
                 // Ok this queue family supports graphics!
                 return static_cast<std::uint32_t>(i);
             }
@@ -780,8 +780,8 @@ VulkanSettingsDecisionMaker::find_distinct_data_transfer_queue_family(const VkPh
     for (std::size_t i = 0; i < available_queue_families.size(); i++) {
         if (available_queue_families[i].queueCount > 0) {
             // A distinct transfer queue has a transfer bit set but no graphics bit.
-            if (!(available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
-                if (available_queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) {
+            if ((available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+                if ((available_queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) != 0) {
                     auto this_queue_family_index = static_cast<std::uint32_t>(i);
                     return this_queue_family_index;
                 }
@@ -816,7 +816,7 @@ VulkanSettingsDecisionMaker::find_any_data_transfer_queue_family(const VkPhysica
         if (available_queue_families[i].queueCount > 0) {
             // All we care about is VK_QUEUE_TRANSFER_BIT.
             // It is very likely that this queue family has VK_QUEUE_GRAPHICS_BIT as well!
-            if (available_queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) {
+            if ((available_queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT) != 0) {
                 auto this_queue_family_index = static_cast<std::uint32_t>(i);
                 return this_queue_family_index;
             }
@@ -852,7 +852,7 @@ VulkanSettingsDecisionMaker::find_queue_family_for_both_graphics_and_presentatio
     for (std::size_t i = 0; i < available_queue_families.size(); i++) {
         if (available_queue_families[i].queueCount > 0) {
             // Check if this queue family supports graphics.
-            if (available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            if ((available_queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0) {
                 // Ok this queue family supports graphics!
                 // Now let's check if it supports presentation.
                 VkBool32 presentation_available = 0;

--- a/src/vulkan-renderer/settings_decision_maker.cpp
+++ b/src/vulkan-renderer/settings_decision_maker.cpp
@@ -5,19 +5,15 @@
 #include <spdlog/spdlog.h>
 
 #include <cassert>
-#include <map>
 
 namespace inexor::vulkan_renderer {
 
-std::uint32_t
-VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(const VkPhysicalDevice &graphics_card,
-                                                                        const VkSurfaceKHR &surface) {
+std::uint32_t VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(VkPhysicalDevice graphics_card,
+                                                                                      VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
 
     spdlog::debug("Deciding automatically how many images in swapchain to use.");
-
-    std::uint32_t number_of_images_in_swapchain = 0;
 
     VkSurfaceCapabilitiesKHR surface_capabilities{};
 
@@ -29,7 +25,7 @@ VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(const Vk
     // TODO: Refactor! How many images do we actually need? Is triple buffering the best option?
 
     // Determine how many images in swapchain to use.
-    number_of_images_in_swapchain = surface_capabilities.minImageCount + 1;
+    std::uint32_t number_of_images_in_swapchain = surface_capabilities.minImageCount + 1;
 
     // If the maximum number of images available in swapchain is greater than our current number, chose it.
     if ((surface_capabilities.maxImageCount > 0) &&
@@ -40,8 +36,9 @@ VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(const Vk
     return number_of_images_in_swapchain;
 }
 
-std::optional<VkSurfaceFormatKHR> VulkanSettingsDecisionMaker::decide_which_surface_color_format_in_swapchain_to_use(
-    const VkPhysicalDevice &graphics_card, const VkSurfaceKHR &surface) {
+std::optional<VkSurfaceFormatKHR>
+VulkanSettingsDecisionMaker::decide_which_surface_color_format_in_swapchain_to_use(VkPhysicalDevice graphics_card,
+                                                                                   VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
 
@@ -82,42 +79,30 @@ std::optional<VkSurfaceFormatKHR> VulkanSettingsDecisionMaker::decide_which_surf
         // Currently we use VK_FORMAT_B8G8R8A8_UNORM only, since it's the norm.
         std::vector<VkFormat> accepted_formats = {
             VK_FORMAT_B8G8R8A8_UNORM
-            // Add more accepted formats here..
+            // TODO: Add more accepted formats here..
         };
 
-        bool found_acceptable_format = false;
+        // In case VK_FORMAT_B8G8R8A8_UNORM is not available select the first available color format.
+        if (!available_surface_formats.empty()) {
+            return available_surface_formats[0];
+        }
 
         // Loop through the list of available surface formats and compare with the list of acceptable formats.
-        for (auto &&surface_format : available_surface_formats) {
+        for (auto &surface_format : available_surface_formats) {
             for (auto &accepted_format : accepted_formats) {
                 if (surface_format.format == accepted_format) {
                     accepted_color_format.format = surface_format.format;
                     accepted_color_format.colorSpace = surface_format.colorSpace;
-
-                    found_acceptable_format = true;
-
-                    return accepted_color_format;
+                    return surface_format;
                 }
             }
-        }
-
-        // In case VK_FORMAT_B8G8R8A8_UNORM is not available select the first available color format.
-        if (!found_acceptable_format) {
-            if (!available_surface_formats.empty()) {
-                accepted_color_format.format = available_surface_formats[0].format;
-                accepted_color_format.colorSpace = available_surface_formats[0].colorSpace;
-
-                return accepted_color_format;
-            }
-            return std::nullopt;
         }
     }
 
     return accepted_color_format;
 }
 
-bool VulkanSettingsDecisionMaker::is_graphics_card_suitable(const VkPhysicalDevice &graphics_card,
-                                                            const VkSurfaceKHR &surface) {
+bool VulkanSettingsDecisionMaker::is_graphics_card_suitable(VkPhysicalDevice graphics_card, VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
 
@@ -194,12 +179,11 @@ bool VulkanSettingsDecisionMaker::is_graphics_card_suitable(const VkPhysicalDevi
     }
 
     // Add more suitability checks here if neccesary.
-    // ....
 
     return true;
 }
 
-VkPhysicalDeviceType VulkanSettingsDecisionMaker::graphics_card_type(const VkPhysicalDevice &graphics_card) {
+VkPhysicalDeviceType VulkanSettingsDecisionMaker::graphics_card_type(VkPhysicalDevice graphics_card) {
     assert(graphics_card);
 
     // The properties of the graphics card.
@@ -211,7 +195,7 @@ VkPhysicalDeviceType VulkanSettingsDecisionMaker::graphics_card_type(const VkPhy
     return graphics_card_properties.deviceType;
 }
 
-std::size_t VulkanSettingsDecisionMaker::rate_graphics_card(const VkPhysicalDevice &graphics_card) {
+std::size_t VulkanSettingsDecisionMaker::rate_graphics_card(VkPhysicalDevice graphics_card) {
     assert(graphics_card);
 
     // The score of the graphics card.
@@ -227,9 +211,7 @@ std::size_t VulkanSettingsDecisionMaker::rate_graphics_card(const VkPhysicalDevi
 
     // Loop through all memory heaps.
     for (std::size_t i = 0; i < graphics_card_memory_properties.memoryHeapCount; i++) {
-        const auto &propertyFlag = graphics_card_memory_properties.memoryHeaps[i].flags;
-
-        if ((propertyFlag & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0) {
+        if ((graphics_card_memory_properties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0) {
             // Use real GPU memory as score.
             graphics_card_score += graphics_card_memory_properties.memoryHeaps[i].size / (1000 * 1000);
         }
@@ -240,92 +222,86 @@ std::size_t VulkanSettingsDecisionMaker::rate_graphics_card(const VkPhysicalDevi
     return graphics_card_score;
 }
 
-std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphics_card_to_use(
-    const VkInstance &vulkan_instance, const VkSurfaceKHR &surface,
-    const std::optional<std::uint32_t> &preferred_graphics_card_index) {
+std::optional<VkPhysicalDevice>
+VulkanSettingsDecisionMaker::decide_which_graphics_card_to_use(VkInstance vulkan_instance, VkSurfaceKHR surface,
+                                                               const std::optional<std::uint32_t> preferred_gpu_index) {
     assert(vulkan_instance);
     assert(surface);
 
     // Do not assert preferred_graphics_card_index because this classifies as runtime error!
 
-    std::uint32_t number_of_available_graphics_cards = 0;
+    std::uint32_t gpu_count = 0;
 
-    // First check how many graphics cards are available.
-    if (const auto result = vkEnumeratePhysicalDevices(vulkan_instance, &number_of_available_graphics_cards, nullptr);
-        result != VK_SUCCESS) {
+    if (const auto result = vkEnumeratePhysicalDevices(vulkan_instance, &gpu_count, nullptr); result != VK_SUCCESS) {
         throw VulkanException("Error: vkEnumeratePhysicalDevices failed!", result);
     }
 
-    if (number_of_available_graphics_cards == 0) {
+    if (gpu_count == 0) {
         // In this case there are not Vulkan compatible graphics cards available!
         spdlog::error("Could not find any graphics cards!");
         return std::nullopt;
     }
 
-    // Preallocate memory for the available graphics cards.
-    std::vector<VkPhysicalDevice> available_graphics_cards(number_of_available_graphics_cards);
+    std::vector<VkPhysicalDevice> available_gpus(gpu_count);
 
     // Get information about the available graphics cards.
-    if (const auto result = vkEnumeratePhysicalDevices(vulkan_instance, &number_of_available_graphics_cards,
-                                                       available_graphics_cards.data());
+    if (const auto result = vkEnumeratePhysicalDevices(vulkan_instance, &gpu_count, available_gpus.data());
         result != VK_SUCCESS) {
         throw VulkanException("Error: vkEnumeratePhysicalDevices failed!", result);
     }
 
-    /// ATTEMPT 1
-    /// If there is only 1 graphics card available, we don't have a choice and must use that one.
-    /// The preferred graphics card index which could have been specified by the user must be either this one or an
-    /// invalid index!
-    if (number_of_available_graphics_cards == 1) {
-        spdlog::debug("Because there is only 1 graphics card available, we don't have a choice and must use that one.");
+    // ATTEMPT 1
+    // If there is only 1 graphics card available, we don't have a choice and must use that one.
+    // The preferred graphics card index which could have been specified by the user must be either this one or an
+    // invalid index!
+    if (gpu_count == 1) {
+        spdlog::debug("Because there is only 1 graphics card available, we don't have a choice and must use that one");
 
         // Did the user specify a preferred GPU by command line argument?
         // If so, let's take a look at what he wanted us to use.
         // This does not matter in any way in this case.
-        if (preferred_graphics_card_index) {
+        if (preferred_gpu_index) {
             // Since we only have one graphics card to choose from, index 0 is our only option.
-            if (0 != *preferred_graphics_card_index) {
-                spdlog::debug("Ignoring command line argument -gpu {} because there is only one GPU to chose from.",
-                              *preferred_graphics_card_index);
+            if (0 != *preferred_gpu_index) {
+                spdlog::debug("Ignoring command line argument -gpu {} because there is only one GPU to chose from",
+                              *preferred_gpu_index);
             }
-            if (!(*preferred_graphics_card_index >= 0 &&
-                  *preferred_graphics_card_index < available_graphics_cards.size())) {
+            if (!(*preferred_gpu_index >= 0 && *preferred_gpu_index < available_gpus.size())) {
                 spdlog::warn("Warning: Array index for selected graphics card would have been invalid anyways!");
             }
         }
 
-        if (is_graphics_card_suitable(available_graphics_cards[0], surface)) {
+        if (is_graphics_card_suitable(available_gpus[0], surface)) {
             spdlog::debug("The only graphics card available is suitable for the application!");
-            spdlog::debug("Score: {}", rate_graphics_card(available_graphics_cards[0]));
-            return available_graphics_cards[0];
+            spdlog::debug("Score: {}", rate_graphics_card(available_gpus[0]));
+            return available_gpus[0];
         }
+
         spdlog::error("Error: The only graphics card available is unsuitable for the application's purposes!");
         return std::nullopt;
     }
 
-    /// ATTEMPT 2
-    /// There is more than 1 graphics cards available, but the user specified which one should be preferred.
-    /// It is important to note that the preferred graphics card can be unsuitable for the application's purposes
-    /// though! If that is the case, the automatic graphics card selection mechanism is responsible for finding a
-    /// suitable graphics card. The user can also simply change the command line argument and try to prefer another
-    /// graphics card.
-    if (preferred_graphics_card_index) {
+    // ATTEMPT 2
+    // There is more than 1 graphics cards available, but the user specified which one should be preferred.
+    // It is important to note that the preferred graphics card can be unsuitable for the application's purposes
+    // though! If that is the case, the automatic graphics card selection mechanism is responsible for finding a
+    // suitable graphics card. The user can also simply change the command line argument and try to prefer another
+    // graphics card.
+    if (preferred_gpu_index) {
         // Check if this array index is valid!
-        if (*preferred_graphics_card_index >= 0 && preferred_graphics_card_index < number_of_available_graphics_cards) {
-            spdlog::debug("Command line parameter for prefered GPU specified. Checking graphics card with index {}.",
-                          *preferred_graphics_card_index);
+        if (*preferred_gpu_index >= 0 && preferred_gpu_index < gpu_count) {
+            spdlog::debug("Command line parameter for prefered GPU specified. Checking graphics card with index {}",
+                          *preferred_gpu_index);
 
             // Check if the graphics card selected by the user meets all the criteria we need!
-            if (VulkanSettingsDecisionMaker::is_graphics_card_suitable(
-                    available_graphics_cards[*preferred_graphics_card_index], surface)) {
+            if (is_graphics_card_suitable(available_gpus[*preferred_gpu_index], surface)) {
                 // We are done: Use the graphics card which was specified by the user's command line argument.
-                spdlog::debug("The prefered graphics card is suitable for this application.");
-                spdlog::debug("Score: {}",
-                              rate_graphics_card(available_graphics_cards[*preferred_graphics_card_index]));
-                return available_graphics_cards[*preferred_graphics_card_index];
+                spdlog::debug("The prefered graphics card is suitable for this application");
+                spdlog::debug("Score: {}", rate_graphics_card(available_gpus[*preferred_gpu_index]));
+                return available_gpus[*preferred_gpu_index];
             }
             spdlog::error("The preferred graphics card with index {} is not suitable for this application!",
-                          *preferred_graphics_card_index);
+                          *preferred_gpu_index);
             spdlog::error("The array index is valid, but this graphics card does not fulfill all requirements!");
 
             // We are NOT done!
@@ -334,55 +310,54 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
         } else {
             // No, this array index for available_graphics_cards is invalid!
             spdlog::error("Error: Invalid command line argument! Graphics card array index {} is invalid!",
-                          *preferred_graphics_card_index);
+                          *preferred_gpu_index);
 
             // We are NOT done!
             // Try to select the best graphics card automatically!
         }
     } else {
         // Give the user a little hint message.
-        spdlog::debug("Info: No command line argument for preferred graphics card given.");
-        spdlog::debug("You have more than 1 graphics card available on your machine.");
-        spdlog::debug("Specify which one to use by passing -gpu <number> as command line argument.");
-        spdlog::debug("Please be aware that the first index is 0.");
+        spdlog::debug("Info: No command line argument for preferred graphics card given");
+        spdlog::debug("You have more than 1 graphics card available on your machine");
+        spdlog::debug("Specify which one to use by passing -gpu <number> as command line argument");
+        spdlog::debug("Please be aware that the first index is 0");
     }
 
-    /// ATTEMPT 3
+    // ATTEMPT 3
     // There are more than 1 graphics card available and the user did not specify which one to use.
     // If there are exactly 2 graphics card and one of them is VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU and the other one
     // is VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, we should prefere the real graphics card over the integrated one.
     // We also need to check if the VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU one is suitable though!
     // If that is not the case, we check if the VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU is suitable and use it instead.
     // If both are unsuitable, there are no suitable graphics cards available on this machine!
-    if (number_of_available_graphics_cards == 2) {
-        bool integrated_graphics_card_exists = false;
-        bool discrete_graphics_card_exists = false;
+    if (gpu_count == 2) {
+        bool integrated_gpu_exists = false;
+        bool discrete_gpu_exists = false;
 
         // Both indices are available because number_of_available_graphics_cards is 2.
-        const VkPhysicalDeviceType gpu_type_1 = graphics_card_type(available_graphics_cards[0]);
-        const VkPhysicalDeviceType gpu_type_2 = graphics_card_type(available_graphics_cards[1]);
+        const VkPhysicalDeviceType gpu_type_1 = graphics_card_type(available_gpus[0]);
+        const VkPhysicalDeviceType gpu_type_2 = graphics_card_type(available_gpus[1]);
 
-        if (VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_1 || VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_2) {
-            discrete_graphics_card_exists = true;
+        if (gpu_type_1 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || gpu_type_2 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+            discrete_gpu_exists = true;
         }
 
-        if (VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU == gpu_type_1 ||
-            VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU == gpu_type_2) {
-            integrated_graphics_card_exists = true;
+        if (gpu_type_1 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU || gpu_type_2 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+            integrated_gpu_exists = true;
         }
 
-        if (discrete_graphics_card_exists && integrated_graphics_card_exists) {
+        if (discrete_gpu_exists && integrated_gpu_exists) {
             // Try to prefer the discrete graphics card over the integrated one!
-            VkPhysicalDevice discrete_gpu;
-            VkPhysicalDevice integrated_GPU = nullptr;
+            VkPhysicalDevice discrete_gpu{nullptr};
+            VkPhysicalDevice integrated_gpu{nullptr};
 
-            if (VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_1) {
-                discrete_gpu = available_graphics_cards[0];
-                integrated_GPU = available_graphics_cards[1];
-            } else if (VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU == gpu_type_2) {
+            if (gpu_type_1 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+                discrete_gpu = available_gpus[0];
+                integrated_gpu = available_gpus[1];
+            } else if (gpu_type_2 == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
                 // The other way around.
-                discrete_gpu = available_graphics_cards[1];
-                integrated_GPU = available_graphics_cards[0];
+                discrete_gpu = available_gpus[1];
+                integrated_gpu = available_gpus[0];
             }
 
             // Usually integrated GPUs which do not support Vulkan are not visible to Vulkan's
@@ -391,20 +366,20 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
 
             // Ok, so try to prefer the discrete GPU over the integrated GPU.
             if (is_graphics_card_suitable(discrete_gpu, surface)) {
-                spdlog::debug("You have 2 GPUs. The discrete GPU (real graphics card) is suitable for the application. "
+                spdlog::debug("You have 2 GPUs. The discrete GPU (real graphics card) is suitable for the application"
                               "The integrated GPU is not!");
                 spdlog::debug("Score: {}", rate_graphics_card(discrete_gpu));
 
                 return discrete_gpu;
             }
             // Ok, so the discrete GPU is unsuitable. What about the integrated GPU?
-            if (is_graphics_card_suitable(integrated_GPU, surface)) {
+            if (is_graphics_card_suitable(integrated_gpu, surface)) {
                 spdlog::debug("You have 2 GPUs. Surprisingly, the integrated one is suitable for the application. The "
                               "discrete GPU is not!");
-                spdlog::debug("Score: {}", rate_graphics_card(integrated_GPU));
+                spdlog::debug("Score: {}", rate_graphics_card(integrated_gpu));
 
                 // This might be a very rare case though.
-                return integrated_GPU;
+                return integrated_gpu;
             }
             spdlog::critical("Neither the integrated GPU nor the discrete GPU are suitable!");
 
@@ -412,23 +387,23 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
             return std::nullopt;
         }
 
-        spdlog::debug("Only discrete GPUs available, no integrated graphics.");
+        spdlog::debug("Only discrete GPUs available, no integrated graphics");
     }
 
-    /// ATTEMPT 4
-    /// - There are more than 2 graphics cards available.
-    /// - Some of them might be suitable for the application.
-    /// - The user did no specify a command line argument to prefer a certain graphics card.
-    /// - It's not like there are 2 GPUs, one of them a real graphics card and another one an integrated one.
-    /// We now have to sort out all the GPU which are unsuitable for the application's purposes.
-    /// After this we have to rank them by a score!
+    // ATTEMPT 4
+    // - There are more than 2 graphics cards available.
+    // - Some of them might be suitable for the application.
+    // - The user did no specify a command line argument to prefer a certain graphics card.
+    // - It's not like there are 2 GPUs, one of them a real graphics card and another one an integrated one.
+    // We now have to sort out all the GPU which are unsuitable for the application's purposes.
+    // After this we have to rank them by a score!
 
     // The suitable graphics cards (by array index).
     std::vector<std::size_t> suitable_graphics_cards;
 
     // Loop through all available graphics cards and sort out the unsuitable ones.
-    for (std::size_t i = 0; i < number_of_available_graphics_cards; i++) {
-        if (VulkanSettingsDecisionMaker::is_graphics_card_suitable(available_graphics_cards[i], surface)) {
+    for (std::size_t i = 0; i < gpu_count; i++) {
+        if (is_graphics_card_suitable(available_gpus[i], surface)) {
             spdlog::debug("Adding graphics card index {} to the list of suitable graphics cards", i);
 
             // Add this graphics card to the list of suitable graphics cards.
@@ -440,72 +415,56 @@ std::optional<VkPhysicalDevice> VulkanSettingsDecisionMaker::decide_which_graphi
     }
 
     // How many graphics cards have been sorted out?
-    const auto how_many_graphics_card_disqualified =
-        number_of_available_graphics_cards - suitable_graphics_cards.size();
+    const auto qualified_gpu_count = gpu_count - suitable_graphics_cards.size();
 
-    if (how_many_graphics_card_disqualified > 0) {
-        spdlog::debug("{} have been disqualified because they are unsuitable for the application's purposes!",
-                      how_many_graphics_card_disqualified);
+    if (qualified_gpu_count > 0) {
+        spdlog::debug("{} gpus have been disqualified because they are unsuitable for the application's purposes!",
+                      qualified_gpu_count);
     }
 
     // We could not find any suitable graphics card!
     if (suitable_graphics_cards.empty()) {
-        spdlog::critical("Error: Could not find suitable graphics card automatically.");
+        spdlog::critical("Error: Could not find suitable graphics card automatically");
         return std::nullopt;
     }
 
     // Only 1 graphics card is suitable, let's choose that one.
     if (suitable_graphics_cards.size() == 1) {
-        spdlog::debug("There is only 1 suitable graphics card available.");
-        spdlog::debug("Score: {}", rate_graphics_card(available_graphics_cards[0]));
-
-        return available_graphics_cards[0];
+        spdlog::debug("There is only 1 suitable graphics card available");
+        spdlog::debug("Score: {}", rate_graphics_card(available_gpus[0]));
+        return available_gpus[0];
     }
 
     // We have more than one suitable graphics card.
     // There is at least one graphics card that is suitable.
 
-    // Use an ordered map to automatically rank graphics cards by score.
-    std::multimap<std::size_t, VkPhysicalDevice> graphics_cards_candidates;
+    VkPhysicalDevice highest_score_gpu{};
+    std::size_t highest_gpu_score{0};
 
-    for (const auto &candidate : available_graphics_cards) {
-        std::size_t candidate_score = rate_graphics_card(candidate);
+    for (auto *gpu_candidate : available_gpus) {
+        std::size_t gpu_score = rate_graphics_card(gpu_candidate);
 
-        if (candidate_score > 0) {
-            // Add it to the candidate map.
-            graphics_cards_candidates.insert(std::make_pair(candidate_score, candidate));
+        if (gpu_score > highest_gpu_score) {
+            highest_gpu_score = gpu_score;
+            highest_score_gpu = gpu_candidate;
         } else {
-            // This is extremely unlike but still we have to account for his.
-            spdlog::debug("A graphics card has been disqualified because it received a score of 0.");
+            spdlog::debug("A graphics card has been disqualified because it received a score of 0");
         }
     }
 
-    // The multimap already ensures that the entries are sorted by key,
-    // which is defined as the graphics card's score!
-
-    // Loop through the map using an interator and return the first graphics card which has a score greater than zero.
-    // It should be extremy unlikely that a graphics card gets a score of zero after all!
-    for (auto candidate_iterator = graphics_cards_candidates.begin();
-         candidate_iterator != graphics_cards_candidates.end(); candidate_iterator++) {
-        spdlog::debug("Score: {}", candidate_iterator->first);
-
-        // We can be sure that the candidate's score is greater than 0 because of the aforementioned code block.
-        return candidate_iterator->second;
+    if (!static_cast<bool>(highest_score_gpu)) {
+        spdlog::critical("Could no find any suitable graphics card");
+        return std::nullopt;
     }
 
-    // In this case, all available graphics cards are suitable for the application's purposes
-    // but scored 0 points in the graphics card score. This is extremely unlikely!
-    return std::nullopt;
+    return highest_score_gpu;
 }
 
 VkSurfaceTransformFlagsKHR
-VulkanSettingsDecisionMaker::decide_which_image_transformation_to_use(const VkPhysicalDevice &graphics_card,
-                                                                      const VkSurfaceKHR &surface) {
+VulkanSettingsDecisionMaker::decide_which_image_transformation_to_use(VkPhysicalDevice graphics_card,
+                                                                      VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
-
-    // Bitmask of VkSurfaceTransformFlagBitsKHR.
-    VkSurfaceTransformFlagsKHR pre_transform{};
 
     VkSurfaceCapabilitiesKHR surface_capabilities{};
 
@@ -514,19 +473,19 @@ VulkanSettingsDecisionMaker::decide_which_image_transformation_to_use(const VkPh
         throw VulkanException("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!", result);
     }
 
-    if ((surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) != 0) {
-        // We prefer a non-rotated transform.
-        pre_transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-    } else {
-        pre_transform = surface_capabilities.currentTransform;
+    if ((surface_capabilities.supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) == 0) {
+        return surface_capabilities.currentTransform;
     }
 
-    return pre_transform;
+    return VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 }
 
 std::optional<VkCompositeAlphaFlagBitsKHR>
-VulkanSettingsDecisionMaker::find_composite_alpha_format(const VkPhysicalDevice selected_graphics_card,
-                                                         const VkSurfaceKHR surface) {
+VulkanSettingsDecisionMaker::find_composite_alpha_format(VkPhysicalDevice selected_graphics_card,
+                                                         VkSurfaceKHR surface) {
+    assert(selected_graphics_card);
+    assert(surface);
+
     const std::vector<VkCompositeAlphaFlagBitsKHR> composite_alpha_flags = {
         VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
         VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
@@ -542,19 +501,18 @@ VulkanSettingsDecisionMaker::find_composite_alpha_format(const VkPhysicalDevice 
         throw VulkanException("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!", result);
     }
 
-    for (auto &composite_alpha_flag : composite_alpha_flags) {
+    for (const auto &composite_alpha_flag : composite_alpha_flags) {
         if ((surface_capabilities.supportedCompositeAlpha & composite_alpha_flag) != 0) {
             return composite_alpha_flag;
-            break;
-        };
+        }
     }
 
     return std::nullopt;
 }
 
 std::optional<VkPresentModeKHR>
-VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(const VkPhysicalDevice &graphics_card,
-                                                                   const VkSurfaceKHR &surface, bool vsync) {
+VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(VkPhysicalDevice graphics_card, VkSurfaceKHR surface,
+                                                                   const bool vsync) {
     assert(graphics_card);
     assert(surface);
 
@@ -652,9 +610,8 @@ VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(const VkPhysi
     return std::nullopt;
 }
 
-SwapchainSettings VulkanSettingsDecisionMaker::decide_swapchain_extent(const VkPhysicalDevice &graphics_card,
-                                                                       const VkSurfaceKHR &surface,
-                                                                       std::uint32_t window_width,
+SwapchainSettings VulkanSettingsDecisionMaker::decide_swapchain_extent(VkPhysicalDevice graphics_card,
+                                                                       VkSurfaceKHR surface, std::uint32_t window_width,
                                                                        std::uint32_t window_height) {
     assert(graphics_card);
     assert(surface);
@@ -681,8 +638,7 @@ SwapchainSettings VulkanSettingsDecisionMaker::decide_swapchain_extent(const VkP
     return updated_swapchain_settings;
 }
 
-std::optional<std::uint32_t>
-VulkanSettingsDecisionMaker::find_graphics_queue_family(const VkPhysicalDevice &graphics_card) {
+std::optional<std::uint32_t> VulkanSettingsDecisionMaker::find_graphics_queue_family(VkPhysicalDevice graphics_card) {
     assert(graphics_card);
 
     std::uint32_t number_of_available_queue_families = 0;
@@ -714,9 +670,8 @@ VulkanSettingsDecisionMaker::find_graphics_queue_family(const VkPhysicalDevice &
     return std::nullopt;
 }
 
-std::optional<std::uint32_t>
-VulkanSettingsDecisionMaker::find_presentation_queue_family(const VkPhysicalDevice &graphics_card,
-                                                            const VkSurfaceKHR &surface) {
+std::optional<std::uint32_t> VulkanSettingsDecisionMaker::find_presentation_queue_family(VkPhysicalDevice graphics_card,
+                                                                                         VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
 
@@ -737,7 +692,7 @@ VulkanSettingsDecisionMaker::find_presentation_queue_family(const VkPhysicalDevi
     // Loop through all available queue families and look for a suitable one.
     for (std::size_t i = 0; i < available_queue_families.size(); i++) {
         if (available_queue_families[i].queueCount > 0) {
-            std::uint32_t this_queue_family_index = static_cast<std::uint32_t>(i);
+            const auto this_queue_family_index = static_cast<std::uint32_t>(i);
 
             VkBool32 presentation_available = 0;
 
@@ -759,7 +714,7 @@ VulkanSettingsDecisionMaker::find_presentation_queue_family(const VkPhysicalDevi
 }
 
 std::optional<std::uint32_t>
-VulkanSettingsDecisionMaker::find_distinct_data_transfer_queue_family(const VkPhysicalDevice &graphics_card) {
+VulkanSettingsDecisionMaker::find_distinct_data_transfer_queue_family(VkPhysicalDevice graphics_card) {
     assert(graphics_card);
 
     std::uint32_t number_of_available_queue_families = 0;
@@ -794,7 +749,7 @@ VulkanSettingsDecisionMaker::find_distinct_data_transfer_queue_family(const VkPh
 }
 
 std::optional<std::uint32_t>
-VulkanSettingsDecisionMaker::find_any_data_transfer_queue_family(const VkPhysicalDevice &graphics_card) {
+VulkanSettingsDecisionMaker::find_any_data_transfer_queue_family(VkPhysicalDevice graphics_card) {
     assert(graphics_card);
 
     std::uint32_t number_of_available_queue_families = 0;
@@ -829,8 +784,8 @@ VulkanSettingsDecisionMaker::find_any_data_transfer_queue_family(const VkPhysica
 }
 
 std::optional<std::uint32_t>
-VulkanSettingsDecisionMaker::find_queue_family_for_both_graphics_and_presentation(const VkPhysicalDevice &graphics_card,
-                                                                                  const VkSurfaceKHR &surface) {
+VulkanSettingsDecisionMaker::find_queue_family_for_both_graphics_and_presentation(VkPhysicalDevice graphics_card,
+                                                                                  VkSurfaceKHR surface) {
     assert(graphics_card);
     assert(surface);
 
@@ -880,10 +835,15 @@ VulkanSettingsDecisionMaker::find_queue_family_for_both_graphics_and_presentatio
     return std::nullopt;
 }
 
-std::optional<VkFormat>
-VulkanSettingsDecisionMaker::find_depth_buffer_format(const VkPhysicalDevice &graphics_card,
-                                                      const std::vector<VkFormat> &formats, const VkImageTiling tiling,
-                                                      const VkFormatFeatureFlags feature_flags) {
+std::optional<VkFormat> VulkanSettingsDecisionMaker::find_depth_buffer_format(VkPhysicalDevice graphics_card,
+                                                                              const std::vector<VkFormat> &formats,
+                                                                              VkImageTiling tiling,
+                                                                              VkFormatFeatureFlags feature_flags) {
+    assert(graphics_card);
+    assert(!formats.empty());
+    assert(tiling);
+    assert(feature_flags);
+
     spdlog::debug("Trying to find appropriate format for depth buffer.");
 
     for (const auto &format : formats) {

--- a/src/vulkan-renderer/tools/cla_parser.cpp
+++ b/src/vulkan-renderer/tools/cla_parser.cpp
@@ -7,12 +7,12 @@
 namespace inexor::vulkan_renderer::tools {
 
 template <>
-int CommandLineArgumentValue::as() const {
+[[nodiscard]] int CommandLineArgumentValue::as() const {
     return std::stoi(m_value);
 }
 
 template <>
-bool CommandLineArgumentValue::as() const {
+[[nodiscard]] bool CommandLineArgumentValue::as() const {
     if (m_value == "false") {
         return false;
     }
@@ -23,7 +23,7 @@ bool CommandLineArgumentValue::as() const {
 }
 
 template <>
-std::uint32_t CommandLineArgumentValue::as() const {
+[[nodiscard]] std::uint32_t CommandLineArgumentValue::as() const {
     return static_cast<std::uint32_t>(as<int>());
 }
 

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -42,12 +42,10 @@ bool File::load_file(const std::string &file_name) {
         spdlog::debug("File {} has been closed.", file_name.c_str());
 
         return true;
-    } else {
-        spdlog::error("Could not open shader!");
-        return false;
     }
 
-    return true;
+    spdlog::error("Could not open shader!");
+    return false;
 }
 
 } // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -7,14 +7,6 @@
 
 namespace inexor::vulkan_renderer::tools {
 
-const std::size_t File::file_size() const {
-    return m_file_size;
-}
-
-const std::vector<char> &File::file_data() const {
-    return m_file_data;
-}
-
 bool File::load_file(const std::string &file_name) {
     assert(!file_name.empty());
 

--- a/src/vulkan-renderer/tools/file.cpp
+++ b/src/vulkan-renderer/tools/file.cpp
@@ -25,7 +25,7 @@ bool File::load_file(const std::string &file_name) {
         spdlog::debug("File {} has been opened.", file_name);
 
         // Read the size of the file.
-        m_file_size = file_to_load.tellg();
+        const auto file_size = file_to_load.tellg();
 
         // Preallocate memory for the file buffer.
         m_file_data.resize(m_file_size);
@@ -34,7 +34,9 @@ bool File::load_file(const std::string &file_name) {
         file_to_load.seekg(0, std::ios::beg);
 
         // Read the file data.
-        file_to_load.read(m_file_data.data(), m_file_size);
+        file_to_load.read(m_file_data.data(), file_size);
+
+        m_file_size = static_cast<std::size_t>(file_size);
 
         // Close the file stream.
         file_to_load.close();

--- a/src/vulkan-renderer/vk_tools/gpu_info.cpp
+++ b/src/vulkan-renderer/vk_tools/gpu_info.cpp
@@ -49,7 +49,7 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
         spdlog::debug("Timestamp valid bits: {}", queue_family_properties[i].timestampValidBits);
 
         for (const auto &queue_bit : queue_bits) {
-            if (queue_family_properties[i].queueFlags & queue_bit) {
+            if ((queue_family_properties[i].queueFlags & queue_bit) != 0) {
                 spdlog::debug("{}", queue_flag_bit_to_string(queue_bit));
             }
         }
@@ -339,7 +339,7 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
         spdlog::debug("[{}] Heap index: {}", i, gpu_mem_properties.memoryTypes[i].heapIndex);
 
         for (const auto &mem_prop_flag : mem_prop_flags) {
-            if (gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag) {
+            if ((gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag) != 0) {
                 spdlog::debug("{}", memory_property_flag_to_string(mem_prop_flag));
             }
         }
@@ -352,7 +352,7 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
         spdlog::debug("Heap [{}], memory size: {}", i, gpu_mem_properties.memoryHeaps[i].size / (1000 * 1000));
 
         for (const auto &mem_heap_prop_flag : mem_heap_prop_flags) {
-            if (gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag) {
+            if ((gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag) != 0) {
                 spdlog::debug("{}", memory_heap_flag_to_string(mem_heap_prop_flag));
             }
         }

--- a/src/vulkan-renderer/vk_tools/gpu_info.cpp
+++ b/src/vulkan-renderer/vk_tools/gpu_info.cpp
@@ -40,7 +40,7 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceQueueFamilyProperties(gpu, &queue_family_count, queue_family_properties.data());
 
-    constexpr std::array queue_bits{VK_QUEUE_GRAPHICS_BIT, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT,
+    constexpr std::array QUEUE_BITS{VK_QUEUE_GRAPHICS_BIT, VK_QUEUE_COMPUTE_BIT, VK_QUEUE_TRANSFER_BIT,
                                     VK_QUEUE_SPARSE_BINDING_BIT, VK_QUEUE_PROTECTED_BIT};
 
     for (std::size_t i = 0; i < queue_family_count; i++) {
@@ -48,7 +48,7 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
         spdlog::debug("Queue count: {}", queue_family_properties[i].queueCount);
         spdlog::debug("Timestamp valid bits: {}", queue_family_properties[i].timestampValidBits);
 
-        for (const auto &queue_bit : queue_bits) {
+        for (const auto &queue_bit : QUEUE_BITS) {
             if ((queue_family_properties[i].queueFlags & queue_bit) != 0) {
                 spdlog::debug("{}", queue_flag_bit_to_string(queue_bit));
             }
@@ -329,7 +329,7 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
     spdlog::debug("Number of memory types: {}", gpu_mem_properties.memoryTypeCount);
     spdlog::debug("Number of heap types: {}", gpu_mem_properties.memoryHeapCount);
 
-    constexpr std::array mem_prop_flags{
+    constexpr std::array MEM_PROP_FLAGS{
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
         VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,       VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
         VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT,    VK_MEMORY_PROPERTY_PROTECTED_BIT,
@@ -338,20 +338,20 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
     for (std::size_t i = 0; i < gpu_mem_properties.memoryTypeCount; i++) {
         spdlog::debug("[{}] Heap index: {}", i, gpu_mem_properties.memoryTypes[i].heapIndex);
 
-        for (const auto &mem_prop_flag : mem_prop_flags) {
+        for (const auto &mem_prop_flag : MEM_PROP_FLAGS) {
             if ((gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag) != 0) {
                 spdlog::debug("{}", memory_property_flag_to_string(mem_prop_flag));
             }
         }
     }
 
-    constexpr std::array mem_heap_prop_flags{VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, VK_MEMORY_HEAP_MULTI_INSTANCE_BIT,
+    constexpr std::array MEM_HEAP_PROP_FLAGS{VK_MEMORY_HEAP_DEVICE_LOCAL_BIT, VK_MEMORY_HEAP_MULTI_INSTANCE_BIT,
                                              VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR, VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM};
 
     for (std::size_t i = 0; i < gpu_mem_properties.memoryHeapCount; i++) {
         spdlog::debug("Heap [{}], memory size: {}", i, gpu_mem_properties.memoryHeaps[i].size / (1000 * 1000));
 
-        for (const auto &mem_heap_prop_flag : mem_heap_prop_flags) {
+        for (const auto &mem_heap_prop_flag : MEM_HEAP_PROP_FLAGS) {
             if ((gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag) != 0) {
                 spdlog::debug("{}", memory_heap_flag_to_string(mem_heap_prop_flag));
             }

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -262,15 +262,17 @@ void Cube::set_type(const Type new_type) {
         auto create_cube = [&](const glm::vec3 &offset) {
             return std::make_shared<Cube>(weak_from_this(), half_size, m_position + offset);
         };
-        // about the order look into the octree documentation
-        m_childs = {create_cube({0, 0, 0}),
-                    create_cube({0, 0, half_size}),
-                    create_cube({0, half_size, 0}),
-                    create_cube({0, half_size, half_size}),
-                    create_cube({half_size, 0, 0}),
-                    create_cube({half_size, 0, half_size}),
-                    create_cube({half_size, half_size, 0}),
-                    create_cube({half_size, half_size, half_size})};
+        // Look into octree documentation to find information about the order of subcubes in space.
+        // We can't use initializer list here because clang-tidy complains about it.
+        // To the best of our knowledge, this is a false positive.
+        m_childs[0] = create_cube({0, 0, 0});
+        m_childs[1] = create_cube({0, 0, half_size});
+        m_childs[2] = create_cube({0, half_size, 0});
+        m_childs[3] = create_cube({0, half_size, half_size});
+        m_childs[4] = create_cube({half_size, 0, 0});
+        m_childs[5] = create_cube({half_size, 0, half_size});
+        m_childs[6] = create_cube({half_size, half_size, 0});
+        m_childs[7] = create_cube({half_size, half_size, half_size});
         break;
     }
     if (m_type == Type::OCTANT && new_type != Type::OCTANT) {

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -194,7 +194,7 @@ std::shared_ptr<Cube> Cube::operator[](std::size_t idx) {
     return m_childs[idx];
 }
 
-const std::shared_ptr<const Cube> Cube::operator[](std::size_t idx) const {
+std::shared_ptr<const Cube> Cube::operator[](std::size_t idx) const {
     assert(idx <= SUB_CUBES);
     return m_childs[idx];
 }
@@ -406,23 +406,22 @@ std::vector<PolygonCache> Cube::polygons(const bool update_invalid) const {
     std::vector<PolygonCache> polygons;
     polygons.reserve(count_geometry_cubes());
 
-    std::function<void(std::shared_ptr<const world::Cube>)> collect;
     // post-order traversal
-    collect = [&collect, &polygons, &update_invalid](std::shared_ptr<const world::Cube> cube) {
-        if (cube->type() == world::Cube::Type::OCTANT) {
-            for (const auto &child : cube->childs()) {
-                collect(child);
+    std::function<void(const Cube &)> collect = [&collect, &polygons, &update_invalid](const Cube &cube) {
+        if (cube.type() == world::Cube::Type::OCTANT) {
+            for (const auto &child : cube.childs()) {
+                collect(*child);
             }
             return;
         }
-        if (!cube->m_polygon_cache_valid && update_invalid) {
-            cube->update_polygon_cache();
+        if (!cube.m_polygon_cache_valid && update_invalid) {
+            cube.update_polygon_cache();
         }
-        if (cube->m_polygon_cache != nullptr) {
-            polygons.push_back(cube->m_polygon_cache);
+        if (cube.m_polygon_cache != nullptr) {
+            polygons.push_back(cube.m_polygon_cache);
         }
     };
-    collect(this->shared_from_this());
+    collect(*this);
     return polygons;
 }
 } // namespace inexor::vulkan_renderer::world

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -321,6 +321,8 @@ void Cube::rotate(const RotationAxis::Type &axis, int rotations) {
     case 3:
         rotate<3>(axis);
         break;
+    default:
+        break;
     }
 }
 

--- a/src/vulkan-renderer/world/cube.cpp
+++ b/src/vulkan-renderer/world/cube.cpp
@@ -59,14 +59,22 @@ std::array<glm::vec3, 8> Cube::vertices() const noexcept {
         const float step = m_size / Indentation::MAX;
         const std::array<Indentation, Cube::EDGES> &ind = m_indentations;
 
-        return {{{pos.x + ind[0].start() * step, pos.y + ind[1].start() * step, pos.z + ind[2].start() * step},
-                 {pos.x + ind[9].start() * step, pos.y + ind[4].start() * step, max.z - ind[2].end() * step},
-                 {pos.x + ind[3].start() * step, max.y - ind[1].end() * step, pos.z + ind[11].start() * step},
-                 {pos.x + ind[6].start() * step, max.y - ind[4].end() * step, max.z - ind[11].end() * step},
-                 {max.x - ind[0].end() * step, pos.y + ind[10].start() * step, pos.z + ind[5].start() * step},
-                 {max.x - ind[9].end() * step, pos.y + ind[7].start() * step, max.z - ind[5].end() * step},
-                 {max.x - ind[3].end() * step, max.y - ind[10].end() * step, pos.z + ind[8].start() * step},
-                 {max.x - ind[6].end() * step, max.y - ind[7].end() * step, max.z - ind[8].end() * step}}};
+        return {{{pos.x + static_cast<float>(ind[0].start()) * step, pos.y + static_cast<float>(ind[1].start()) * step,
+                  pos.z + static_cast<float>(ind[2].start()) * step},
+                 {pos.x + static_cast<float>(ind[9].start()) * step, pos.y + static_cast<float>(ind[4].start()) * step,
+                  max.z - static_cast<float>(ind[2].end()) * step},
+                 {pos.x + static_cast<float>(ind[3].start()) * step, max.y - static_cast<float>(ind[1].end()) * step,
+                  pos.z + static_cast<float>(ind[11].start()) * step},
+                 {pos.x + static_cast<float>(ind[6].start()) * step, max.y - static_cast<float>(ind[4].end()) * step,
+                  max.z - static_cast<float>(ind[11].end()) * step},
+                 {max.x - static_cast<float>(ind[0].end()) * step, pos.y + static_cast<float>(ind[10].start()) * step,
+                  pos.z + static_cast<float>(ind[5].start()) * step},
+                 {max.x - static_cast<float>(ind[9].end()) * step, pos.y + static_cast<float>(ind[7].start()) * step,
+                  max.z - static_cast<float>(ind[5].end()) * step},
+                 {max.x - static_cast<float>(ind[3].end()) * step, max.y - static_cast<float>(ind[10].end()) * step,
+                  pos.z + static_cast<float>(ind[8].start()) * step},
+                 {max.x - static_cast<float>(ind[6].end()) * step, max.y - static_cast<float>(ind[7].end()) * step,
+                  max.z - static_cast<float>(ind[8].end()) * step}}};
     }
     return {};
 }

--- a/src/vulkan-renderer/world/indentation.cpp
+++ b/src/vulkan-renderer/world/indentation.cpp
@@ -10,11 +10,11 @@ Indentation::Indentation(const std::uint8_t start, const std::uint8_t end) noexc
 
 Indentation::Indentation(const std::uint8_t uid) noexcept {
     assert(uid <= 44);
-    constexpr std::array<std::uint8_t, Indentation::MAX> masks{44, 42, 39, 35, 30, 24, 17, 9};
+    constexpr std::array<std::uint8_t, Indentation::MAX> MASKS{44, 42, 39, 35, 30, 24, 17, 9};
     for (std::uint8_t idx = 0; idx < Indentation::MAX; idx++) {
-        if (masks[idx] <= uid) {
+        if (MASKS[idx] <= uid) {
             m_start = Indentation::MAX - idx;
-            m_end = m_start + (uid - masks[idx]);
+            m_end = m_start + (uid - MASKS[idx]);
             return;
         }
     }

--- a/src/vulkan-renderer/world/indentation.cpp
+++ b/src/vulkan-renderer/world/indentation.cpp
@@ -60,11 +60,11 @@ std::uint8_t Indentation::offset() const noexcept {
     return this->m_end - this->m_start;
 }
 
-void Indentation::indent_start(std::int8_t steps) noexcept {
+void Indentation::indent_start(std::uint8_t steps) noexcept {
     this->set_start(this->m_start + steps);
 }
 
-void Indentation::indent_end(std::int8_t steps) noexcept {
+void Indentation::indent_end(std::uint8_t steps) noexcept {
     this->set_end(this->m_end - steps);
 }
 

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -27,9 +27,10 @@ CommandBuffer::CommandBuffer(const wrapper::Device &device, VkCommandPool comman
     m_device.set_debug_marker_name(m_command_buffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, m_name);
 }
 
-CommandBuffer::CommandBuffer(CommandBuffer &&other) noexcept
-    : m_command_buffer(std::exchange(other.m_command_buffer, nullptr)), m_device(other.m_device),
-      m_name(std::move(other.m_name)) {}
+CommandBuffer::CommandBuffer(CommandBuffer &&other) noexcept : m_device(other.m_device) {
+    m_command_buffer = std::exchange(other.m_command_buffer, nullptr);
+    m_name = std::move(other.m_name);
+}
 
 void CommandBuffer::begin(VkCommandBufferUsageFlags flags) const {
     auto begin_info = make_info<VkCommandBufferBeginInfo>();

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -11,8 +11,8 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-CommandBuffer::CommandBuffer(const wrapper::Device &device, VkCommandPool command_pool, const std::string &name)
-    : m_device(device), m_name(name) {
+CommandBuffer::CommandBuffer(const wrapper::Device &device, VkCommandPool command_pool, std::string name)
+    : m_device(device), m_name(std::move(name)) {
     auto alloc_info = make_info<VkCommandBufferAllocateInfo>();
     alloc_info.commandBufferCount = 1;
     alloc_info.commandPool = command_pool;

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -23,8 +23,9 @@ CommandPool::CommandPool(const Device &device, const std::uint32_t queue_family_
     spdlog::debug("Created command pool successfully.");
 }
 
-CommandPool::CommandPool(CommandPool &&other) noexcept
-    : m_device(other.m_device), m_command_pool(std::exchange(other.m_command_pool, nullptr)) {}
+CommandPool::CommandPool(CommandPool &&other) noexcept : m_device(other.m_device) {
+    m_command_pool = std::exchange(other.m_command_pool, nullptr);
+}
 
 CommandPool::~CommandPool() {
     vkDestroyCommandPool(m_device.device(), m_command_pool, nullptr);

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -81,10 +81,7 @@ void CpuTexture::generate_error_texture_data() {
             const int index = (x + (y * m_texture_width)) * m_texture_channels;
             const int color_id = get_color(x, y, SQUARE_DIMENSION, COLORS.size());
 
-            m_texture_data[index + 0] = COLORS[color_id][0];
-            m_texture_data[index + 1] = COLORS[color_id][1];
-            m_texture_data[index + 2] = COLORS[color_id][2];
-            m_texture_data[index + 3] = COLORS[color_id][3];
+            std::memcpy(m_texture_data, &COLORS[color_id][0], 4 * sizeof(COLORS[color_id][0]));
         }
     }
 }

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -68,7 +68,8 @@ void CpuTexture::generate_error_texture_data() {
     constexpr std::array<std::array<unsigned char, 4>, 2> COLORS{{{0xFF, 0x69, 0xB4, 0xFF}, {0x94, 0x00, 0xD3, 0xFF}}};
 
     const auto get_color = [](int x, int y, int square_dimension, std::size_t colors) -> int {
-        return (std::size_t(x / square_dimension) + std::size_t(y / square_dimension)) % colors;
+        return static_cast<int>(
+            (static_cast<std::size_t>(x / square_dimension) + static_cast<std::size_t>(y / square_dimension)) % colors);
     };
 
     // Note: Using the stb library function since we are freeing with stbi_image_free.

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -73,7 +73,7 @@ void CpuTexture::generate_error_texture_data() {
     };
 
     // Note: Using the stb library function since we are freeing with stbi_image_free.
-    m_texture_data = static_cast<stbi_uc *>(STBI_MALLOC(data_size()));
+    m_texture_data = static_cast<stbi_uc *>(STBI_MALLOC(data_size())); // NOLINT
 
     // Performance could be improved by copying complete rows after one or two rows are created with the loops.
     for (int y = 0; y < m_texture_height; y++) {

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -82,9 +82,7 @@ void CpuTexture::generate_error_texture_data() {
     // Performance could be improved by copying complete rows after one or two rows are created with the loops.
     for (int y = 0; y < m_texture_height; y++) {
         for (int x = 0; x < m_texture_width; x++) {
-            const int index = (x + (y * m_texture_width)) * m_texture_channels;
             const int color_id = get_color(x, y, SQUARE_DIMENSION, COLORS.size());
-
             std::memcpy(m_texture_data, &COLORS[color_id][0], 4 * sizeof(COLORS[color_id][0]));
         }
     }

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -45,10 +45,14 @@ CpuTexture::CpuTexture(const std::string &file_name, std::string name) : m_name(
     }
 }
 
-CpuTexture::CpuTexture(CpuTexture &&other) noexcept
-    : m_name(std::move(other.m_name)), m_texture_width(other.m_texture_width), m_texture_height(other.m_texture_height),
-      m_texture_channels(other.m_texture_channels), m_mip_levels(other.m_mip_levels),
-      m_texture_data(other.m_texture_data) {}
+CpuTexture::CpuTexture(CpuTexture &&other) noexcept {
+    m_name = std::move(other.m_name);
+    m_texture_width = other.m_texture_width;
+    m_texture_height = other.m_texture_height;
+    m_texture_channels = other.m_texture_channels;
+    m_mip_levels = other.m_mip_levels;
+    m_texture_data = other.m_texture_data;
+}
 
 CpuTexture::~CpuTexture() {
     stbi_image_free(m_texture_data);

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -39,6 +39,8 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
 
     std::vector<VkDescriptorPoolSize> pool_sizes;
 
+    pool_sizes.reserve(layout_bindings.size());
+
     for (const auto &descriptor_pool_type : layout_bindings) {
         pool_sizes.emplace_back(VkDescriptorPoolSize{descriptor_pool_type.descriptorType, swapchain_image_count});
     }

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -11,13 +11,15 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-ResourceDescriptor::ResourceDescriptor(ResourceDescriptor &&other) noexcept
-    : m_device(other.m_device), m_name(std::move(other.m_name)),
-      m_descriptor_pool(std::exchange(other.m_descriptor_pool, nullptr)),
-      m_descriptor_set_layout(std::exchange(other.m_descriptor_set_layout, nullptr)),
-      m_descriptor_set_layout_bindings(std::move(other.m_descriptor_set_layout_bindings)),
-      m_write_descriptor_sets(std::move(other.m_write_descriptor_sets)),
-      m_descriptor_sets(std::move(other.m_descriptor_sets)), m_swapchain_image_count(other.m_swapchain_image_count) {}
+ResourceDescriptor::ResourceDescriptor(ResourceDescriptor &&other) noexcept : m_device(other.m_device) {
+    m_name = std::move(other.m_name);
+    m_descriptor_pool = std::exchange(other.m_descriptor_pool, nullptr);
+    m_descriptor_set_layout = std::exchange(other.m_descriptor_set_layout, nullptr);
+    m_descriptor_set_layout_bindings = std::move(other.m_descriptor_set_layout_bindings);
+    m_write_descriptor_sets = std::move(other.m_write_descriptor_sets);
+    m_descriptor_sets = std::move(other.m_descriptor_sets);
+    m_swapchain_image_count = other.m_swapchain_image_count;
+}
 
 ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapchain_image_count,
                                        std::vector<VkDescriptorSetLayoutBinding> &&layout_bindings,

--- a/src/vulkan-renderer/wrapper/descriptor_builder.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor_builder.cpp
@@ -55,7 +55,7 @@ DescriptorBuilder &DescriptorBuilder::add_combined_image_sampler(const VkSampler
     VkWriteDescriptorSet descriptor_write{};
     descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     descriptor_write.dstSet = nullptr;
-    descriptor_write.dstBinding = 0;
+    descriptor_write.dstBinding = binding;
     descriptor_write.dstArrayElement = 0;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     descriptor_write.descriptorCount = 1;

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -9,13 +9,13 @@
 // It makes memory of all new allocations initialized to bit pattern 0xDCDCDCDC.
 // Before an allocation is destroyed, its memory is filled with bit pattern 0xEFEFEFEF.
 // Memory is automatically mapped and unmapped if necessary.
-#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
+#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1 // NOLINT
 
 // Enforce specified number of bytes as a margin before and after every allocation.
-#define VMA_DEBUG_MARGIN 16
+#define VMA_DEBUG_MARGIN 16 // NOLINT
 
 // Enable validation of contents of the margins.
-#define VMA_DEBUG_DETECT_CORRUPTION 1
+#define VMA_DEBUG_DETECT_CORRUPTION 1 // NOLINT
 
 #include <spdlog/spdlog.h>
 #include <vk_mem_alloc.h>

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -385,9 +385,11 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
     spdlog::debug("Created device successfully.");
 }
 
-Device::Device(Device &&other) noexcept
-    : m_device(std::exchange(other.m_device, nullptr)), m_graphics_card(std::exchange(other.m_graphics_card, nullptr)),
-      m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers), m_surface(other.m_surface) {}
+Device::Device(Device &&other) noexcept : m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers) {
+    m_device = std::exchange(other.m_device, nullptr);
+    m_graphics_card = std::exchange(other.m_graphics_card, nullptr);
+    m_surface = other.m_surface;
+}
 
 Device::~Device() {
     vmaDestroyAllocator(m_allocator);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -104,7 +104,7 @@ bool Device::is_presentation_supported(const VkPhysicalDevice graphics_card, con
     assert(graphics_card);
     assert(surface);
 
-    VkBool32 presentation_supported = false;
+    VkBool32 presentation_supported = VK_FALSE;
 
     // Query if presentation is supported.
     if (const auto result = vkGetPhysicalDeviceSurfaceSupportKHR(graphics_card, 0, surface, &presentation_supported);
@@ -112,7 +112,7 @@ bool Device::is_presentation_supported(const VkPhysicalDevice graphics_card, con
         throw VulkanException("Error: vkGetPhysicalDeviceSurfaceSupportKHR failed!", result);
     }
 
-    return presentation_supported;
+    return presentation_supported == VK_TRUE;
 }
 
 Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enable_vulkan_debug_markers,

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -26,7 +26,7 @@
 namespace {
 
 // TODO: Make proper use of queue priorities in the future.
-constexpr float default_queue_priority = 1.0f;
+constexpr float DEFAULT_QUEUE_PRIORITY = 1.0f;
 
 } // namespace
 
@@ -163,7 +163,7 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
         auto device_queue_ci = make_info<VkDeviceQueueCreateInfo>();
         device_queue_ci.queueFamilyIndex = *queue_family_index_for_both_graphics_and_presentation;
         device_queue_ci.queueCount = 1;
-        device_queue_ci.pQueuePriorities = &::default_queue_priority;
+        device_queue_ci.pQueuePriorities = &::DEFAULT_QUEUE_PRIORITY;
 
         queues_to_create.push_back(device_queue_ci);
     } else {
@@ -199,7 +199,7 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
         auto device_queue_ci = make_info<VkDeviceQueueCreateInfo>();
         device_queue_ci.queueFamilyIndex = m_graphics_queue_family_index;
         device_queue_ci.queueCount = 1;
-        device_queue_ci.pQueuePriorities = &::default_queue_priority;
+        device_queue_ci.pQueuePriorities = &::DEFAULT_QUEUE_PRIORITY;
 
         queues_to_create.push_back(device_queue_ci);
 
@@ -207,7 +207,7 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
         device_queue_ci = make_info<VkDeviceQueueCreateInfo>();
         device_queue_ci.queueFamilyIndex = m_present_queue_family_index;
         device_queue_ci.queueCount = 1;
-        device_queue_ci.pQueuePriorities = &::default_queue_priority;
+        device_queue_ci.pQueuePriorities = &::DEFAULT_QUEUE_PRIORITY;
 
         queues_to_create.push_back(device_queue_ci);
     }
@@ -230,7 +230,7 @@ Device::Device(const VkInstance instance, const VkSurfaceKHR surface, bool enabl
         auto device_queue_ci = make_info<VkDeviceQueueCreateInfo>();
         device_queue_ci.queueFamilyIndex = m_transfer_queue_family_index;
         device_queue_ci.queueCount = 1;
-        device_queue_ci.pQueuePriorities = &::default_queue_priority;
+        device_queue_ci.pQueuePriorities = &::DEFAULT_QUEUE_PRIORITY;
 
         queues_to_create.push_back(device_queue_ci);
     } else {

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -31,8 +31,10 @@ Fence::Fence(const wrapper::Device &device, const std::string &name, const bool 
     spdlog::debug("Created fence {} successfully.", m_name);
 }
 
-Fence::Fence(Fence &&other) noexcept
-    : m_device(other.m_device), m_fence(std::exchange(other.m_fence, nullptr)), m_name(std::move(other.m_name)) {}
+Fence::Fence(Fence &&other) noexcept : m_device(other.m_device) {
+    m_fence = std::exchange(other.m_fence, nullptr);
+    m_name = std::move(other.m_name);
+}
 
 Fence::~Fence() {
     vkDestroyFence(m_device.device(), m_fence, nullptr);

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -36,9 +36,10 @@ Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const s
     spdlog::debug("Created framebuffer {} successfully.", m_name);
 }
 
-Framebuffer::Framebuffer(Framebuffer &&other) noexcept
-    : m_device(other.m_device), m_framebuffer(std::exchange(other.m_framebuffer, nullptr)),
-      m_name(std::move(other.m_name)) {}
+Framebuffer::Framebuffer(Framebuffer &&other) noexcept : m_device(other.m_device) {
+    m_framebuffer = std::exchange(other.m_framebuffer, nullptr);
+    m_name = std::move(other.m_name);
+}
 
 Framebuffer::~Framebuffer() {
     vkDestroyFramebuffer(m_device.device(), m_framebuffer, nullptr);

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -13,8 +13,8 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
-                         const wrapper::Swapchain &swapchain, const std::string &name)
-    : m_device(device), m_name(name) {
+                         const wrapper::Swapchain &swapchain, std::string name)
+    : m_device(device), m_name(std::move(name)) {
     spdlog::trace("Creating framebuffer {}.", m_name);
 
     auto framebuffer_ci = make_info<VkFramebufferCreateInfo>();

--- a/src/vulkan-renderer/wrapper/glfw_context.cpp
+++ b/src/vulkan-renderer/wrapper/glfw_context.cpp
@@ -16,7 +16,9 @@ GLFWContext::GLFWContext() {
     spdlog::debug("Created GLFW context successfully.");
 }
 
-GLFWContext::GLFWContext(GLFWContext &&other) noexcept : m_initialized(other.m_initialized) {}
+GLFWContext::GLFWContext(GLFWContext &&other) noexcept {
+    m_initialized = other.m_initialized;
+}
 
 GLFWContext::~GLFWContext() {
     glfwTerminate();

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -63,10 +63,13 @@ GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, 
     std::memcpy(m_allocation_info.pMappedData, data, data_size);
 }
 
-GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
-    : m_name(std::move(other.m_name)), m_device(other.m_device), m_buffer(std::exchange(other.m_buffer, nullptr)),
-      m_allocation(std::exchange(other.m_allocation, nullptr)), m_allocation_info(other.m_allocation_info),
-      m_allocation_ci(other.m_allocation_ci) {}
+GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept : m_device(other.m_device) {
+    m_name = std::move(other.m_name);
+    m_buffer = std::exchange(other.m_buffer, nullptr);
+    m_allocation = std::exchange(other.m_allocation, nullptr);
+    m_allocation_info = other.m_allocation_info;
+    m_allocation_ci = other.m_allocation_ci;
+}
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
     vmaDestroyBuffer(m_device.allocator(), m_buffer, m_allocation);

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -65,8 +65,8 @@ GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, 
 
 GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
     : m_name(std::move(other.m_name)), m_device(other.m_device), m_buffer(std::exchange(other.m_buffer, nullptr)),
-      m_allocation(std::exchange(other.m_allocation, nullptr)), m_allocation_info(std::move(other.m_allocation_info)),
-      m_allocation_ci(std::move(other.m_allocation_ci)) {}
+      m_allocation(std::exchange(other.m_allocation, nullptr)), m_allocation_info(other.m_allocation_info),
+      m_allocation_ci(other.m_allocation_ci) {}
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
     vmaDestroyBuffer(m_device.allocator(), m_buffer, m_allocation);

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -28,11 +28,16 @@ GpuTexture::GpuTexture(const wrapper::Device &device, void *data, const std::siz
 }
 
 GpuTexture::GpuTexture(GpuTexture &&other) noexcept
-    : m_texture_image(std::exchange(other.m_texture_image, nullptr)), m_name(std::move(other.m_name)),
-      m_texture_width(other.m_texture_width), m_texture_height(other.m_texture_height),
-      m_texture_channels(other.m_texture_channels), m_mip_levels(other.m_mip_levels), m_device(other.m_device),
-      m_sampler(std::exchange(other.m_sampler, nullptr)), m_texture_image_format(other.m_texture_image_format),
-      m_copy_command_buffer(std::move(other.m_copy_command_buffer)) {}
+    : m_device(other.m_device), m_texture_image_format(other.m_texture_image_format),
+      m_copy_command_buffer(std::move(other.m_copy_command_buffer)) {
+    m_texture_image = std::exchange(other.m_texture_image, nullptr);
+    m_name = std::move(other.m_name);
+    m_texture_width = other.m_texture_width;
+    m_texture_height = other.m_texture_height;
+    m_texture_channels = other.m_texture_channels;
+    m_mip_levels = other.m_mip_levels;
+    m_sampler = std::exchange(other.m_sampler, nullptr);
+}
 
 GpuTexture::~GpuTexture() {
     vkDestroySampler(m_device.device(), m_sampler, nullptr);

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -55,8 +55,7 @@ void GpuTexture::create_texture(void *texture_data, const std::size_t texture_si
 
     spdlog::debug("Transitioning image layout of texture {} to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.", m_name);
 
-    transition_image_layout(m_texture_image->get(), m_texture_image_format, VK_IMAGE_LAYOUT_UNDEFINED,
-                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    transition_image_layout(m_texture_image->get(), VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     VkBufferImageCopy buffer_image_region{};
     buffer_image_region.bufferOffset = 0;
@@ -77,14 +76,13 @@ void GpuTexture::create_texture(void *texture_data, const std::size_t texture_si
 
     m_copy_command_buffer.end_recording_and_submit_command();
 
-    transition_image_layout(m_texture_image->get(), m_texture_image_format, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+    transition_image_layout(m_texture_image->get(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     create_texture_sampler();
 }
 
-void GpuTexture::transition_image_layout(VkImage image, VkFormat format, VkImageLayout old_layout,
-                                         VkImageLayout new_layout) {
+void GpuTexture::transition_image_layout(VkImage image, VkImageLayout old_layout, VkImageLayout new_layout) {
 
     auto barrier = make_info<VkImageMemoryBarrier>();
     barrier.oldLayout = old_layout;

--- a/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
+++ b/src/vulkan-renderer/wrapper/graphics_pipeline.cpp
@@ -10,9 +10,11 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-GraphicsPipeline::GraphicsPipeline(GraphicsPipeline &&other) noexcept
-    : m_device(other.m_device), graphics_pipeline(std::exchange(other.graphics_pipeline, nullptr)),
-      pipeline_cache(std::exchange(other.pipeline_cache, nullptr)), name(std::move(other.name)) {}
+GraphicsPipeline::GraphicsPipeline(GraphicsPipeline &&other) noexcept : m_device(other.m_device) {
+    graphics_pipeline = std::exchange(other.graphics_pipeline, nullptr);
+    pipeline_cache = std::exchange(other.pipeline_cache, nullptr);
+    name = std::move(other.name);
+}
 
 GraphicsPipeline::GraphicsPipeline(const Device &device, const VkPipelineLayout pipeline_layout,
                                    const VkRenderPass render_pass,

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -73,10 +73,14 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
     m_device.set_debug_marker_name(m_image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
 }
 
-Image::Image(Image &&other) noexcept
-    : m_device(other.m_device), m_allocation(other.m_allocation), m_allocation_info(other.m_allocation_info),
-      m_image(other.m_image), m_format(other.m_format), m_image_view(other.m_image_view),
-      m_name(std::move(other.m_name)) {}
+Image::Image(Image &&other) noexcept : m_device(other.m_device) {
+    m_allocation = other.m_allocation;
+    m_allocation_info = other.m_allocation_info;
+    m_image = other.m_image;
+    m_format = other.m_format;
+    m_image_view = other.m_image_view;
+    m_name = std::move(other.m_name);
+}
 
 Image::~Image() {
     vkDestroyImageView(m_device.device(), m_image_view, nullptr);

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -214,7 +214,9 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     spdlog::debug("Validation layers are requested. RenderDoc instance layer is not requested.");
 }
 
-Instance::Instance(Instance &&other) noexcept : m_instance(std::exchange(other.m_instance, nullptr)) {}
+Instance::Instance(Instance &&other) noexcept {
+    m_instance = std::exchange(other.m_instance, nullptr);
+}
 
 Instance::~Instance() {
     vkDestroyInstance(m_instance, nullptr);

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -67,8 +67,8 @@ bool Instance::is_extension_supported(const std::string &extension_name) {
 Instance::Instance(const std::string &application_name, const std::string &engine_name,
                    const std::uint32_t application_version, const std::uint32_t engine_version,
                    const std::uint32_t vulkan_api_version, bool enable_validation_layers,
-                   bool enable_renderdoc_instance_layer, std::vector<std::string> requested_instance_extensions,
-                   std::vector<std::string> requested_instance_layers) {
+                   bool enable_renderdoc_instance_layer, const std::vector<std::string> &requested_instance_extensions,
+                   const std::vector<std::string> &requested_instance_layers) {
     assert(!application_name.empty());
     assert(!engine_name.empty());
 

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -116,8 +116,8 @@ Instance::Instance(const std::string &application_name, const std::string &engin
 
     // Add all instance extensions which are required by GLFW to our wishlist.
     for (std::size_t i = 0; i < glfw_extension_count; i++) {
-        spdlog::debug(glfw_extensions[i]);
-        instance_extension_wishlist.push_back(glfw_extensions[i]);
+        spdlog::debug(glfw_extensions[i]);                         // NOLINT
+        instance_extension_wishlist.push_back(glfw_extensions[i]); // NOLINT
     }
 
     // We have to check which instance extensions of our wishlist are available on the current system!

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -66,8 +66,8 @@ bool Instance::is_extension_supported(const std::string &extension_name) {
 
 Instance::Instance(const std::string &application_name, const std::string &engine_name,
                    const std::uint32_t application_version, const std::uint32_t engine_version,
-                   const std::uint32_t vulkan_api_version, bool enable_validation_layers,
-                   bool enable_renderdoc_instance_layer, const std::vector<std::string> &requested_instance_extensions,
+                   const std::uint32_t vulkan_api_version, bool enable_validation_layers, bool enable_renderdoc_layer,
+                   const std::vector<std::string> &requested_instance_extensions,
                    const std::vector<std::string> &requested_instance_layers) {
     assert(!application_name.empty());
     assert(!engine_name.empty());
@@ -144,7 +144,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
     // RenderDoc is a very useful open source graphics debugger for Vulkan and other APIs.
     // Not using it all the time during development is fine, but as soon as something crashes
     // you should enable it, take a snapshot and look up what's wrong.
-    if (enable_renderdoc_instance_layer) {
+    if (enable_renderdoc_layer) {
         instance_layers_wishlist.push_back("VK_LAYER_RENDERDOC_Capture");
     }
 

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -19,8 +19,10 @@ OnceCommandBuffer::OnceCommandBuffer(const Device &device, const VkQueue queue, 
 }
 
 OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept
-    : m_device(other.m_device), m_queue(other.m_queue), m_command_pool(std::move(other.m_command_pool)),
-      m_command_buffer(std::exchange(other.m_command_buffer, nullptr)), m_recording_started(other.m_recording_started) {
+    : m_device(other.m_device), m_command_pool(std::move(other.m_command_pool)) {
+    m_queue = other.m_queue;
+    m_command_buffer = std::exchange(other.m_command_buffer, nullptr);
+    m_recording_started = other.m_recording_started;
 }
 
 OnceCommandBuffer::~OnceCommandBuffer() {

--- a/src/vulkan-renderer/wrapper/renderpass.cpp
+++ b/src/vulkan-renderer/wrapper/renderpass.cpp
@@ -9,8 +9,10 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-RenderPass::RenderPass(RenderPass &&other) noexcept
-    : m_device(other.m_device), renderpass(std::exchange(other.renderpass, nullptr)), name(std::move(other.name)) {}
+RenderPass::RenderPass(RenderPass &&other) noexcept : m_device(other.m_device) {
+    renderpass = std::exchange(other.renderpass, nullptr);
+    name = std::move(other.name);
+}
 
 RenderPass::RenderPass(const Device &device, const std::vector<VkAttachmentDescription> &attachments,
                        const std::vector<VkSubpassDependency> &dependencies,

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -29,9 +29,10 @@ Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(d
     spdlog::debug("Created semaphore successfully.");
 }
 
-Semaphore::Semaphore(Semaphore &&other) noexcept
-    : m_device(other.m_device), m_semaphore(std::exchange(other.m_semaphore, nullptr)),
-      m_name(std::move(other.m_name)) {}
+Semaphore::Semaphore(Semaphore &&other) noexcept : m_device(other.m_device) {
+    m_semaphore = std::exchange(other.m_semaphore, nullptr);
+    m_name = std::move(other.m_name);
+}
 
 Semaphore::~Semaphore() {
     vkDestroySemaphore(m_device.device(), m_semaphore, nullptr);

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -64,9 +64,12 @@ Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std
     m_device.set_debug_marker_name(m_shader_module, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
 }
 
-Shader::Shader(Shader &&other) noexcept
-    : m_device(other.m_device), m_type(other.m_type), m_name(std::move(other.m_name)),
-      m_entry_point(std::move(other.m_entry_point)), m_shader_module(std::exchange(other.m_shader_module, nullptr)) {}
+Shader::Shader(Shader &&other) noexcept : m_device(other.m_device) {
+    m_type = other.m_type;
+    m_name = std::move(other.m_name);
+    m_entry_point = std::move(other.m_entry_point);
+    m_shader_module = std::exchange(other.m_shader_module, nullptr);
+}
 
 Shader::~Shader() {
     vkDestroyShaderModule(m_device.device(), m_shader_module, nullptr);

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -20,12 +20,12 @@ StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept
       m_device(other.m_device) {}
 
 void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer) {
-    spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices.");
+    spdlog::debug("Beginning command buffer recording for copy of staging buffer for vertices");
 
     m_command_buffer_for_copying.create_command_buffer();
     m_command_buffer_for_copying.start_recording();
 
-    spdlog::debug("Specifying vertex buffer copy operation in command buffer.");
+    spdlog::debug("Specifying vertex buffer copy operation in command buffer");
 
     VkBufferCopy vertex_buffer_copy{};
     vertex_buffer_copy.srcOffset = 0;
@@ -35,7 +35,7 @@ void StagingBuffer::upload_data_to_gpu(const GPUMemoryBuffer &tarbuffer) {
     vkCmdCopyBuffer(m_command_buffer_for_copying.command_buffer(), m_buffer, tarbuffer.buffer(), 1,
                     &vertex_buffer_copy);
 
-    spdlog::debug("Finished uploading mesh data to graphics card memory.");
+    spdlog::debug("Finished uploading mesh data to graphics card memory");
 
     m_command_buffer_for_copying.end_recording_and_submit_command();
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -100,8 +100,8 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
 
     vkGetPhysicalDeviceFormatProperties(m_device.physical_device(), m_surface_format.format, &formatProps);
 
-    if ((formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) ||
-        (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT)) {
+    if ((formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) != 0 ||
+        (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT) != 0) {
         swapchain_ci.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -96,12 +96,12 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     swapchain_ci.compositeAlpha = composite_alpha.value();
 
     // Set additional usage flag for blitting from the swapchain images if supported.
-    VkFormatProperties formatProps;
+    VkFormatProperties format_properties;
 
-    vkGetPhysicalDeviceFormatProperties(m_device.physical_device(), m_surface_format.format, &formatProps);
+    vkGetPhysicalDeviceFormatProperties(m_device.physical_device(), m_surface_format.format, &format_properties);
 
-    if ((formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) != 0 ||
-        (formatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT) != 0) {
+    if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR) != 0 ||
+        (format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT) != 0) {
         swapchain_ci.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -15,8 +15,8 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Swapchain::Swapchain(const Device &device, const VkSurfaceKHR surface, std::uint32_t window_width,
-                     std::uint32_t window_height, const bool enable_vsync, const std::string &name)
-    : m_device(device), m_surface(surface), m_vsync_enabled(enable_vsync), m_name(name) {
+                     std::uint32_t window_height, const bool enable_vsync, std::string name)
+    : m_device(device), m_surface(surface), m_vsync_enabled(enable_vsync), m_name(std::move(name)) {
     assert(device.device());
     assert(surface);
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -159,7 +159,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
 }
 
 std::uint32_t Swapchain::acquire_next_image(const Semaphore &semaphore) {
-    std::uint32_t image_index;
+    std::uint32_t image_index = 0;
     vkAcquireNextImageKHR(m_device.device(), m_swapchain, std::numeric_limits<std::uint64_t>::max(), semaphore.get(),
                           VK_NULL_HANDLE, &image_index);
     return image_index;

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -23,13 +23,17 @@ Swapchain::Swapchain(const Device &device, const VkSurfaceKHR surface, std::uint
     setup_swapchain(VK_NULL_HANDLE, window_width, window_height);
 }
 
-Swapchain::Swapchain(Swapchain &&other) noexcept
-    : m_device(other.m_device), m_surface(std::exchange(other.m_surface, nullptr)),
-      m_swapchain(std::exchange(other.m_swapchain, nullptr)), m_surface_format(other.m_surface_format),
-      m_extent(other.m_extent), m_swapchain_images(std::move(other.m_swapchain_images)),
-      m_swapchain_image_views(std::move(other.m_swapchain_image_views)),
-      m_swapchain_image_count(other.m_swapchain_image_count), m_vsync_enabled(other.m_vsync_enabled),
-      m_name(std::move(other.m_name)) {}
+Swapchain::Swapchain(Swapchain &&other) noexcept : m_device(other.m_device) {
+    m_surface = std::exchange(other.m_surface, nullptr);
+    m_swapchain = std::exchange(other.m_swapchain, nullptr);
+    m_surface_format = other.m_surface_format;
+    m_extent = other.m_extent;
+    m_swapchain_images = std::move(other.m_swapchain_images);
+    m_swapchain_image_views = std::move(other.m_swapchain_image_views);
+    m_swapchain_image_count = other.m_swapchain_image_count;
+    m_vsync_enabled = other.m_vsync_enabled;
+    m_name = std::move(other.m_name);
+}
 
 void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width,
                                 std::uint32_t window_height) {

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -36,8 +36,6 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     auto swapchain_settings = VulkanSettingsDecisionMaker::decide_swapchain_extent(
         m_device.physical_device(), m_surface, window_width, window_height);
 
-    window_width = swapchain_settings.window_size.width;
-    window_height = swapchain_settings.window_size.height;
     m_extent = swapchain_settings.swapchain_size;
 
     std::optional<VkPresentModeKHR> present_mode = VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -33,16 +33,14 @@ Swapchain::Swapchain(Swapchain &&other) noexcept
 
 void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width,
                                 std::uint32_t window_height) {
-    VulkanSettingsDecisionMaker settings_decision_maker;
-
-    auto swapchain_settings = settings_decision_maker.decide_swapchain_extent(m_device.physical_device(), m_surface,
-                                                                              m_extent.width, m_extent.height);
+    auto swapchain_settings = VulkanSettingsDecisionMaker::decide_swapchain_extent(
+        m_device.physical_device(), m_surface, m_extent.width, m_extent.height);
 
     window_width = swapchain_settings.window_size.width;
     window_height = swapchain_settings.window_size.height;
     m_extent = swapchain_settings.swapchain_size;
 
-    std::optional<VkPresentModeKHR> present_mode = settings_decision_maker.decide_which_presentation_mode_to_use(
+    std::optional<VkPresentModeKHR> present_mode = VulkanSettingsDecisionMaker::decide_which_presentation_mode_to_use(
         m_device.physical_device(), m_surface, m_vsync_enabled);
 
     if (!present_mode) {
@@ -50,9 +48,9 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     }
 
     m_swapchain_image_count =
-        settings_decision_maker.decide_how_many_images_in_swapchain_to_use(m_device.physical_device(), m_surface);
+        VulkanSettingsDecisionMaker::decide_how_many_images_in_swapchain_to_use(m_device.physical_device(), m_surface);
 
-    auto surface_format_candidate = settings_decision_maker.decide_which_surface_color_format_in_swapchain_to_use(
+    auto surface_format_candidate = VulkanSettingsDecisionMaker::decide_which_surface_color_format_in_swapchain_to_use(
         m_device.physical_device(), m_surface);
 
     if (!surface_format_candidate) {
@@ -69,9 +67,8 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     swapchain_ci.imageExtent.width = m_extent.width;
     swapchain_ci.imageExtent.height = m_extent.height;
     swapchain_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    swapchain_ci.preTransform =
-        (VkSurfaceTransformFlagBitsKHR)settings_decision_maker.decide_which_image_transformation_to_use(
-            m_device.physical_device(), m_surface);
+    swapchain_ci.preTransform = static_cast<VkSurfaceTransformFlagBitsKHR>(
+        VulkanSettingsDecisionMaker::decide_which_image_transformation_to_use(m_device.physical_device(), m_surface));
     swapchain_ci.imageArrayLayers = 1;
     swapchain_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchain_ci.queueFamilyIndexCount = 0;
@@ -87,7 +84,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     swapchain_ci.clipped = VK_TRUE;
 
     const auto &composite_alpha =
-        settings_decision_maker.find_composite_alpha_format(m_device.physical_device(), m_surface);
+        VulkanSettingsDecisionMaker::find_composite_alpha_format(m_device.physical_device(), m_surface);
 
     if (!composite_alpha) {
         throw std::runtime_error("Error: Could not find composite alpha format while recreating swapchain!");

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -34,7 +34,7 @@ Swapchain::Swapchain(Swapchain &&other) noexcept
 void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_t window_width,
                                 std::uint32_t window_height) {
     auto swapchain_settings = VulkanSettingsDecisionMaker::decide_swapchain_extent(
-        m_device.physical_device(), m_surface, m_extent.width, m_extent.height);
+        m_device.physical_device(), m_surface, window_width, window_height);
 
     window_width = swapchain_settings.window_size.width;
     window_height = swapchain_settings.window_size.height;

--- a/src/vulkan-renderer/wrapper/uniform_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -17,4 +17,4 @@ void UniformBuffer::update(void *data, const std::size_t size) {
     std::memcpy(m_allocation_info.pMappedData, data, size);
 }
 
-}; // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -12,14 +12,14 @@ Window::Window(const std::string &title, const std::uint32_t width, const std::u
     assert(!title.empty());
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-    glfwWindowHint(GLFW_VISIBLE, visible);
-    glfwWindowHint(GLFW_RESIZABLE, resizable);
+    glfwWindowHint(GLFW_VISIBLE, visible ? GLFW_TRUE : GLFW_FALSE);
+    glfwWindowHint(GLFW_RESIZABLE, resizable ? GLFW_TRUE : GLFW_FALSE);
 
     spdlog::debug("Creating window.");
 
-    m_window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
+    m_window = glfwCreateWindow(static_cast<int>(width), static_cast<int>(height), title.c_str(), nullptr, nullptr);
 
-    if (!m_window) {
+    if (m_window == nullptr) {
         throw std::runtime_error("Error: glfwCreateWindow failed for window " + title + " !");
     }
 }
@@ -78,7 +78,7 @@ void Window::poll() {
 }
 
 bool Window::should_close() {
-    return glfwWindowShouldClose(m_window);
+    return glfwWindowShouldClose(m_window) == GLFW_TRUE;
 }
 
 Window::~Window() {

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -24,7 +24,9 @@ Window::Window(const std::string &title, const std::uint32_t width, const std::u
     }
 }
 
-Window::Window(Window &&other) noexcept : m_window(std::exchange(other.m_window, nullptr)) {}
+Window::Window(Window &&other) noexcept {
+    m_window = std::exchange(other.m_window, nullptr);
+}
 
 void Window::wait_for_focus() {
     int current_width = 0;

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -73,10 +73,6 @@ void Window::show() {
     glfwShowWindow(m_window);
 }
 
-void Window::hide() {
-    glfwHideWindow(m_window);
-}
-
 void Window::poll() {
     glfwPollEvents();
 }

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -19,8 +19,10 @@ WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_
     spdlog::debug("Created window surface successfully");
 }
 
-WindowSurface::WindowSurface(WindowSurface &&other) noexcept
-    : m_instance(other.m_instance), m_surface(std::exchange(other.m_surface, nullptr)) {}
+WindowSurface::WindowSurface(WindowSurface &&other) noexcept {
+    m_instance = other.m_instance;
+    m_surface = std::exchange(other.m_surface, nullptr);
+}
 
 WindowSurface::~WindowSurface() {
     vkDestroySurfaceKHR(m_instance, m_surface, nullptr);


### PR DESCRIPTION
This PR cleans up all of the current clang-tidy warnings to allow us to add a clang-tidy CI. There are a few other key changes in the PR such as switching our clang-tidy config style from enabling all checks, and then disabling ones we don't want to just enabling ones we want. This avoids the problem of new clang-tidy versions introducing new checks which we don't want.

Closes https://github.com/inexorgame/vulkan-renderer/issues/341