### PR TITLE
[input] Refactoring

### DIFF
--- a/documentation/source/development/reference/keyboard-mouse-input.rst
+++ b/documentation/source/development/reference/keyboard-mouse-input.rst
@@ -1,7 +1,7 @@
 Keyboard and mouse input
 ========================
 
-Inexor engine uses `glfw3 <https://www.glfw.org/>`__ for window management and for keyboard and mouse input. Inexor does not use `manual polling <https://www.glfw.org/docs/3.3/group__input.html#ga67ddd1b7dcbbaff03e4a76c0ea67103a>`__ of keyboard and mouse input data, but uses `callbacks <https://www.glfw.org/docs/3.3/input_guide.html#input_keyboard>`__ instead. This way, we ensure we are not missing a key event. For more information check out `glfw's input guide <https://www.glfw.org/docs/3.3/input_guide.html>`__. Inexor uses a wrapper class for keyboard and mouse input data, called ``KeyboardMouseInputData``. This class offers an easy-to-use interface for setting and getting keyboard and mouse input.
+Inexor engine uses `glfw3 <https://www.glfw.org/>`__ for window management and for keyboard and mouse input. Inexor does not use `manual polling <https://www.glfw.org/docs/3.3/group__input.html#ga67ddd1b7dcbbaff03e4a76c0ea67103a>`__ of keyboard and mouse input data, but uses `callbacks <https://www.glfw.org/docs/3.3/input_guide.html#input_keyboard>`__ instead. This way, we ensure we are not missing a key event. For more information check out `glfw's input guide <https://www.glfw.org/docs/3.3/input_guide.html>`__. Inexor uses a wrapper class for keyboard and mouse input data, called ``KeyboardMouseInputData``. This class offers an easy-to-use interface for setting and getting keyboard and mouse input. ``KeyboardMouseInputData`` is thread safe since `pull request 401. <https://github.com/inexorgame/vulkan-renderer/pull/401>`__
 
 .. note::
 
@@ -9,12 +9,13 @@ Inexor engine uses `glfw3 <https://www.glfw.org/>`__ for window management and f
 
 .. note::
 
-    Currently, ``KeyboardMouseInputData`` is not thread safe! It is important to note that it's not possible handle glfw input data in a thread which is separate from the thread which created the corresponding window. For more information, check out this `glfw forum post <https://discourse.glfw.org/t/multithreading-glfw/573>`__.
+    It's not possible handle glfw input data in a thread which is separate from the thread which created the corresponding window. For more information, check out this `glfw forum post <https://discourse.glfw.org/t/multithreading-glfw/573>`__.
 
 Keyboard input
 --------------
 
-* We store the pressed keys as a ``std::unordered_map<std::int32_t, bool>`` member in ``KeyboardMouseInputData``
+* We store the pressed keys as a ``std::array<bool, GLFW_KEY_LAST>`` member in ``KeyboardMouseInputData``
+* The maximum number of keys is defined by ``GLFW_KEY_LAST``
 * If a key is pressed or released, we notify ``KeyboardMouseInputData`` by calling method ``press_key`` and ``release_key``, respectively
 * Check if a key is currently pressed by calling method ``is_key_pressed``
 * Check if a key was pressed once by calling method ``was_key_pressed_once``
@@ -22,7 +23,8 @@ Keyboard input
 Mouse input
 -----------
 
-* We store the pressed mouse buttons as a ``std::unordered_map<std::int32_t, bool>`` member in ``KeyboardMouseInputData``.
+* We store the pressed mouse buttons as a ``std::array<bool, GLFW_MOUSE_BUTTON_LAST>`` member in ``KeyboardMouseInputData``
+* The maximum number of mouse buttons is defined by ``GLFW_MOUSE_BUTTON_LAST``.
 * If a mouse button is pressed or released, we notify ``KeyboardMouseInputData`` by calling method ``press_mouse_button`` and ``release_mouse_button``, respectively
 * To update the current cursor position, we call ``set_cursor_pos``
 * To get the current cursor position, we call ``get_cursor_pos``

