### PR TITLE
[device|instance] Don't throw exception when it's not an error

### DIFF
--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -46,7 +46,8 @@ bool Device::is_extension_supported(const VkPhysicalDevice graphics_card, const 
     }
 
     if (device_extension_count == 0) {
-        throw std::runtime_error("Error: No Vulkan device extensions available!");
+        spdlog::info("No Vulkan device extensions available!");
+        return false;
     }
 
     std::vector<VkExtensionProperties> device_extensions(device_extension_count);
@@ -78,7 +79,8 @@ bool Device::is_layer_supported(const VkPhysicalDevice graphics_card, const std:
     }
 
     if (device_layer_count == 0) {
-        throw std::runtime_error("Error: No Vulkan device extensions available!");
+        spdlog::info("No Vulkan device layers available!");
+        return false;
     }
 
     std::vector<VkLayerProperties> device_layers(device_layer_count);

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -19,7 +19,8 @@ bool Instance::is_layer_supported(const std::string &layer_name) {
     }
 
     if (instance_layer_count == 0) {
-        throw std::runtime_error("Error: No Vulkan instance layers available!");
+        spdlog::info("No Vulkan instance layers available!");
+        return false;
     }
 
     std::vector<VkLayerProperties> instance_layers(instance_layer_count);
@@ -45,7 +46,8 @@ bool Instance::is_extension_supported(const std::string &extension_name) {
     }
 
     if (instance_extension_count == 0) {
-        throw std::runtime_error("Error: No Vulkan instance extensions available!");
+        spdlog::info("No Vulkan instance extensions available!");
+        return false;
     }
 
     std::vector<VkExtensionProperties> instance_extensions(instance_extension_count);


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/389

Also: copy paste errors in action haha
```cpp
if (device_layer_count == 0) {
    throw std::runtime_error("Error: No Vulkan device extensions available!");
}
```
