### PR TITLE
[cmake] Ignore msvc linker warning LNK4099

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,6 +15,8 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
         inexor-vulkan-renderer-example
         PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     )
+    # Ignore MSVC linker warning LNK4099
+    set_target_properties(inexor-vulkan-renderer-example PROPERTIES LINK_FLAGS "/ignore:4099")
 endif()
 
 # enable exceptions when using MSVC toolchain, makes Clang on windows possible


### PR DESCRIPTION
Let's ignore this entirely since it's not important at all

https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4099?view=msvc-170
https://stackoverflow.com/questions/25843883/how-to-remove-warning-lnk4099-pdb-lib-pdb-was-not-found