### PR TITLE
Implement basic SPIR-V reflection

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -13,7 +13,6 @@ class Device;
 class Shader {
     const Device &m_device;
     std::string m_name;
-    std::string m_entry_point;
     VkShaderStageFlagBits m_type;
     VkShaderModule m_shader_module{VK_NULL_HANDLE};
 
@@ -24,8 +23,7 @@ public:
     /// @param name The internal debug marker name of the VkShaderModule.
     /// @param code The memory block of the SPIR-V shader.
     /// @param entry_point The name of the entry point, "main" by default.
-    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code,
-           const std::string &entry_point = "main");
+    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code);
 
     /// @brief Construct a shader module from a SPIR-V file.
     /// This constructor loads the file content and just calls the other constructor.
@@ -34,8 +32,7 @@ public:
     /// @param name The internal debug marker name of the VkShaderModule.
     /// @param file_name The name of the SPIR-V shader file to load.
     /// @param entry_point The name of the entry point, "main" by default.
-    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name,
-           const std::string &entry_point = "main");
+    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name);
 
     Shader(const Shader &) = delete;
     Shader(Shader &&) noexcept;
@@ -47,10 +44,6 @@ public:
 
     [[nodiscard]] const std::string &name() const {
         return m_name;
-    }
-
-    [[nodiscard]] const std::string &entry_point() const {
-        return m_entry_point;
     }
 
     [[nodiscard]] VkShaderStageFlagBits type() const {

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -2,6 +2,7 @@
 
 #include <vulkan/vulkan_core.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -13,30 +14,27 @@ class Device;
 class Shader {
     const Device &m_device;
     std::string m_name;
-    VkShaderStageFlagBits m_type;
-    VkShaderModule m_shader_module{VK_NULL_HANDLE};
+    VkShaderModule m_module{VK_NULL_HANDLE};
+
+    VkShaderStageFlagBits m_stage;
 
 public:
-    /// @brief Construct a shader module from a block of SPIR-V memory.
-    /// @param device The const reference to a device RAII wrapper instance.
-    /// @param type The shader type.
-    /// @param name The internal debug marker name of the VkShaderModule.
-    /// @param code The memory block of the SPIR-V shader.
-    /// @param entry_point The name of the entry point, "main" by default.
-    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::vector<char> &code);
-
     /// @brief Construct a shader module from a SPIR-V file.
     /// This constructor loads the file content and just calls the other constructor.
     /// @param device The const reference to a device RAII wrapper instance.
-    /// @param type The shader type.
     /// @param name The internal debug marker name of the VkShaderModule.
     /// @param file_name The name of the SPIR-V shader file to load.
     /// @param entry_point The name of the entry point, "main" by default.
-    Shader(const Device &m_device, VkShaderStageFlagBits type, const std::string &name, const std::string &file_name);
+    Shader(const Device &m_device, const std::string &name, const std::string &file_name);
 
+    /// @brief Construct a shader module from a block of SPIR-V memory.
+    /// @param device The const reference to a device RAII wrapper instance.
+    /// @param name The internal debug marker name of the VkShaderModule.
+    /// @param binary The memory block of the SPIR-V shader.
+    /// @param entry_point The name of the entry point, "main" by default.
+    Shader(const Device &m_device, const std::string &name, std::vector<char> &&binary);
     Shader(const Shader &) = delete;
     Shader(Shader &&) noexcept;
-
     ~Shader();
 
     Shader &operator=(const Shader &) = delete;
@@ -46,12 +44,12 @@ public:
         return m_name;
     }
 
