### PR TITLE
[ci] Change windows runner to windows-2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
   windows:
     name: ${{ matrix.config.name }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This change should allow Windows builds to work correctly again
after GitHub updated the windows-latest runner to Windows Server 2022.

Ideally, we want to stay up-to-date with the latest windows runners so
a separate issue will be raised to address this to eventually move to windows-2022.

https://github.com/actions/virtual-environments/issues/4856