### PR TITLE
[representation|gpu-info] Refactoring

### DIFF
--- a/include/inexor/vulkan-renderer/exception.hpp
+++ b/include/inexor/vulkan-renderer/exception.hpp
@@ -19,7 +19,7 @@ class VulkanException final : public InexorException {
 public:
     /// @param message The exception message.
     /// @param result The VkResult value of the Vulkan API call which failed.
-    VulkanException(const std::string &message, VkResult result);
+    VulkanException(std::string message, VkResult result);
 };
 
 } // namespace inexor::vulkan_renderer

--- a/include/inexor/vulkan-renderer/vk_tools/representation.hpp
+++ b/include/inexor/vulkan-renderer/vk_tools/representation.hpp
@@ -10,11 +10,6 @@ namespace inexor::vulkan_renderer::vk_tools {
 template <typename VulkanDataType>
 [[nodiscard]] std::string_view as_string(VulkanDataType);
 
-/// @brief Turn a VkResult into a std::string_view.
-/// @note This function can be used for both VkResult error and success values.
-/// @param result The VkResult return value which will be turned into a std::string_view.
-[[nodiscard]] std::string_view result_to_string(VkResult result);
-
 /// @brief Return a VkResult's description text as std::string_view.
 /// @note This function can be used for both VkResult error and success values.
 /// @param result The VkResult return value which will be turned into a std::string_view.

--- a/include/inexor/vulkan-renderer/vk_tools/representation.hpp
+++ b/include/inexor/vulkan-renderer/vk_tools/representation.hpp
@@ -10,14 +10,14 @@ namespace inexor::vulkan_renderer::vk_tools {
 template <typename VulkanDataType>
 [[nodiscard]] std::string_view as_string(VulkanDataType);
 
-/// @brief Turn a VkResult into a std::string.
+/// @brief Turn a VkResult into a std::string_view.
 /// @note This function can be used for both VkResult error and success values.
-/// @param result The VkResult return value which will be turned into a std::string.
-[[nodiscard]] std::string result_to_string(VkResult result);
+/// @param result The VkResult return value which will be turned into a std::string_view.
+[[nodiscard]] std::string_view result_to_string(VkResult result);
 
-/// @brief Return a VkResult's description text as std::string.
+/// @brief Return a VkResult's description text as std::string_view.
 /// @note This function can be used for both VkResult error and success values.
-/// @param result The VkResult return value which will be turned into a std::string.
-[[nodiscard]] std::string result_to_description(VkResult result);
+/// @param result The VkResult return value which will be turned into a std::string_view.
+[[nodiscard]] std::string_view result_to_description(VkResult result);
 
 } // namespace inexor::vulkan_renderer::vk_tools

--- a/include/inexor/vulkan-renderer/vk_tools/representation.hpp
+++ b/include/inexor/vulkan-renderer/vk_tools/representation.hpp
@@ -6,41 +6,18 @@
 
 namespace inexor::vulkan_renderer::vk_tools {
 
-/// @brief Convert a VkPresentModeKHR value into the corresponding std::string value.
-/// @param present_mode The present mode.
-/// @return A std::string which contains the presentation mode.
-[[nodiscard]] std::string present_mode_khr_to_string(VkPresentModeKHR present_mode);
+/// @brief Convert a Vulkan data structure into a std::string_view.
+template <typename VulkanDataType>
+[[nodiscard]] std::string_view as_string(VulkanDataType);
 
-/// @brief Convert a VkPhysicalDeviceType value into the corresponding std::string value.
-/// @param gpu_type The type of the physical device.
-/// @return A std::string which contains the physical device type.
-[[nodiscard]] std::string physical_device_type_to_string(VkPhysicalDeviceType gpu_type);
-
-/// @brief Convert a VkFormat value into the corresponding value as std::string.
-/// @param format The VkFormat to convert.
-/// @return A std::string which contains the VkFormat.
-[[nodiscard]] std::string format_to_string(VkFormat format);
-
-/// @brief Turn a VkResult into a string.
+/// @brief Turn a VkResult into a std::string.
 /// @note This function can be used for both VkResult error and success values.
-/// @param result The VkResult return value which will be turned into a string.
+/// @param result The VkResult return value which will be turned into a std::string.
 [[nodiscard]] std::string result_to_string(VkResult result);
 
-/// @brief Return a VkResult's description text.
+/// @brief Return a VkResult's description text as std::string.
 /// @note This function can be used for both VkResult error and success values.
-/// @param result The VkResult return value which will be turned into a string.
+/// @param result The VkResult return value which will be turned into a std::string.
 [[nodiscard]] std::string result_to_description(VkResult result);
-
-/// @brief Convert a VkQueueFlagBits value into the corresponding value as std::string.
-/// @param bit The queue flag bit.
-[[nodiscard]] std::string queue_flag_bit_to_string(VkQueueFlagBits bit);
-
-/// @brief Convert a VkMemoryPropertyFlags value into the corresponding value as std::string.
-/// @param bit The memory property flag bit.
-[[nodiscard]] std::string memory_property_flag_to_string(VkMemoryPropertyFlags bit);
-
-/// @brief Convert a VkMemoryHeapFlagBits value into the corresponding value as std::string.
-/// @param bit The memory heap flag bit.
-[[nodiscard]] std::string memory_heap_flag_to_string(VkMemoryHeapFlagBits bit);
 
 } // namespace inexor::vulkan_renderer::vk_tools

--- a/src/vulkan-renderer/exception.cpp
+++ b/src/vulkan-renderer/exception.cpp
@@ -4,8 +4,11 @@
 
 namespace inexor::vulkan_renderer {
 
-VulkanException::VulkanException(const std::string &message, const VkResult result)
-    : InexorException(message + " (" + vk_tools::result_to_string(result) + ": " +
-                      vk_tools::result_to_description(result) + ")") {}
+VulkanException::VulkanException(std::string message, const VkResult result)
+    : InexorException(message.append(std::string_view(" ("))
+                          .append(vk_tools::result_to_string(result))
+                          .append(std::string_view(": "))
+                          .append(vk_tools::result_to_description(result))
+                          .append(std::string_view(")"))) {}
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/exception.cpp
+++ b/src/vulkan-renderer/exception.cpp
@@ -5,10 +5,10 @@
 namespace inexor::vulkan_renderer {
 
 VulkanException::VulkanException(std::string message, const VkResult result)
-    : InexorException(message.append(std::string_view(" ("))
-                          .append(vk_tools::result_to_string(result))
-                          .append(std::string_view(": "))
+    : InexorException(message.append(" (")
+                          .append(vk_tools::as_string<VkResult>(result))
+                          .append(": ")
                           .append(vk_tools::result_to_description(result))
-                          .append(std::string_view(")"))) {}
+                          .append(")")) {}
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/vk_tools/gpu_info.cpp
+++ b/src/vulkan-renderer/vk_tools/gpu_info.cpp
@@ -49,8 +49,8 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
         spdlog::debug("Timestamp valid bits: {}", queue_family_properties[i].timestampValidBits);
 
         for (const auto &queue_bit : QUEUE_BITS) {
-            if ((queue_family_properties[i].queueFlags & queue_bit) != 0) {
-                spdlog::debug("{}", queue_flag_bit_to_string(queue_bit));
+            if (static_cast<bool>(queue_family_properties[i].queueFlags & queue_bit)) {
+                spdlog::debug("{}", vk_tools::as_string<VkQueueFlags>(queue_bit));
             }
         }
 
@@ -259,7 +259,7 @@ void print_supported_surface_formats(const VkPhysicalDevice gpu, const VkSurface
     }
 
     for (const auto &format : surface_formats) {
-        spdlog::debug("Surface format: {}", format_to_string(format.format));
+        spdlog::debug("Surface format: {}", vk_tools::as_string<VkFormat>(format.format));
     }
 }
 
@@ -293,7 +293,7 @@ void print_presentation_modes(const VkPhysicalDevice gpu, const VkSurfaceKHR sur
     }
 
     for (const auto &mode : present_modes) {
-        spdlog::debug("Present mode: {}", present_mode_khr_to_string(mode));
+        spdlog::debug("Present mode: {}", vk_tools::as_string<VkPresentModeKHR>(mode));
     }
 }
 
@@ -314,7 +314,7 @@ void print_physical_device_info(const VkPhysicalDevice gpu) {
                   VK_VERSION_MINOR(gpu_properties.driverVersion), VK_VERSION_PATCH(gpu_properties.driverVersion));
     spdlog::debug("Vendor ID: {}", gpu_properties.vendorID);
     spdlog::debug("Device ID: {}", gpu_properties.deviceID);
-    spdlog::debug("Device type: {}", physical_device_type_to_string(gpu_properties.deviceType));
+    spdlog::debug("Device type: {}", vk_tools::as_string<VkPhysicalDeviceType>(gpu_properties.deviceType));
 }
 
 void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
@@ -339,8 +339,8 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
         spdlog::debug("[{}] Heap index: {}", i, gpu_mem_properties.memoryTypes[i].heapIndex);
 
         for (const auto &mem_prop_flag : MEM_PROP_FLAGS) {
-            if ((gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag) != 0) {
-                spdlog::debug("{}", memory_property_flag_to_string(mem_prop_flag));
+            if (static_cast<bool>(gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag)) {
+                spdlog::debug("{}", vk_tools::as_string<VkMemoryPropertyFlags>(mem_prop_flag));
             }
         }
     }
@@ -352,8 +352,8 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
         spdlog::debug("Heap [{}], memory size: {}", i, gpu_mem_properties.memoryHeaps[i].size / (1000 * 1000));
 
         for (const auto &mem_heap_prop_flag : MEM_HEAP_PROP_FLAGS) {
-            if ((gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag) != 0) {
-                spdlog::debug("{}", memory_heap_flag_to_string(mem_heap_prop_flag));
+            if (static_cast<bool>(gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag)) {
+                spdlog::debug("{}", vk_tools::as_string<VkMemoryHeapFlags>(mem_heap_prop_flag));
             }
         }
     }

--- a/src/vulkan-renderer/vk_tools/gpu_info.cpp
+++ b/src/vulkan-renderer/vk_tools/gpu_info.cpp
@@ -14,7 +14,7 @@ void print_driver_vulkan_version() {
     std::uint32_t api_version{0};
 
     if (const auto result = vkEnumerateInstanceVersion(&api_version); result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceVersion returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateInstanceVersion returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -66,7 +66,7 @@ void print_instance_layers() {
 
     // Query how many instance layers are available.
     if (const auto result = vkEnumerateInstanceLayerProperties(&instance_layer_count, nullptr); result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceLayerProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateInstanceLayerProperties returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -82,7 +82,7 @@ void print_instance_layers() {
     // Store all available instance layers.
     if (const auto result = vkEnumerateInstanceLayerProperties(&instance_layer_count, instance_layers.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceLayerProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateInstanceLayerProperties returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -101,7 +101,8 @@ void print_instance_extensions() {
     // Query how many instance extensions are available.
     if (const auto result = vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, nullptr);
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceExtensionProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateInstanceExtensionProperties returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -118,7 +119,8 @@ void print_instance_extensions() {
     if (const auto result =
             vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, extensions.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceExtensionProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateInstanceExtensionProperties returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -136,7 +138,7 @@ void print_device_layers(const VkPhysicalDevice gpu) {
 
     // Query how many device layers are available.
     if (const auto result = vkEnumerateDeviceLayerProperties(gpu, &device_layer_count, nullptr); result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateDeviceLayerProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateDeviceLayerProperties returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -152,7 +154,7 @@ void print_device_layers(const VkPhysicalDevice gpu) {
     // Store all available device layers.
     if (const auto result = vkEnumerateDeviceLayerProperties(gpu, &device_layer_count, device_layers.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateDeviceLayerProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateDeviceLayerProperties returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -173,7 +175,8 @@ void print_device_extensions(const VkPhysicalDevice gpu) {
     // First check how many device extensions are available.
     if (const auto result = vkEnumerateDeviceExtensionProperties(gpu, nullptr, &device_extension_count, nullptr);
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateDeviceExtensionProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateDeviceExtensionProperties returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -190,7 +193,8 @@ void print_device_extensions(const VkPhysicalDevice gpu) {
     if (const auto result =
             vkEnumerateDeviceExtensionProperties(gpu, nullptr, &device_extension_count, device_extensions.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateDeviceExtensionProperties returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumerateDeviceExtensionProperties returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -211,7 +215,8 @@ void print_surface_capabilities(const VkPhysicalDevice gpu, const VkSurfaceKHR s
 
     if (const auto result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(gpu, surface, &surface_capabilities);
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!", result_to_string(result));
+        spdlog::error("Error: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -254,7 +259,8 @@ void print_supported_surface_formats(const VkPhysicalDevice gpu, const VkSurface
 
     if (const auto result = vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &format_count, surface_formats.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkGetPhysicalDeviceSurfaceFormatsKHR returned {}!", result_to_string(result));
+        spdlog::error("Error: vkGetPhysicalDeviceSurfaceFormatsKHR returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -272,7 +278,8 @@ void print_presentation_modes(const VkPhysicalDevice gpu, const VkSurfaceKHR sur
     // Query how many presentation modes are available.
     if (const auto result = vkGetPhysicalDeviceSurfacePresentModesKHR(gpu, surface, &present_mode_count, nullptr);
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkGetPhysicalDeviceSurfacePresentModesKHR returned {}!", result_to_string(result));
+        spdlog::error("Error: vkGetPhysicalDeviceSurfacePresentModesKHR returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -288,7 +295,8 @@ void print_presentation_modes(const VkPhysicalDevice gpu, const VkSurfaceKHR sur
     if (const auto result =
             vkGetPhysicalDeviceSurfacePresentModesKHR(gpu, surface, &present_mode_count, present_modes.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkGetPhysicalDeviceSurfacePresentModesKHR returned {}!", result_to_string(result));
+        spdlog::error("Error: vkGetPhysicalDeviceSurfacePresentModesKHR returned {}!",
+                      vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -582,7 +590,7 @@ void print_all_physical_devices(const VkInstance instance, const VkSurfaceKHR su
 
     // Query how many graphics cards are available.
     if (const auto result = vkEnumeratePhysicalDevices(instance, &gpu_count, nullptr); result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumeratePhysicalDevices returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumeratePhysicalDevices returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 
@@ -598,7 +606,7 @@ void print_all_physical_devices(const VkInstance instance, const VkSurfaceKHR su
     // Store all available graphics cards.
     if (const auto result = vkEnumeratePhysicalDevices(instance, &gpu_count, available_gpus.data());
         result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumeratePhysicalDevices returned {}!", result_to_string(result));
+        spdlog::error("Error: vkEnumeratePhysicalDevices returned {}!", vk_tools::as_string<VkResult>(result));
         return;
     }
 

--- a/src/vulkan-renderer/vk_tools/representation.cpp
+++ b/src/vulkan-renderer/vk_tools/representation.cpp
@@ -2,7 +2,11 @@
 
 namespace inexor::vulkan_renderer::vk_tools {
 
-std::string present_mode_khr_to_string(const VkPresentModeKHR present_mode) {
+/// @brief Convert a VkPresentModeKHR value into a corresponding std::string_view.
+/// @param present_mode The present mode.
+/// @return A std::string_view which contains the presentation mode.
+template <>
+std::string_view as_string(const VkPresentModeKHR present_mode) {
     switch (present_mode) {
     case VK_PRESENT_MODE_IMMEDIATE_KHR:
         return "VK_PRESENT_MODE_IMMEDIATE_KHR";
@@ -19,12 +23,14 @@ std::string present_mode_khr_to_string(const VkPresentModeKHR present_mode) {
     default:
         break;
     }
-
-    // If no name can be found, convert the present mode's value to std::string and return it.
-    return std::to_string(present_mode);
+    return "Unknown";
 }
 
-std::string physical_device_type_to_string(const VkPhysicalDeviceType gpu_type) {
+/// @brief Convert a VkPhysicalDeviceType value into a corresponding std::string_view.
+/// @param gpu_type The type of the physical device.
+/// @return A std::string_view which contains the physical device type.
+template <>
+std::string_view as_string(const VkPhysicalDeviceType gpu_type) {
     switch (gpu_type) {
     case VK_PHYSICAL_DEVICE_TYPE_OTHER:
         return "VK_PHYSICAL_DEVICE_TYPE_OTHER";
@@ -39,12 +45,14 @@ std::string physical_device_type_to_string(const VkPhysicalDeviceType gpu_type) 
     default:
         break;
     }
-
-    // If no name can be found, convert the physical device type value to a std::string and return it.
-    return std::to_string(gpu_type);
+    return "Unknown";
 }
 
-std::string format_to_string(const VkFormat format) {
+/// @brief Convert a VkFormat value into the corresponding value as std::string_view.
+/// @param format The VkFormat to convert.
+/// @return A std::string_view which contains the VkFormat.
+template <>
+std::string_view as_string(const VkFormat format) {
     switch (format) {
     case VK_FORMAT_UNDEFINED:
         return "VK_FORMAT_UNDEFINED";
@@ -531,9 +539,7 @@ std::string format_to_string(const VkFormat format) {
     default:
         break;
     }
-
-    // If not name can be found, convert the format value to std::string and return it.
-    return std::to_string(format);
+    return "Unknown";
 }
 
 std::string result_to_string(const VkResult result) {
@@ -601,8 +607,6 @@ std::string result_to_string(const VkResult result) {
     default:
         break;
     }
-
-    // Don't forget to offer a default value.
     return "Unknown";
 }
 
@@ -622,77 +626,78 @@ std::string result_to_description(const VkResult result) {
         return "A return array was too small for the result";
     case VK_SUBOPTIMAL_KHR:
         return "A swapchain no longer matches the surface properties exactly, but can still be used to present to the "
-               "surface successfully.";
+               "surface successfully";
     case VK_ERROR_OUT_OF_HOST_MEMORY:
-        return "A host memory allocation has failed.";
+        return "A host memory allocation has failed";
     case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-        return "A device memory allocation has failed.";
+        return "A device memory allocation has failed";
     case VK_ERROR_INITIALIZATION_FAILED:
-        return "Initialization of an object could not be completed for implementation-specific reasons.";
+        return "Initialization of an object could not be completed for implementation-specific reasons";
     case VK_ERROR_DEVICE_LOST:
         return "The logical or physical device has been lost. See Lost Device";
     case VK_ERROR_MEMORY_MAP_FAILED:
-        return "Mapping of a memory object has failed.";
+        return "Mapping of a memory object has failed";
     case VK_ERROR_LAYER_NOT_PRESENT:
-        return "A requested layer is not present or could not be loaded.";
+        return "A requested layer is not present or could not be loaded";
     case VK_ERROR_EXTENSION_NOT_PRESENT:
-        return "A requested extension is not supported.";
+        return "A requested extension is not supported";
     case VK_ERROR_FEATURE_NOT_PRESENT:
-        return "A requested feature is not supported.";
+        return "A requested feature is not supported";
     case VK_ERROR_INCOMPATIBLE_DRIVER:
         return "The requested version of Vulkan is not supported by the driver or is otherwise incompatible for "
-               "implementation-specific reasons.";
+               "implementation-specific reasons";
     case VK_ERROR_TOO_MANY_OBJECTS:
-        return "Too many objects of the type have already been created.";
+        return "Too many objects of the type have already been created";
     case VK_ERROR_FORMAT_NOT_SUPPORTED:
-        return "A requested format is not supported on this device.";
+        return "A requested format is not supported on this device";
     case VK_ERROR_FRAGMENTED_POOL:
         return "A pool allocation has failed due to fragmentation of the pool�s memory. This must only be returned if "
                "no attempt to allocate host or device memory was made to accommodate the new allocation. This should "
                "be returned in preference to VK_ERROR_OUT_OF_POOL_MEMORY, but only if the implementation is certain "
-               "that the pool allocation failure was due to fragmentation.";
+               "that the pool allocation failure was due to fragmentation";
     case VK_ERROR_SURFACE_LOST_KHR:
-        return "A surface is no longer available.";
+        return "A surface is no longer available";
     case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR:
         return "The requested window is already in use by Vulkan or another API in a manner which prevents it from "
-               "being used again.";
+               "being used again";
     case VK_ERROR_OUT_OF_DATE_KHR:
         return "A surface has changed in such a way that it is no longer compatible with the swapchain, and further "
                "presentation requests using the swapchain will fail. Applications must query the new surface "
-               "properties and recreate their swapchain if they wish to continue presenting to the surface.";
+               "properties and recreate their swapchain if they wish to continue presenting to the surface";
     case VK_ERROR_INCOMPATIBLE_DISPLAY_KHR:
         return "The display used by a swapchain does not use the same presentable image layout, or is incompatible in "
-               "a way that prevents sharing an image.";
+               "a way that prevents sharing an image";
     case VK_ERROR_INVALID_SHADER_NV:
         return "One or more shaders failed to compile or link. More details are reported back to the application via "
-               "VK_EXT_debug_report if enabled.";
+               "VK_EXT_debug_report if enabled";
     case VK_ERROR_OUT_OF_POOL_MEMORY:
         return "A pool memory allocation has failed. This must only be returned if no attempt to allocate host or "
                "device memory was made to accommodate the new allocation. If the failure was definitely due to "
-               "fragmentation of the pool, VK_ERROR_FRAGMENTED_POOL should be returned instead.";
+               "fragmentation of the pool, VK_ERROR_FRAGMENTED_POOL should be returned instead";
     case VK_ERROR_INVALID_EXTERNAL_HANDLE:
-        return "An external handle is not a valid handle of the specified type.";
+        return "An external handle is not a valid handle of the specified type";
     case VK_ERROR_FRAGMENTATION:
-        return "A descriptor pool creation has failed due to fragmentation.";
+        return "A descriptor pool creation has failed due to fragmentation";
     case VK_ERROR_INVALID_DEVICE_ADDRESS_EXT:
-        return "A buffer creation failed because the requested address is not available.";
+        return "A buffer creation failed because the requested address is not available";
     case VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT:
         return "An operation on a swapchain created with VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT "
                "failed as it did not have exlusive full-screen access. This may occur due to implementation-dependent "
-               "reasons, outside of  the application�s control.";
+               "reasons, outside of the application�s control";
     case VK_ERROR_UNKNOWN:
         return "An unknown error has occurred; either the application has provided invalid input, or an implementation "
-               "failure has occurred.";
+               "failure has occurred";
     default:
         break;
     }
-
-    // Don't forget to offer a default value.
     return "Unknown";
 }
 
-std::string queue_flag_bit_to_string(const VkQueueFlagBits bit) {
-    switch (bit) {
+/// @brief Convert a VkQueueFlagBits value into the corresponding value as std::string_view.
+/// @param bit The queue flag bit.
+template <>
+std::string_view as_string(const VkQueueFlagBits queue_flag_bit) {
+    switch (queue_flag_bit) {
     case VK_QUEUE_GRAPHICS_BIT:
         return "VK_QUEUE_GRAPHICS_BIT";
         break;
@@ -714,13 +719,14 @@ std::string queue_flag_bit_to_string(const VkQueueFlagBits bit) {
     default:
         break;
     }
-
-    // Don't forget to offer a default value.
     return "Unknown";
 }
 
-std::string memory_property_flag_to_string(const VkMemoryPropertyFlags bit) {
-    switch (bit) {
+/// @brief Convert a VkMemoryPropertyFlags value into the corresponding value as std::string.
+/// @param bit The memory property flag bit.
+template <>
+std::string_view as_string(const VkMemoryPropertyFlags mem_prop_flag_bit) {
+    switch (mem_prop_flag_bit) {
     case VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT:
         return "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT";
     case VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT:
@@ -742,13 +748,14 @@ std::string memory_property_flag_to_string(const VkMemoryPropertyFlags bit) {
     default:
         break;
     }
-
-    // Don't forget to offer a default value.
     return "Unknown";
 }
 
-std::string memory_heap_flag_to_string(const VkMemoryHeapFlagBits bit) {
-    switch (bit) {
+/// @brief Convert a VkMemoryHeapFlagBits value into the corresponding value as std::string.
+/// @param bit The memory heap flag bit.
+template <>
+std::string_view as_string(const VkMemoryHeapFlagBits heap_flag_bit) {
+    switch (heap_flag_bit) {
     case VK_MEMORY_HEAP_DEVICE_LOCAL_BIT:
         return "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT";
     case VK_MEMORY_HEAP_MULTI_INSTANCE_BIT: // same as VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR
@@ -758,8 +765,6 @@ std::string memory_heap_flag_to_string(const VkMemoryHeapFlagBits bit) {
     default:
         break;
     }
-
-    // Don't forget to offer a default value.
     return "Unknown";
 }
 

--- a/src/vulkan-renderer/vk_tools/representation.cpp
+++ b/src/vulkan-renderer/vk_tools/representation.cpp
@@ -542,7 +542,7 @@ std::string_view as_string(const VkFormat format) {
     return "Unknown";
 }
 
-std::string result_to_string(const VkResult result) {
+std::string_view result_to_string(const VkResult result) {
     switch (result) {
     case VK_SUCCESS:
         return "VK_SUCCESS";
@@ -610,7 +610,7 @@ std::string result_to_string(const VkResult result) {
     return "Unknown";
 }
 
-std::string result_to_description(const VkResult result) {
+std::string_view result_to_description(const VkResult result) {
     switch (result) {
     case VK_SUCCESS:
         return "Command successfully completed";

--- a/src/vulkan-renderer/vk_tools/representation.cpp
+++ b/src/vulkan-renderer/vk_tools/representation.cpp
@@ -542,7 +542,11 @@ std::string_view as_string(const VkFormat format) {
     return "Unknown";
 }
 
-std::string_view result_to_string(const VkResult result) {
+/// @brief Convert a VkResult value into the corresponding value as std::string_view.
+/// @param format The VkResult to convert.
+/// @return A std::string_view which contains the VkResult.
+template <>
+std::string_view as_string<VkResult>(const VkResult result) {
     switch (result) {
     case VK_SUCCESS:
         return "VK_SUCCESS";


### PR DESCRIPTION
- [x] Use `std::string_view` for representations.
- [x] Use templated `as_string` functions.