--- a/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
+++ b/include/inexor/vulkan-renderer/input/keyboard_mouse_data.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
+#include <GLFW/glfw3.h>
+
 #include <array>
-#include <cstdint>
-#include <unordered_map>
+#include <shared_mutex>
 
 namespace inexor::vulkan_renderer::input {
 
 /// @brief A wrapper for keyboard and mouse input data.
-/// @warning Not thread safe!
 class KeyboardMouseInputData {
+private:
     std::array<std::int64_t, 2> m_previous_cursor_pos{0, 0};
     std::array<std::int64_t, 2> m_current_cursor_pos{0, 0};
-    std::unordered_map<std::int32_t, bool> m_pressed_keys;
-    std::unordered_map<std::int32_t, bool> m_pressed_mouse_buttons;
-    bool keyboard_updated{false};
-    bool mouse_buttons_updated{false};
+    std::array<bool, GLFW_KEY_LAST> m_pressed_keys{false};
+    std::array<bool, GLFW_MOUSE_BUTTON_LAST> m_pressed_mouse_buttons{false};
+    bool m_keyboard_updated{false};
+    bool m_mouse_buttons_updated{false};
+    mutable std::shared_mutex m_input_mutex;
 
 public:
     KeyboardMouseInputData() = default;
@@ -26,55 +28,59 @@ public:
     KeyboardMouseInputData &operator=(KeyboardMouseInputData &&) = delete;
 
     /// @brief Change the key's state to pressed.
-    /// @param key The key which was pressed.
+    /// @param key the key which was pressed
     void press_key(std::int32_t key);
 
     /// @brief Change the key's state to unpressed.
-    /// @param key The key which was released.
+    /// @param key the key which was released
+    /// @note key must be smaller than ``GLFW_KEY_LAST``
     void release_key(std::int32_t key);
 
+    /// @brief Check if the given key is currently pressed.
+    /// @param key the key index
+    /// @note key must be smaller than ``GLFW_KEY_LAST``
+    /// @return ``true`` if the key is pressed
+    [[nodiscard]] bool is_key_pressed(std::int32_t key) const;
+
+    /// @brief Checks if a key was pressed once.
+    /// @param key The key index
+    /// @note key must be smaller than ``GLFW_KEY_LAST``
+    /// @return ``true`` if the key was pressed
+    [[nodiscard]] bool was_key_pressed_once(std::int32_t key);
+
     /// @brief Change the mouse button's state to pressed.
-    /// @param button The mouse button which was pressed.
+    /// @param button the mouse button which was pressed
+    /// @note button must be smaller than ``GLFW_MOUSE_BUTTON_LAST``
     void press_mouse_button(std::int32_t button);
 
     /// @brief Change the mouse button's state to unpressed.
-    /// @param button The mouse button which was released.
+    /// @param button the mouse button which was released
+    /// @note button must be smaller than ``GLFW_MOUSE_BUTTON_LAST``
     void release_mouse_button(std::int32_t button);
 
-    /// @brief Set the current cursor position.
-    /// @param cursor_pos_x The current x-coordinate of the cursor.
-    /// @param cursor_pos_y The current y-coordinate of the cursor.
-    void set_cursor_pos(double cursor_pos_x, double cursor_pos_y);
-
-    /// @return Return a std::array of size 2 which contains the x-position in index 0 and y-position in index 1.
-    [[nodiscard]] std::array<std::int64_t, 2> get_cursor_pos() const;
-
     /// @brief Check if the given mouse button is currently pressed.
-    /// @param mouse_button The mouse button index.
-    /// @returm True if the mouse button is pressed, false otherwise.
-    [[nodiscard]] bool is_mouse_button_pressed(std::int32_t mouse_button);
-
-    /// @brief Check if the given key is currently pressed.
-    /// @param key The key index.
-    /// @retur True if the key is pressed, false otherwise.
-    [[nodiscard]] bool is_key_pressed(std::int32_t key);
-
-    /// @brief Calculate the change in x- and y-position of the cursor.
-    /// @return A std::array of size 2 which contains the change in x-position in index 0
-    /// and the change in y-position in index 1.
-    [[nodiscard]] std::array<double, 2> calculate_cursor_position_delta();
-
-    /// @brief Checks if a key was pressed once.
-    /// @note This method will set the state of the key to false upon call.
-    /// @param key The key index.
-    /// @retur True if the key was pressed, false otherwise.
-    [[nodiscard]] bool was_key_pressed_once(std::int32_t key);
+    /// @param button the mouse button index
+    /// @note button must be smaller than ``GLFW_MOUSE_BUTTON_LAST``
+    /// @return ``true`` if the mouse button is pressed
+    [[nodiscard]] bool is_mouse_button_pressed(std::int32_t button) const;
 
     /// @brief Checks if a mouse button was pressed once.
-    /// @note This method will set the state of the mouse button to false upon call.
-    /// @param mouse_button The mouse button index.
-    /// @returm True if the mouse button was pressed, false otherwise.
-    [[nodiscard]] bool was_mouse_button_pressed_once(std::int32_t mouse_button);
+    /// @param button the mouse button index
+    /// @note button must be smaller than ``GLFW_MOUSE_BUTTON_LAST``
+    /// @return ``true`` if the mouse button was pressed
+    [[nodiscard]] bool was_mouse_button_pressed_once(std::int32_t button);
+
+    /// @brief Set the current cursor position.
+    /// @param pos_x the current x-coordinate of the cursor
+    /// @param pos_y the current y-coordinate of the cursor
+    void set_cursor_pos(double pos_x, double pos_y);
+
+    [[nodiscard]] std::array<std::int64_t, 2> get_cursor_pos() const;
+
+    /// @brief Calculate the change in x- and y-position of the cursor.
+    /// @return a std::array of size 2 which contains the change in x-position in index 0 and the change in y-position
+    /// in index 1
+    [[nodiscard]] std::array<double, 2> calculate_cursor_position_delta();
 };
 
 } // namespace inexor::vulkan_renderer::input

