### PR TITLE
[device|instance] Add missing Vulkan API version checks

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/instance.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/instance.hpp
@@ -11,7 +11,7 @@ namespace inexor::vulkan_renderer::wrapper {
 class Instance {
 private:
     VkInstance m_instance{VK_NULL_HANDLE};
-    std::uint32_t m_vk_api_version;
+    static constexpr std::uint32_t REQUIRED_VK_API_VERSION{VK_API_VERSION_1_2};
 
 public:
     /// @brief Check if a certain instance layer is available on the system.
@@ -25,33 +25,28 @@ public:
     [[nodiscard]] static bool is_extension_supported(const std::string &extension_name);
 
     /// @brief Construct the Vulkan instance and specify the requested instance layers and instance extensions.
-    /// @param application_name The Vulkan application's internal application name.
-    /// @param engine_name The Vulkan application's internal engine name.
-    /// @param application_version The Vulkan application's internal version.
-    /// @param engine_version The Vulkan application's internal engine version.
-    /// @param vk_api_version The requested version of Vulkan API from which an instance will be created.
-    /// If the requested version of Vulkan API is not available, the creation of the instance will fail!
-    /// @param enable_validation_layers True if validation layers should be enabled, false otherwise.
-    /// @param enable_renderdoc_layer True if renderdoc layer should be enabled, false otherwise.
-    /// @param requested_instance_extensions The instance extensions which are requested.
-    /// @param requested_instance_layers The instance layers which are requested.
+    /// @param application_name The Vulkan application's internal application name
+    /// @param engine_name The Vulkan application's internal engine name
+    /// @param application_version The Vulkan application's internal version
+    /// @param engine_version The Vulkan application's internal engine version
+    /// @param enable_validation_layers True if validation layers should be enabled
+    /// @param enable_renderdoc_layer True if renderdoc layer should be enabled
+    /// @param requested_instance_extensions The instance extensions which are requested
+    /// @param requested_instance_layers The instance layers which are requested
     Instance(const std::string &application_name, const std::string &engine_name, std::uint32_t application_version,
-             std::uint32_t engine_version, std::uint32_t vk_api_version, bool enable_validation_layers,
-             bool enable_renderdoc_layer, const std::vector<std::string> &requested_instance_extensions,
+             std::uint32_t engine_version, bool enable_validation_layers, bool enable_renderdoc_layer,
+             const std::vector<std::string> &requested_instance_extensions,
              const std::vector<std::string> &requested_instance_layers);
 
     /// @brief Construct the Vulkan instance without the requested instance layers and instance extensions.
-    /// @param application_name The Vulkan application's internal application name.
-    /// @param engine_name The Vulkan application's internal engine name.
-    /// @param application_version The Vulkan application's internal version.
-    /// @param engine_version The Vulkan application's internal engine version.
-    /// @param vk_api_version The requested version of Vulkan API from which an instance will be created.
-    /// If the requested version of Vulkan API is not available, the creation of the instance will fail!
-    /// @param enable_validation_layers True if validation layers should be enabled, false otherwise.
-    /// @param enable_renderdoc_layer True if renderdoc layer should be enabled, false otherwise.
+    /// @param application_name The Vulkan application's internal application name
+    /// @param engine_name The Vulkan application's internal engine name
+    /// @param application_version The Vulkan application's internal version
+    /// @param engine_version The Vulkan application's internal engine version
+    /// @param enable_validation_layers True if validation layers should be enabled, false otherwise
+    /// @param enable_renderdoc_layer True if renderdoc layer should be enabled, false otherwise
     Instance(const std::string &application_name, const std::string &engine_name, std::uint32_t application_version,
-             std::uint32_t engine_version, std::uint32_t vk_api_version, bool enable_validation_layers,
-             bool enable_renderdoc_layer);
+             std::uint32_t engine_version, bool enable_validation_layers, bool enable_renderdoc_layer);
 
     Instance(const Instance &) = delete;
     Instance(Instance &&) noexcept;
@@ -63,10 +58,6 @@ public:
 
     [[nodiscard]] VkInstance instance() const {
         return m_instance;
-    }
-
-    [[nodiscard]] std::uint32_t vulkan_api_version() const {
-        return m_vk_api_version;
     }
 };
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -394,8 +394,8 @@ Application::Application(int argc, char **argv) {
 
     m_instance = std::make_unique<wrapper::Instance>(
         APP_NAME, ENGINE_NAME, VK_MAKE_VERSION(APP_VERSION[0], APP_VERSION[1], APP_VERSION[2]),
-        VK_MAKE_VERSION(ENGINE_VERSION[0], ENGINE_VERSION[1], ENGINE_VERSION[2]), VK_API_VERSION_1_2,
-        m_enable_validation_layers, enable_renderdoc_instance_layer);
+        VK_MAKE_VERSION(ENGINE_VERSION[0], ENGINE_VERSION[1], ENGINE_VERSION[2]), m_enable_validation_layers,
+        enable_renderdoc_instance_layer);
 
     m_input_data = std::make_unique<input::KeyboardMouseInputData>();
 

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -326,13 +326,13 @@ Device::Device(const wrapper::Instance &instance, const VkSurfaceKHR surface, bo
 
     replay_file_test.close();
 
-    // VMA allows to record memory allocations to a .csv file.
+    // VMA allows recording memory allocations to a .csv file.
     // This .csv file can be replayed using tools from the repository.
     // This is very useful every time there is a bug in memory management.
     VmaRecordSettings vma_record_settings;
 
-    // We flush the stream after every write operation because we are expecting unforeseen program crashes.
-    // This might has a negative effect on the application's performance but it's worth it for now.
+    // We flush the stream after every write operation because we are expecting unforeseen program crashes
+    // This might have a negative effect on the application's performance
     vma_record_settings.flags = VMA_RECORD_FLUSH_AFTER_CALL_BIT;
     vma_record_settings.pFilePath = vma_replay_file.c_str();
 

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -340,7 +340,10 @@ Device::Device(const wrapper::Instance &instance, const VkSurfaceKHR surface, bo
     vma_allocator_ci.physicalDevice = m_graphics_card;
     vma_allocator_ci.instance = instance.instance();
     vma_allocator_ci.device = m_device;
-    vma_allocator_ci.vulkanApiVersion = instance.vulkan_api_version();
+
+    // Just tell Vulkan Memory Allocator to use Vulkan 1.1, even if a newer version is specified in instance wrapper
+    // This might need to be changed in the future
+    vma_allocator_ci.vulkanApiVersion = VK_API_VERSION_1_1;
 #if VMA_RECORDING_ENABLED
     vma_allocator_ci.pRecordSettings = &vma_record_settings;
 #endif


### PR DESCRIPTION
- [x] Throw an exception in instance wrapper if the requested version of Vulkan API is not available
- ~~If the version of Vulkan API specified inside of the instance wrapper is greater than `VK_API_VERSION_1_1`, tell Vulkan memory allovator (VMA) to use no newer version than `VK_API_VERSION_1_1` anyways.~~