### PR TITLE
[cmake] Fix linker errors in inexor-vulkan-renderer-example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ option(INEXOR_BUILD_TESTS "Build tests" OFF)
 set(INEXOR_CONAN_PROFILE "default" CACHE STRING "conan profile")
 option(INEXOR_USE_VMA_RECORDING "Use VulkanMemoryAllocator recording feature" OFF)
 
+# Fix CMake UI not passing libraries to inexor-vulkan-renderer-example
+# TODO: Refactor this!
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
 message(STATUS "INEXOR_BUILD_BENCHMARKS = ${INEXOR_BUILD_BENCHMARKS}")
 message(STATUS "INEXOR_BUILD_DOC = ${INEXOR_BUILD_DOC}")
 message(STATUS "INEXOR_BUILD_EXAMPLE = ${INEXOR_BUILD_EXAMPLE}")


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/228

This small code change in CMakeLists.txt fixes the issue with CMake UI:

```cpp
if(NOT DEFINED CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE "Debug")
endif()
```

This also works with the cmake command line. It is a quick fix, but it will work for now. I'm afraid many more people are losing interest in this project if we don't make sure CMake UI is working as well. This will buy us all the time to dig into the real cause of this problem.

Props to @MyCatFishSteve for proposing this.

I tested on Windows and Ubuntu 20.04.