--- a/src/vulkan-renderer/input/keyboard_mouse_data.cpp
+++ b/src/vulkan-renderer/input/keyboard_mouse_data.cpp
@@ -1,75 +1,90 @@
 #include "inexor/vulkan-renderer/input/keyboard_mouse_data.hpp"
 
+#include <cassert>
+#include <mutex>
+
 namespace inexor::vulkan_renderer::input {
 
 void KeyboardMouseInputData::press_key(const std::int32_t key) {
+    assert(key < GLFW_KEY_LAST);
+    std::scoped_lock lock(m_input_mutex);
     m_pressed_keys[key] = true;
-    keyboard_updated = true;
+    m_keyboard_updated = true;
 }
 
 void KeyboardMouseInputData::release_key(const std::int32_t key) {
+    assert(key < GLFW_KEY_LAST);
+    std::scoped_lock lock(m_input_mutex);
     m_pressed_keys[key] = false;
-    keyboard_updated = true;
+    m_keyboard_updated = true;
+}
+
+bool KeyboardMouseInputData::is_key_pressed(const std::int32_t key) const {
+    assert(key < GLFW_KEY_LAST);
+    std::shared_lock lock(m_input_mutex);
+    return m_pressed_keys[key];
+}
+bool KeyboardMouseInputData::was_key_pressed_once(const std::int32_t key) {
+    assert(key < GLFW_KEY_LAST);
+    std::scoped_lock lock(m_input_mutex);
+    if (m_pressed_keys[key] || !m_keyboard_updated) {
+        return false;
+    }
+    m_pressed_keys[key] = false;
+    return true;
 }
 
 void KeyboardMouseInputData::press_mouse_button(const std::int32_t button) {
+    assert(button < GLFW_MOUSE_BUTTON_LAST);
+    std::scoped_lock lock(m_input_mutex);
     m_pressed_mouse_buttons[button] = true;
-    mouse_buttons_updated = true;
+    m_mouse_buttons_updated = true;
 }
 
 void KeyboardMouseInputData::release_mouse_button(const std::int32_t button) {
+    assert(button < GLFW_MOUSE_BUTTON_LAST);
+    std::scoped_lock lock(m_input_mutex);
     m_pressed_mouse_buttons[button] = false;
-    mouse_buttons_updated = true;
+    m_mouse_buttons_updated = true;
 }
 
-void KeyboardMouseInputData::set_cursor_pos(const double cursor_pos_x, const double cursor_pos_y) {
-    m_current_cursor_pos[0] = static_cast<std::int64_t>(cursor_pos_x);
-    m_current_cursor_pos[1] = static_cast<std::int64_t>(cursor_pos_y);
+bool KeyboardMouseInputData::is_mouse_button_pressed(const std::int32_t button) const {
+    assert(button < GLFW_MOUSE_BUTTON_LAST);
+    std::shared_lock lock(m_input_mutex);
+    return m_pressed_mouse_buttons[button];
+}
+
+bool KeyboardMouseInputData::was_mouse_button_pressed_once(const std::int32_t button) {
+    assert(button < GLFW_MOUSE_BUTTON_LAST);
+    std::scoped_lock lock(m_input_mutex);
+    if (!m_pressed_mouse_buttons[button] || !m_mouse_buttons_updated) {
+        return false;
+    }
+    m_pressed_mouse_buttons[button] = false;
+    return true;
+}
+
+void KeyboardMouseInputData::set_cursor_pos(const double pos_x, const double pos_y) {
+    std::scoped_lock lock(m_input_mutex);
+    m_current_cursor_pos[0] = static_cast<std::int64_t>(pos_x);
+    m_current_cursor_pos[1] = static_cast<std::int64_t>(pos_y);
 }
 
 std::array<std::int64_t, 2> KeyboardMouseInputData::get_cursor_pos() const {
+    std::shared_lock lock(m_input_mutex);
     return m_current_cursor_pos;
-}
-
-bool KeyboardMouseInputData::is_mouse_button_pressed(std::int32_t mouse_button) {
-    return m_pressed_mouse_buttons[mouse_button];
-}
-
-bool KeyboardMouseInputData::is_key_pressed(std::int32_t key) {
-    return m_pressed_keys[key];
 }
 
 std::array<double, 2> KeyboardMouseInputData::calculate_cursor_position_delta() {
     // Calculate the change in cursor position in x- and y-axis.
-    const std::array<double, 2> m_cursor_pos_delta{
+    const std::array m_cursor_pos_delta{
         static_cast<double>(m_current_cursor_pos[0]) - static_cast<double>(m_previous_cursor_pos[0]),
         static_cast<double>(m_current_cursor_pos[1]) - static_cast<double>(m_previous_cursor_pos[1])};
 
+    std::scoped_lock lock(m_input_mutex);
     m_previous_cursor_pos = m_current_cursor_pos;
 
     return m_cursor_pos_delta;
-}
-
-[[nodiscard]] bool KeyboardMouseInputData::was_key_pressed_once(const std::int32_t key) {
-    if (!keyboard_updated) {
-        return false;
-    }
-    if (m_pressed_keys[key]) {
-        m_pressed_keys[key] = false;
-        return true;
-    }
-    return false;
-}
-
-[[nodiscard]] bool KeyboardMouseInputData::was_mouse_button_pressed_once(const std::int32_t mouse_button) {
-    if (!mouse_buttons_updated) {
-        return false;
-    }
-    if (m_pressed_mouse_buttons[mouse_button]) {
-        m_pressed_mouse_buttons[mouse_button] = false;
-        return true;
-    }
-    return false;
 }
 
 } // namespace inexor::vulkan_renderer::input


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/400

This makes the input class thread safe and uses a `std::vector` instead of an `std::unordered_map` to store the keys.