### PR TITLE
[io] Add missing cstdint include

### DIFF
--- a/include/inexor/vulkan-renderer/io/nxoc_parser.hpp
+++ b/include/inexor/vulkan-renderer/io/nxoc_parser.hpp
@@ -2,6 +2,7 @@
 
 #include "inexor/vulkan-renderer/io/octree_parser.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 

--- a/include/inexor/vulkan-renderer/io/octree_parser.hpp
+++ b/include/inexor/vulkan-renderer/io/octree_parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 


### PR DESCRIPTION
This was breaking build with latest GCC.