### PR TITLE
[tests|benchmarks] Print engine metadata in unit tests and benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,32 @@ find_package(Vulkan REQUIRED)
 # Dependency setup with conan
 include(conan_setup)
 
+# The marked constants in application.hpp will be replaced with the following values
+set(ENGINE_NAME "Inexor Engine")
+set(APP_NAME "Inexor Vulkan-renderer example")
+
+set(ENGINE_VERSION_MAJOR 0)
+set(ENGINE_VERSION_MINOR 1)
+set(ENGINE_VERSION_PATCH 0)
+
+set(APP_VERSION_MAJOR 0)
+set(APP_VERSION_MINOR 1)
+set(APP_VERSION_PATCH 0)
+
+set(BUILD_TYPE ${CMAKE_BUILD_TYPE})
+
+find_package(Git REQUIRED)
+set(GIT_SHA "unknown")
+
+# Extract the current git sha
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=7
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    ERROR_QUIET
+    OUTPUT_VARIABLE GIT_SHA
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 add_subdirectory(shaders)
 add_subdirectory(src)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_executable(inexor-vulkan-renderer-benchmarks engine_benchmark_main.cpp)
+add_executable(
+    inexor-vulkan-renderer-benchmarks
+    engine_benchmark_main.cpp
+)
 
 set_target_properties(
     inexor-vulkan-renderer-benchmarks PROPERTIES
@@ -6,6 +9,14 @@ set_target_properties(
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(
+    inexor-vulkan-renderer-benchmarks
+
+    PUBLIC
+    # Include configured header file which contains engine metadata
+    ${CMAKE_BINARY_DIR}/src/include/inexor/vulkan-renderer/
 )
 
 target_link_libraries(

--- a/benchmarks/engine_benchmark_main.cpp
+++ b/benchmarks/engine_benchmark_main.cpp
@@ -1,13 +1,23 @@
 #include <benchmark/benchmark.h>
 
+#include "inexor/vulkan-renderer/meta.hpp"
+
 #include <iostream>
 
 int main(int argc, char **argv) {
+    using namespace inexor::vulkan_renderer;
+
+    // Print engine and application metadata.
+    std::cout << m_engine_name << ", version " << m_engine_version_str << std::endl;
+    std::cout << m_application_name << ", version " << m_application_version_str << std::endl;
+    std::cout << "Configuration: " << m_build_type << ", Git SHA " << m_build_git << std::endl;
+
     benchmark::Initialize(&argc, argv);
     if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
         return 1;
     }
     benchmark::RunSpecifiedBenchmarks();
 
+    std::cout << "Press Enter to close" << std::endl;
     std::cin.get();
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,32 +96,6 @@ if(MSVC)
     target_compile_options(inexor-vulkan-renderer PRIVATE "-EHs")
 endif()
 
-# The marked constants in application.hpp will be replaced with the following values
-set(ENGINE_NAME "Inexor Engine")
-set(APP_NAME "Inexor Vulkan-renderer example")
-
-set(ENGINE_VERSION_MAJOR 0)
-set(ENGINE_VERSION_MINOR 1)
-set(ENGINE_VERSION_PATCH 0)
-
-set(APP_VERSION_MAJOR 1)
-set(APP_VERSION_MINOR 0)
-set(APP_VERSION_PATCH 0)
-
-set(BUILD_TYPE ${CMAKE_BUILD_TYPE})
-
-# Extract the current git sha
-find_package(Git REQUIRED)
-set(GIT_SHA "unknown")
-
-execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=7
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    ERROR_QUIET
-    OUTPUT_VARIABLE GIT_SHA
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
 # Replace variables in header file with CMake values
 configure_file(
     ../include/inexor/vulkan-renderer/meta.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/inexor/vulkan-renderer/meta.hpp
@@ -133,7 +107,7 @@ target_include_directories(
     PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/third_party
-# Include configured header files
+    # Include configured header file which contains engine metadata
     ${CMAKE_CURRENT_BINARY_DIR}/include/
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_executable(inexor-vulkan-renderer-tests unit_tests_main.cpp)
+add_executable(
+    inexor-vulkan-renderer-tests
+    unit_tests_main.cpp
+)
 
 set_target_properties(
     inexor-vulkan-renderer-tests PROPERTIES
@@ -6,6 +9,14 @@ set_target_properties(
     CXX_EXTENSIONS OFF
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(
+    inexor-vulkan-renderer-tests
+
+    PUBLIC
+    # Include configured header file which contains engine metadata
+    ${CMAKE_BINARY_DIR}/src/include/inexor/vulkan-renderer/
 )
 
 target_link_libraries(

--- a/tests/unit_tests_main.cpp
+++ b/tests/unit_tests_main.cpp
@@ -1,9 +1,20 @@
 #include <gtest/gtest.h>
 
+#include "inexor/vulkan-renderer/meta.hpp"
+
 #include <iostream>
 
 int main(int argc, char **argv) {
+    using namespace inexor::vulkan_renderer;
+
+    // Print engine and application metadata.
+    std::cout << m_engine_name << ", version " << m_engine_version_str << std::endl;
+    std::cout << m_application_name << ", version " << m_application_version_str << std::endl;
+    std::cout << "Configuration: " << m_build_type << ", Git SHA " << m_build_git << std::endl;
+    
     testing::InitGoogleTest(&argc, argv);
     RUN_ALL_TESTS();
+
+    std::cout << "Press Enter to close" << std::endl;
     std::cin.get();
 }

--- a/tests/unit_tests_main.cpp
+++ b/tests/unit_tests_main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     std::cout << m_engine_name << ", version " << m_engine_version_str << std::endl;
     std::cout << m_application_name << ", version " << m_application_version_str << std::endl;
     std::cout << "Configuration: " << m_build_type << ", Git SHA " << m_build_git << std::endl;
-    
+
     testing::InitGoogleTest(&argc, argv);
     RUN_ALL_TESTS();
 


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/360
I would like this to be merged into `hanni/version_constexpr_fix`.
Tested on Ubuntu 20.04 and Windows.

![Screenshot from 2021-05-02 23-23-32](https://user-images.githubusercontent.com/7914428/116828239-b8963900-ab9d-11eb-93a2-a0e2f24314de.png)
