### PR TITLE
[destructors] Remove unnecessary if checks

### DIFF
--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -27,9 +27,7 @@ CommandPool::CommandPool(CommandPool &&other) noexcept
     : m_device(other.m_device), m_command_pool(std::exchange(other.m_command_pool, nullptr)) {}
 
 CommandPool::~CommandPool() {
-    if (m_command_pool != nullptr) {
-        vkDestroyCommandPool(m_device.device(), m_command_pool, nullptr);
-    }
+    vkDestroyCommandPool(m_device.device(), m_command_pool, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -50,9 +50,7 @@ CpuTexture::CpuTexture(CpuTexture &&other) noexcept
       m_texture_data(other.m_texture_data) {}
 
 CpuTexture::~CpuTexture() {
-    if (m_texture_data != nullptr) {
-        stbi_image_free(m_texture_data);
-    }
+    stbi_image_free(m_texture_data);
 }
 
 void CpuTexture::generate_error_texture_data() {

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -114,13 +114,8 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
 }
 
 ResourceDescriptor::~ResourceDescriptor() {
-    if (m_descriptor_set_layout != nullptr) {
-        vkDestroyDescriptorSetLayout(m_device.device(), m_descriptor_set_layout, nullptr);
-    }
-
-    if (m_descriptor_pool != nullptr) {
-        vkDestroyDescriptorPool(m_device.device(), m_descriptor_pool, nullptr);
-    }
+    vkDestroyDescriptorSetLayout(m_device.device(), m_descriptor_set_layout, nullptr);
+    vkDestroyDescriptorPool(m_device.device(), m_descriptor_pool, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -394,13 +394,8 @@ Device::Device(Device &&other) noexcept
       m_enable_vulkan_debug_markers(other.m_enable_vulkan_debug_markers), m_surface(other.m_surface) {}
 
 Device::~Device() {
-    if (m_allocator != nullptr) {
-        vmaDestroyAllocator(m_allocator);
-    }
-
-    if (m_device != nullptr) {
-        vkDestroyDevice(m_device, nullptr);
-    }
+    vmaDestroyAllocator(m_allocator);
+    vkDestroyDevice(m_device, nullptr);
 }
 
 void Device::set_debug_marker_name(void *object, VkDebugReportObjectTypeEXT object_type,

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -34,9 +34,7 @@ Fence::Fence(Fence &&other) noexcept
     : m_device(other.m_device), m_fence(std::exchange(other.m_fence, nullptr)), m_name(std::move(other.m_name)) {}
 
 Fence::~Fence() {
-    if (m_fence != nullptr) {
-        vkDestroyFence(m_device.device(), m_fence, nullptr);
-    }
+    vkDestroyFence(m_device.device(), m_fence, nullptr);
 }
 
 void Fence::block(std::uint64_t timeout_limit) const {

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -40,9 +40,7 @@ Framebuffer::Framebuffer(Framebuffer &&other) noexcept
       m_name(std::move(other.m_name)) {}
 
 Framebuffer::~Framebuffer() {
-    if (m_framebuffer != nullptr) {
-        vkDestroyFramebuffer(m_device.device(), m_framebuffer, nullptr);
-    }
+    vkDestroyFramebuffer(m_device.device(), m_framebuffer, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/glfw_context.cpp
+++ b/src/vulkan-renderer/wrapper/glfw_context.cpp
@@ -19,9 +19,7 @@ GLFWContext::GLFWContext() {
 GLFWContext::GLFWContext(GLFWContext &&other) noexcept : m_initialized(other.m_initialized) {}
 
 GLFWContext::~GLFWContext() {
-    if (m_initialized) {
-        glfwTerminate();
-    }
+    glfwTerminate();
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -68,9 +68,7 @@ GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept
       m_allocation_ci(std::move(other.m_allocation_ci)) {}
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {
-    if (m_buffer != nullptr) {
-        vmaDestroyBuffer(m_device.allocator(), m_buffer, m_allocation);
-    }
+    vmaDestroyBuffer(m_device.allocator(), m_buffer, m_allocation);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -33,9 +33,7 @@ GpuTexture::GpuTexture(GpuTexture &&other) noexcept
       m_copy_command_buffer(std::move(other.m_copy_command_buffer)) {}
 
 GpuTexture::~GpuTexture() {
-    if (m_sampler != nullptr) {
-        vkDestroySampler(m_device.device(), m_sampler, nullptr);
-    }
+    vkDestroySampler(m_device.device(), m_sampler, nullptr);
 }
 
 void GpuTexture::create_texture(void *texture_data, const std::size_t texture_size) {

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -77,13 +77,8 @@ Image::Image(Image &&other) noexcept
       m_name(std::move(other.m_name)) {}
 
 Image::~Image() {
-    if (m_image_view != nullptr) {
-        vkDestroyImageView(m_device.device(), m_image_view, nullptr);
-    }
-
-    if (m_image != nullptr) {
-        vmaDestroyImage(m_device.allocator(), m_image, m_allocation);
-    }
+    vkDestroyImageView(m_device.device(), m_image_view, nullptr);
+    vmaDestroyImage(m_device.allocator(), m_image, m_allocation);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -217,9 +217,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
 Instance::Instance(Instance &&other) noexcept : m_instance(std::exchange(other.m_instance, nullptr)) {}
 
 Instance::~Instance() {
-    if (m_instance != nullptr) {
-        vkDestroyInstance(m_instance, nullptr);
-    }
+    vkDestroyInstance(m_instance, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -33,9 +33,7 @@ Semaphore::Semaphore(Semaphore &&other) noexcept
       m_name(std::move(other.m_name)) {}
 
 Semaphore::~Semaphore() {
-    if (m_semaphore != nullptr) {
-        vkDestroySemaphore(m_device.device(), m_semaphore, nullptr);
-    }
+    vkDestroySemaphore(m_device.device(), m_semaphore, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -69,9 +69,7 @@ Shader::Shader(Shader &&other) noexcept
       m_entry_point(std::move(other.m_entry_point)), m_shader_module(std::exchange(other.m_shader_module, nullptr)) {}
 
 Shader::~Shader() {
-    if (m_shader_module != nullptr) {
-        vkDestroyShaderModule(m_device.device(), m_shader_module, nullptr);
-    }
+    vkDestroyShaderModule(m_device.device(), m_shader_module, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -188,14 +188,10 @@ void Swapchain::recreate(std::uint32_t window_width, std::uint32_t window_height
 }
 
 Swapchain::~Swapchain() {
-    if (m_swapchain != nullptr) {
-        vkDestroySwapchainKHR(m_device.device(), m_swapchain, nullptr);
-    }
+    vkDestroySwapchainKHR(m_device.device(), m_swapchain, nullptr);
 
     for (auto *image_view : m_swapchain_image_views) {
-        if (image_view != nullptr) {
-            vkDestroyImageView(m_device.device(), image_view, nullptr);
-        }
+        vkDestroyImageView(m_device.device(), image_view, nullptr);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -86,9 +86,7 @@ bool Window::should_close() {
 }
 
 Window::~Window() {
-    if (m_window != nullptr) {
-        glfwDestroyWindow(m_window);
-    }
+    glfwDestroyWindow(m_window);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -23,9 +23,7 @@ WindowSurface::WindowSurface(WindowSurface &&other) noexcept
     : m_instance(other.m_instance), m_surface(std::exchange(other.m_surface, nullptr)) {}
 
 WindowSurface::~WindowSurface() {
-    if (m_surface != nullptr) {
-        vkDestroySurfaceKHR(m_instance, m_surface, nullptr);
-    }
+    vkDestroySurfaceKHR(m_instance, m_surface, nullptr);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper


### PR DESCRIPTION
It's not illegal to call all those Vulkan functions on invalid objects. We don't need those checks.
Tested on Ubuntu and Windows.