### PR TITLE
[camera] Make sure to convert horizontal fov to vertical fov before passing to glm

### DIFF
--- a/configuration/renderer.toml
+++ b/configuration/renderer.toml
@@ -13,8 +13,8 @@ name = "Inexor-Engine"
 
 [application.window]
 mode = "windowed"
-width = 800
-height = 800
+width = 1280
+height = 720
 name = "Inexor-Vulkan-Renderer"
 
 [shaders]

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -53,7 +53,7 @@ private:
     /// The camera's maximum pitch angle.
     /// Looking straight upwards is the maximum pitch angle.
     float m_pitch_max{+89.0f};
-    /// The camera's field of view.
+    /// The camera's horizontal field of view.
     float m_fov{90.0f};
     /// The camera's maximum field of view.
     float m_fov_max{90.0f};

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -76,8 +76,6 @@ private:
 
     /// The keys for the movement FORWARD, BACKWARD, LEFT, RIGHT.
     std::array<bool, 4> m_keys{false, false, false, false};
-    /// Will be set to ``true`` if the matrices need to be recalculated.
-    bool m_update_needed{true};
 
     void update_vectors();
 
@@ -212,16 +210,12 @@ public:
     void update(float delta_time);
 
     [[nodiscard]] const glm::mat4 &view_matrix() {
-        if (m_update_needed) {
-            update_matrices();
-        }
+        update_matrices();
         return m_view_matrix;
     }
 
     [[nodiscard]] const glm::mat4 &perspective_matrix() {
-        if (m_update_needed) {
-            update_matrices();
-        }
+        update_matrices();
         return m_perspective_matrix;
     }
 };

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -77,6 +77,12 @@ private:
     /// The keys for the movement FORWARD, BACKWARD, LEFT, RIGHT.
     std::array<bool, 4> m_keys{false, false, false, false};
 
+    float m_vertical_fov{0.0f};
+
+    bool m_update_vertical_fov{false};
+    bool m_update_view_matrix{false};
+    bool m_update_perspective_matrix{false};
+
     void update_vectors();
 
     void update_matrices();

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -28,8 +28,9 @@ void Camera::update_vectors() {
 
 void Camera::update_matrices() {
     if (m_type == CameraType::LOOK_AT) {
+        const float vertical_fov = 2.0f * glm::atan(glm::tan(glm::radians(m_fov) / 2.0f) / m_aspect_ratio);
         m_view_matrix = glm::lookAt(m_position, m_position + m_front, m_up);
-        m_perspective_matrix = glm::perspective(glm::radians(m_fov), m_aspect_ratio, m_near_plane, m_far_plane);
+        m_perspective_matrix = glm::perspective(vertical_fov, m_aspect_ratio, m_near_plane, m_far_plane);
         m_update_needed = false;
     }
 }

--- a/src/vulkan-renderer/camera.cpp
+++ b/src/vulkan-renderer/camera.cpp
@@ -22,7 +22,6 @@ void Camera::update_vectors() {
         m_front = glm::normalize(front);
         m_right = glm::normalize(glm::cross(m_front, m_world_up));
         m_up = glm::normalize(glm::cross(m_right, m_front));
-        m_update_needed = false;
     }
 }
 
@@ -31,7 +30,6 @@ void Camera::update_matrices() {
         const float vertical_fov = 2.0f * glm::atan(glm::tan(glm::radians(m_fov) / 2.0f) / m_aspect_ratio);
         m_view_matrix = glm::lookAt(m_position, m_position + m_front, m_up);
         m_perspective_matrix = glm::perspective(vertical_fov, m_aspect_ratio, m_near_plane, m_far_plane);
-        m_update_needed = false;
     }
 }
 
@@ -107,8 +105,6 @@ void Camera::change_zoom(const float offset) {
 }
 
 void Camera::update(const float delta_time) {
-    m_update_needed = true;
-
     if (m_type == CameraType::LOOK_AT && is_moving()) {
         const float move_speed = delta_time * m_movement_speed;
 


### PR DESCRIPTION
Closes https://github.com/inexorgame/vulkan-renderer/issues/407

`glm::perspective` takes in the vertical FOV, so passing in a value of `90` gives us a horizontal FOV of `121`, which is pretty high. This PR adds a conversion before constructing the projection matrix, and also changes the default window size to have an aspect ratio of 16:9 (otherwise the hfov will equal vfov which makes things not look right)