-    [[nodiscard]] VkShaderStageFlagBits type() const {
-        return m_type;
+    [[nodiscard]] VkShaderModule module() const {
+        return m_module;
     }
 
-    [[nodiscard]] VkShaderModule module() const {
-        return m_shader_module;
+    [[nodiscard]] VkShaderStageFlagBits stage() const {
+        return m_stage;
     }
 };
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -163,7 +163,7 @@ void Application::load_shaders() {
         spdlog::debug("Loading vertex shader file {}.", vertex_shader_file);
 
         // Insert the new shader into the list of shaders.
-        m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader", vertex_shader_file);
+        m_shaders.emplace_back(*m_device, "unnamed vertex shader", vertex_shader_file);
     }
 
     spdlog::debug("Loading fragment shaders.");
@@ -177,8 +177,7 @@ void Application::load_shaders() {
         spdlog::debug("Loading fragment shader file {}.", fragment_shader_file);
 
         // Insert the new shader into the list of shaders.
-        m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
-                               fragment_shader_file);
+        m_shaders.emplace_back(*m_device, "unnamed fragment shader", fragment_shader_file);
     }
 
     spdlog::debug("Loading shaders finished.");

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -38,10 +38,8 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     io.FontGlobalScale = m_scale;
 
     spdlog::debug("Loading ImGUI shaders");
-    m_vertex_shader = std::make_unique<wrapper::Shader>(m_device, VK_SHADER_STAGE_VERTEX_BIT, "ImGUI vertex shader",
-                                                        "shaders/ui.vert.spv");
-    m_fragment_shader = std::make_unique<wrapper::Shader>(m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                                          "ImGUI fragment shader", "shaders/ui.frag.spv");
+    m_vertex_shader = std::make_unique<wrapper::Shader>(m_device, "ImGUI vertex shader", "shaders/ui.vert.spv");
+    m_fragment_shader = std::make_unique<wrapper::Shader>(m_device, "ImGUI fragment shader", "shaders/ui.frag.spv");
 
     // Load font texture
 

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -39,7 +39,7 @@ void GraphicsStage::bind_buffer(const BufferResource *buffer, const std::uint32_
 void GraphicsStage::uses_shader(const wrapper::Shader &shader) {
     auto create_info = wrapper::make_info<VkPipelineShaderStageCreateInfo>();
     create_info.module = shader.module();
-    create_info.stage = shader.type();
+    create_info.stage = shader.stage();
     create_info.pName = "main";
     m_shaders.push_back(create_info);
 }

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -40,7 +40,7 @@ void GraphicsStage::uses_shader(const wrapper::Shader &shader) {
     auto create_info = wrapper::make_info<VkPipelineShaderStageCreateInfo>();
     create_info.module = shader.module();
     create_info.stage = shader.type();
-    create_info.pName = shader.entry_point().c_str();
+    create_info.pName = "main";
     m_shaders.push_back(create_info);
 }
 

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -35,16 +35,15 @@ std::vector<char> read_binary(const std::string &file_name) {
 namespace inexor::vulkan_renderer::wrapper {
 
 Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std::string &name,
-               const std::string &file_name, const std::string &entry_point)
-    : Shader(device, type, name, read_binary(file_name), entry_point) {}
+               const std::string &file_name)
+    : Shader(device, type, name, read_binary(file_name)) {}
 
 Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std::string &name,
-               const std::vector<char> &code, const std::string &entry_point)
-    : m_device(device), m_type(type), m_name(name), m_entry_point(entry_point) {
+               const std::vector<char> &code)
+    : m_device(device), m_type(type), m_name(name) {
     assert(device.device());
     assert(!name.empty());
     assert(!code.empty());
-    assert(!entry_point.empty());
 
     auto shader_module_ci = make_info<VkShaderModuleCreateInfo>();
     shader_module_ci.codeSize = code.size();
@@ -67,7 +66,6 @@ Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std
 Shader::Shader(Shader &&other) noexcept : m_device(other.m_device) {
     m_type = other.m_type;
     m_name = std::move(other.m_name);
-    m_entry_point = std::move(other.m_entry_point);
     m_shader_module = std::exchange(other.m_shader_module, nullptr);
 }
 


### PR DESCRIPTION
- [ ] Wait for #533 to be merged 

This PR introduces SPIR-V reflection to parse the execution stage and push constant size from each shader. We can take this further and extract more things like descriptor set layouts in the future.