### PR TITLE
Refactoring: Introduce wrapper functions for Vulkan create methods

### DIFF
--- a/include/inexor/vulkan-renderer/render_graph.hpp
+++ b/include/inexor/vulkan-renderer/render_graph.hpp
@@ -197,6 +197,10 @@ public:
         m_push_constant_ranges.push_back(range);
     }
 
+    [[nodiscard]] const std::string &name() const {
+        return m_name;
+    }
+
     /// @brief Specifies a function that will be called during command buffer recording for this stage
     /// @details This function can be used to specify other vulkan commands during command buffer recording. The most
     /// common use for this is for draw commands.

--- a/include/inexor/vulkan-renderer/render_graph.hpp
+++ b/include/inexor/vulkan-renderer/render_graph.hpp
@@ -70,6 +70,10 @@ public:
 
     RenderResource &operator=(const RenderResource &) = delete;
     RenderResource &operator=(RenderResource &&) = delete;
+
+    [[nodiscard]] const std::string &name() const {
+        return m_name;
+    }
 };
 
 enum class BufferUsage {

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -11,6 +11,7 @@ class Device;
 
 /// @brief RAII wrapper class for VkCommandPool.
 class CommandPool {
+    std::string m_name;
     const Device &m_device;
     VkCommandPool m_command_pool{VK_NULL_HANDLE};
 
@@ -19,9 +20,10 @@ public:
     /// @note It is important that the queue family index is specified in the abstraction above this command pool
     /// wrapper. We can't choose one queue family index automatically inside of this wrapper which fits every purpose,
     /// because some wrappers require a queue family index which supports graphics bit, other require transfer bit.
-    /// @param device The const reference to the device RAII wrapper class.
-    /// @param queue_family_index The queue family index which is used by this command pool.
-    CommandPool(const Device &device, std::uint32_t queue_family_index);
+    /// @param device The const reference to the device RAII wrapper class
+    /// @param queue_family_index The queue family index which is used by this command pool
+    /// @param name The internal debug marker name which will be assigned to this command pool
+    CommandPool(const Device &device, std::uint32_t queue_family_index, std::string name);
 
     CommandPool(const CommandPool &) = delete;
     CommandPool(CommandPool &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
@@ -39,7 +39,7 @@ public:
     CpuTexture &operator=(const CpuTexture &) = delete;
     CpuTexture &operator=(CpuTexture &&) = default;
 
-    [[nodiscard]] std::string name() const {
+    [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -172,6 +172,13 @@ public:
     void create_descriptor_pool(const VkDescriptorPoolCreateInfo &descriptor_pool_ci, VkDescriptorPool *descriptor_pool,
                                 const std::string &name) const;
 
+    /// @brief Call vkCreateDescriptorSetLayout
+    /// @param descriptor_set_layout_ci The descriptor set layout create info structure
+    /// @param descriptor_set_layout The descriptor set layout to create
+    /// @param name The internal debug marker name which will be assigned to this descriptor set layout
+    void create_descriptor_set_layout(const VkDescriptorSetLayoutCreateInfo &descriptor_set_layout_ci,
+                               VkDescriptorSetLayout *descriptor_set_layout, const std::string &name) const;
+
     /// @brief Call vkCreateFramebuffer
     /// @param framebuffer_ci The framebuffer create info structure
     /// @param framebuffer The Vulkan framebuffer to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -157,6 +157,16 @@ public:
     /// @brief End the debug region of the current renderpass using vkCmdDebugMarkerEndEXT.
     /// @param command_buffer The command buffer which is associated to the debug marker
     void end_debug_region(VkCommandBuffer command_buffer) const;
+
+    /// @brief Call vkCreateGraphicsPipelines
+    /// @param pipeline_ci The graphics pipeline create info structure
+    /// @param pipeline The graphics pipeline to create
+    /// @param name The internal debug marker name which will be assigned to this pipeline
+    // TODO: Offer parameter for Vulkan pipeline caches!
+    // TODO: Use std::span to offer a more general method (creating multiple pipelines with one call)
+    // TODO: We might want to use std::span<std::pair<VkGraphicsPipelineCreateInfo, VkPipeline *>>
+    void create_graphics_pipeline(const VkGraphicsPipelineCreateInfo &pipeline_ci, VkPipeline *pipeline,
+                                  const std::string &name) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -177,7 +177,7 @@ public:
     /// @param descriptor_set_layout The descriptor set layout to create
     /// @param name The internal debug marker name which will be assigned to this descriptor set layout
     void create_descriptor_set_layout(const VkDescriptorSetLayoutCreateInfo &descriptor_set_layout_ci,
-                               VkDescriptorSetLayout *descriptor_set_layout, const std::string &name) const;
+                                      VkDescriptorSetLayout *descriptor_set_layout, const std::string &name) const;
 
     /// @brief Call vkCreateFramebuffer
     /// @param framebuffer_ci The framebuffer create info structure
@@ -203,6 +203,12 @@ public:
     void create_image_view(const VkImageViewCreateInfo &image_view_ci, VkImageView *image_view,
                            const std::string &name) const;
 
+    /// @brief Call vkCreatePipelineLayout
+    /// @param pipeline_layout_ci The pipeline layout create info structure
+    /// @param pipeline_layout The pipeline layout to create
+    /// @param name The internal debug marker name which will be assigned to this pipeline layout
+    void create_pipeline_layout(const VkPipelineLayoutCreateInfo &pipeline_layout_ci, VkPipelineLayout *pipeline_layout,
+                                const std::string &name) const;
     /// @brief Call vkCreateSemaphore
     /// @param semaphore_ci The semaphore create info structure
     /// @param semaphore The semaphore to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -165,6 +165,13 @@ public:
     void create_command_pool(const VkCommandPoolCreateInfo &command_pool_ci, VkCommandPool *command_pool,
                              const std::string &name) const;
 
+    /// @brief Call vkCreateDescriptorPool
+    /// @param descriptor_pool_ci The descriptor pool create info structure
+    /// @param descriptor_pool The descriptor pool to create
+    /// @param name The internal debug marker name which will be assigned to this command pool
+    void create_descriptor_pool(const VkDescriptorPoolCreateInfo &descriptor_pool_ci, VkDescriptorPool *descriptor_pool,
+                                const std::string &name) const;
+
     /// @brief Call vkCreateFramebuffer
     /// @param framebuffer_ci The framebuffer create info structure
     /// @param framebuffer The Vulkan framebuffer to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -158,6 +158,13 @@ public:
     /// @param command_buffer The command buffer which is associated to the debug marker
     void end_debug_region(VkCommandBuffer command_buffer) const;
 
+    /// @brief Call vkCreateCommandPool
+    /// @param command_pool_ci The command pool create info structure
+    /// @param command_pool The command pool to create
+    /// @param name The internal debug marker name which will be assigned to this command pool
+    void create_command_pool(const VkCommandPoolCreateInfo &command_pool_ci, VkCommandPool *command_pool,
+                             const std::string &name) const;
+
     /// @brief Call vkCreateFramebuffer
     /// @param framebuffer_ci The framebuffer create info structure
     /// @param framebuffer The Vulkan framebuffer to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -209,12 +209,20 @@ public:
     /// @param name The internal debug marker name which will be assigned to this pipeline layout
     void create_pipeline_layout(const VkPipelineLayoutCreateInfo &pipeline_layout_ci, VkPipelineLayout *pipeline_layout,
                                 const std::string &name) const;
+
     /// @brief Call vkCreateSemaphore
     /// @param semaphore_ci The semaphore create info structure
     /// @param semaphore The semaphore to create
     /// @param name The internal debug marker name which will be assigned to this semaphore
     void create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
                           const std::string &name) const;
+
+    /// @brief Call vkCreateShaderModule
+    /// @param shader_module_ci The shader module create info structure
+    /// @param shader_module The shader module to create
+    /// @param name The internal debug marker name which will be assigned to this shader module
+    void create_shader_module(const VkShaderModuleCreateInfo &shader_module_ci, VkShaderModule *shader_module,
+                              const std::string &name) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -174,6 +174,13 @@ public:
     // TODO: We might want to use std::span<std::pair<VkGraphicsPipelineCreateInfo, VkPipeline *>>
     void create_graphics_pipeline(const VkGraphicsPipelineCreateInfo &pipeline_ci, VkPipeline *pipeline,
                                   const std::string &name) const;
+
+    /// @brief Call vkCreateImageView
+    /// @param image_view_ci The image view create info structure
+    /// @param image_view The image view to create
+    /// @param name The internal debug marker name which will be assigned to this image view
+    void create_image_view(const VkImageViewCreateInfo &image_view_ci, VkImageView *image_view,
+                           const std::string &name) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -223,6 +223,12 @@ public:
     void create_render_pass(const VkRenderPassCreateInfo &render_pass_ci, VkRenderPass *render_pass,
                             const std::string &name) const;
 
+    /// @brief Call vkCreateSampler
+    /// @param sampler_ci The sampler create info structure
+    /// @param sampler The sampler to create
+    /// @param name The internal debug marker name which will be assigned to this sampler
+    void create_sampler(const VkSamplerCreateInfo &sampler_ci, VkSampler *sampler, const std::string &name) const;
+
     /// @brief Call vkCreateSemaphore
     /// @param semaphore_ci The semaphore create info structure
     /// @param semaphore The semaphore to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -181,6 +181,13 @@ public:
     /// @param name The internal debug marker name which will be assigned to this image view
     void create_image_view(const VkImageViewCreateInfo &image_view_ci, VkImageView *image_view,
                            const std::string &name) const;
+
+    /// @brief Call vkCreateSemaphore
+    /// @param semaphore_ci The semaphore create info structure
+    /// @param semaphore The semaphore to create
+    /// @param name The internal debug marker name which will be assigned to this semaphore
+    void create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
+                          const std::string &name) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -179,6 +179,12 @@ public:
     void create_descriptor_set_layout(const VkDescriptorSetLayoutCreateInfo &descriptor_set_layout_ci,
                                       VkDescriptorSetLayout *descriptor_set_layout, const std::string &name) const;
 
+    /// @brief Call vkCreateFence
+    /// @param fence_ci The fence create info structure
+    /// @param fence The fence to create
+    /// @param name The internal debug marker name which will be assigned to this fence
+    void create_fence(const VkFenceCreateInfo &fence_ci, VkFence *fence, const std::string &name) const;
+
     /// @brief Call vkCreateFramebuffer
     /// @param framebuffer_ci The framebuffer create info structure
     /// @param framebuffer The Vulkan framebuffer to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -216,6 +216,13 @@ public:
     void create_pipeline_layout(const VkPipelineLayoutCreateInfo &pipeline_layout_ci, VkPipelineLayout *pipeline_layout,
                                 const std::string &name) const;
 
+    /// @brief Call vkCreateRenderPass
+    /// @param render_pass_ci The render pass create info structure
+    /// @param render_pass The render pass to create
+    /// @param name The internal debug marker name which will be assigned to this render pass
+    void create_render_pass(const VkRenderPassCreateInfo &render_pass_ci, VkRenderPass *render_pass,
+                            const std::string &name) const;
+
     /// @brief Call vkCreateSemaphore
     /// @param semaphore_ci The semaphore create info structure
     /// @param semaphore The semaphore to create

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -41,34 +41,32 @@ class Device {
 
 public:
     /// @brief Check if a certain device extension is available for a specific graphics card.
-    /// @param graphics_card The graphics card.
-    /// @param extension The name of the device extension.
-    /// @return ``true`` if the requested device extension is available.
+    /// @param graphics_card The graphics card
+    /// @param extension The name of the device extension
+    /// @return ``true`` if the requested device extension is available
     [[nodiscard]] static bool is_extension_supported(VkPhysicalDevice graphics_card, const std::string &extension);
 
     /// @brief Check if a swapchain is available for a specific graphics card.
-    /// @param graphics_card The graphics card.
-    /// @return ``true`` if swapchain is supported.
+    /// @param graphics_card The graphics card
+    /// @return ``true`` if swapchain is supported
     [[nodiscard]] static bool is_swapchain_supported(VkPhysicalDevice graphics_card);
 
     /// @brief Check if presentation is available for a specific combination of graphics card and surface.
-    /// @param graphics_card The graphics card.
-    /// @param surface The (window) surface.
-    /// @return ``true`` if presentation is supported.
+    /// @param graphics_card The graphics card
+    /// @param surface The window surface
+    /// @return ``true`` if presentation is supported
     [[nodiscard]] static bool is_presentation_supported(VkPhysicalDevice graphics_card, VkSurfaceKHR surface);
 
     /// @brief Default constructor.
-    /// @param instance The instance wrapper from which the device will be created.
-    /// @param surface The surface which will be associated with the device.
-    /// @param enable_vulkan_debug_markers True if Vulkan debug markers should be enabled, false otherwise.
-    /// @param prefer_distinct_transfer_queue True if a distinct data transfer queue (if available) should be
-    /// enabled, false otherwise.
+    /// @param instance The instance wrapper from which the device will be created
+    /// @param surface The surface which will be associated with the device
+    /// @param enable_vulkan_debug_markers ``true`` if Vulkan debug markers should be enabled
+    /// @param prefer_distinct_transfer_queue ``true`` if a distinct data transfer queue should be preferred
     /// @param preferred_physical_device_index The index of the preferred graphics card which should be used,
     /// starting from 0. If the graphics card index is invalid or if the graphics card is unsuitable for the
     /// application's purpose, another graphics card will be selected automatically. See the details of the device
-    /// selection mechanism!
-    /// @todo Add overloaded constructors for VkPhysicalDeviceFeatures and requested device extensions in the
-    /// future!
+    /// selection mechanism.
+    /// TODO: Add overloaded constructors for VkPhysicalDeviceFeatures and requested device extensions
     Device(const wrapper::Instance &instance, VkSurfaceKHR surface, bool enable_vulkan_debug_markers,
            bool prefer_distinct_transfer_queue,
            std::optional<std::uint32_t> preferred_physical_device_index = std::nullopt);
@@ -126,38 +124,38 @@ public:
     /// @brief Assign an internal Vulkan debug marker name to a Vulkan object.
     /// This internal name can be seen in external debuggers like RenderDoc.
     /// @note This method is only available in debug mode with ``VK_EXT_debug_marker`` device extension enabled.
-    /// @param object The Vulkan object.
-    /// @param object_type The Vulkan debug report object type.
-    /// @param name The internal name of the Vulkan object.
+    /// @param object The Vulkan object
+    /// @param object_type The Vulkan debug report object type
+    /// @param name The internal name of the Vulkan object
     void set_debug_marker_name(void *object, VkDebugReportObjectTypeEXT object_type, const std::string &name) const;
 
     /// @brief Assigns a block of memory to a Vulkan resource.
     /// This memory block can be seen in external debuggers like RenderDoc.
     /// @note This method is only available in debug mode with ``VK_EXT_debug_marker`` device extension enabled.
-    /// @param object The Vulkan object.
-    /// @param object_type The Vulkan debug report object type.
-    /// @param name The name of the memory block which will be connected to this object.
-    /// @param memory_size The size of the memory block in bytes.
-    /// @param memory_address The memory address to read from.
+    /// @param object The Vulkan object
+    /// @param object_type The Vulkan debug report object type
+    /// @param name The name of the memory block which will be connected to this object
+    /// @param memory_size The size of the memory block in bytes
+    /// @param memory_block The memory block to read from
     void set_memory_block_attachment(void *object, VkDebugReportObjectTypeEXT object_type, std::uint64_t name,
                                      std::size_t memory_size, const void *memory_block) const;
 
-    /// @param color [in] The rgba color of the rendering region.
-    /// @param name [in] The name of the rendering region.
-    /// @param command_buffer [in] The associated command buffer.
-    /// The rendering region will be visible in external debuggers like RenderDoc.
     /// @brief Vulkan debug markers: Annotation of a rendering region.
+    /// The rendering region will be visible in external debuggers like RenderDoc.
+    /// @param command_buffer The associated command buffer
+    /// @param name The name of the rendering region
+    /// @param color The rgba color of the rendering region
     void bind_debug_region(VkCommandBuffer command_buffer, const std::string &name, std::array<float, 4> color) const;
 
-    /// @brief Insert a debug markers into the current renderpass using vkCmdDebugMarkerInsertEXT. This debug
-    /// markers can be seen in external debuggers like RenderDoc.
-    /// @param command_buffer The command buffer which is associated to the debug marker.
-    /// @param name The name of the debug marker.
-    /// @param color An array of red, green, blue and alpha values for the debug region's color.
+    /// @brief Insert a debug markers into the current renderpass using vkCmdDebugMarkerInsertEXT.
+    /// This debug markers can be seen in external debuggers like RenderDoc.
+    /// @param command_buffer The command buffer which is associated to the debug marker
+    /// @param name The name of the debug marker
+    /// @param color An array of red, green, blue and alpha values for the debug region's color
     void insert_debug_marker(VkCommandBuffer command_buffer, const std::string &name, std::array<float, 4> color) const;
 
     /// @brief End the debug region of the current renderpass using vkCmdDebugMarkerEndEXT.
-    /// @param command_buffer The command buffer which is associated to the debug marker.
+    /// @param command_buffer The command buffer which is associated to the debug marker
     void end_debug_region(VkCommandBuffer command_buffer) const;
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -236,6 +236,13 @@ public:
     /// @param name The internal debug marker name which will be assigned to this shader module
     void create_shader_module(const VkShaderModuleCreateInfo &shader_module_ci, VkShaderModule *shader_module,
                               const std::string &name) const;
+
+    /// @brief Call vkCreateSwapchainKHR
+    /// @param swapchain_ci The swapchain_ci create info structure
+    /// @param swapchain The swapchain to create
+    /// @param name The internal debug marker name which will be assigned to this swapchain
+    void create_swapchain(const VkSwapchainCreateInfoKHR &swapchain_ci, VkSwapchainKHR *swapchain,
+                          const std::string &name) const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -158,6 +158,13 @@ public:
     /// @param command_buffer The command buffer which is associated to the debug marker
     void end_debug_region(VkCommandBuffer command_buffer) const;
 
+    /// @brief Call vkCreateFramebuffer
+    /// @param framebuffer_ci The framebuffer create info structure
+    /// @param framebuffer The Vulkan framebuffer to create
+    /// @param name The internal debug marker name which will be assigned to this framebuffer
+    void create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
+                            const std::string &name) const;
+
     /// @brief Call vkCreateGraphicsPipelines
     /// @param pipeline_ci The graphics pipeline create info structure
     /// @param pipeline The graphics pipeline to create

--- a/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
@@ -74,7 +74,7 @@ public:
     GpuTexture &operator=(const GpuTexture &) = delete;
     GpuTexture &operator=(GpuTexture &&) = delete;
 
-    [[nodiscard]] std::string name() const {
+    [[nodiscard]] const std::string &name() const {
         return m_name;
     }
 

--- a/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/once_command_buffer.hpp
@@ -19,6 +19,7 @@ class Device;
 /// tell the driver about our intent using VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT.
 class OnceCommandBuffer {
     const Device &m_device;
+    std::string m_name;
     // We must store the VkQueue separately since we don't know from
     // the context of the use of this OnceCommandBuffer which queue to use!
     VkQueue m_queue{VK_NULL_HANDLE};
@@ -32,10 +33,11 @@ public:
     /// @param device The const reference to a device RAII wrapper instance.
     /// @param queue The Vulkan queue to use.
     /// @param queue_family_index The Vulkan queue family index to use.
+    /// @param name The internal debug marker name which will be assigned to this command buffer
     /// @warn We can't determine the queue and queue family index to use automatically using the device wrapper
     /// reference because we might choose a queue which is unsuitable for the requested purpose!
     /// This is the reason we must specify the queue and queue family index in the constructor.
-    OnceCommandBuffer(const Device &device, VkQueue queue, std::uint32_t queue_family_index);
+    OnceCommandBuffer(const Device &device, VkQueue queue, std::uint32_t queue_family_index, const std::string &name);
 
     OnceCommandBuffer(const OnceCommandBuffer &) = delete;
     OnceCommandBuffer(OnceCommandBuffer &&) noexcept;

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -483,7 +483,8 @@ Application::Application(int argc, char **argv) {
     load_textures();
     load_shaders();
 
-    m_command_pool = std::make_unique<wrapper::CommandPool>(*m_device, m_device->graphics_queue_family_index());
+    m_command_pool =
+        std::make_unique<wrapper::CommandPool>(*m_device, m_device->graphics_queue_family_index(), "command pool");
 
     m_uniform_buffers.emplace_back(*m_device, "matrices uniform buffer", sizeof(UniformBufferObject));
 

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -139,14 +139,8 @@ void RenderGraph::build_pipeline_layout(const RenderStage *stage, PhysicalStage 
     pipeline_layout_ci.pSetLayouts = stage->m_descriptor_layouts.data();
     pipeline_layout_ci.pushConstantRangeCount = static_cast<std::uint32_t>(stage->m_push_constant_ranges.size());
     pipeline_layout_ci.pPushConstantRanges = stage->m_push_constant_ranges.data();
-    if (const auto result =
-            vkCreatePipelineLayout(m_device.device(), &pipeline_layout_ci, nullptr, &physical.m_pipeline_layout);
-        result != VK_SUCCESS) {
-        throw VulkanException("Failed to create pipeline layout!", result);
-    }
 
-    m_device.set_debug_marker_name(physical.m_pipeline_layout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT,
-                                   stage->m_name + " pipeline layout");
+    m_device.create_pipeline_layout(pipeline_layout_ci, &physical.m_pipeline_layout, stage->name());
 }
 
 void RenderGraph::record_command_buffer(const RenderStage *stage, PhysicalStage &physical,

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -378,11 +378,7 @@ void RenderGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGr
     pipeline_ci.pStages = stage->m_shaders.data();
 
     // TODO: Pipeline caching (basically load the render graph from a file)
-    if (const auto result =
-            vkCreateGraphicsPipelines(m_device.device(), nullptr, 1, &pipeline_ci, nullptr, &physical.m_pipeline);
-        result != VK_SUCCESS) {
-        throw VulkanException("Failed to create pipeline!", result);
-    }
+    m_device.create_graphics_pipeline(pipeline_ci, &physical.m_pipeline, stage->name());
 }
 
 void RenderGraph::compile(const RenderResource *target) {

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -266,10 +266,8 @@ void RenderGraph::build_render_pass(const GraphicsStage *stage, PhysicalGraphics
     render_pass_ci.pAttachments = attachments.data();
     render_pass_ci.pDependencies = &subpass_dependency;
     render_pass_ci.pSubpasses = &subpass_description;
-    if (const auto result = vkCreateRenderPass(m_device.device(), &render_pass_ci, nullptr, &physical.m_render_pass);
-        result != VK_SUCCESS) {
-        throw VulkanException("Failed to create render pass!", result);
-    }
+
+    m_device.create_render_pass(render_pass_ci, &physical.m_render_pass, stage->name());
 }
 
 void RenderGraph::build_graphics_pipeline(const GraphicsStage *stage, PhysicalGraphicsStage &physical) const {

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -130,10 +130,7 @@ void RenderGraph::build_image_view(const TextureResource &texture_resource, Phys
     image_view_ci.subresourceRange.levelCount = 1;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
 
-    if (const auto result = vkCreateImageView(m_device.device(), &image_view_ci, nullptr, &physical.m_image_view);
-        result != VK_SUCCESS) {
-        throw VulkanException("Failed to create image view!", result);
-    }
+    m_device.create_image_view(image_view_ci, &physical.m_image_view, texture_resource.m_name);
 }
 
 void RenderGraph::build_pipeline_layout(const RenderStage *stage, PhysicalStage &physical) const {

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -6,19 +6,14 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-CommandPool::CommandPool(const Device &device, const std::uint32_t queue_family_index) : m_device(device) {
+CommandPool::CommandPool(const Device &device, const std::uint32_t queue_family_index, std::string name)
+    : m_device(device), m_name(std::move(name)) {
     assert(device.device());
 
     auto command_pool_ci = make_info<VkCommandPoolCreateInfo>();
     command_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     command_pool_ci.queueFamilyIndex = queue_family_index;
-
-    if (const auto result = vkCreateCommandPool(m_device.device(), &command_pool_ci, nullptr, &m_command_pool);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateCommandPool failed!", result);
-    }
-
-    // TODO: Assign an internal name to this command pool using Vulkan debug markers.
+    device.create_command_pool(command_pool_ci, &m_command_pool, m_name);
 }
 
 CommandPool::CommandPool(CommandPool &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -58,15 +58,7 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
     descriptor_set_layout_ci.bindingCount = static_cast<std::uint32_t>(m_descriptor_set_layout_bindings.size());
     descriptor_set_layout_ci.pBindings = m_descriptor_set_layout_bindings.data();
 
-    if (const auto result =
-            vkCreateDescriptorSetLayout(device.device(), &descriptor_set_layout_ci, nullptr, &m_descriptor_set_layout);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateDescriptorSetLayout failed for descriptor " + m_name + " !", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_descriptor_set_layout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT,
-                                   m_name);
+    m_device.create_descriptor_set_layout(descriptor_set_layout_ci, &m_descriptor_set_layout, m_name);
 
     const std::vector<VkDescriptorSetLayout> descriptor_set_layouts(swapchain_image_count, m_descriptor_set_layout);
 

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -52,13 +52,7 @@ ResourceDescriptor::ResourceDescriptor(const Device &device, std::uint32_t swapc
     descriptor_pool_ci.pPoolSizes = pool_sizes.data();
     descriptor_pool_ci.maxSets = static_cast<std::uint32_t>(swapchain_image_count);
 
-    if (const auto result = vkCreateDescriptorPool(device.device(), &descriptor_pool_ci, nullptr, &m_descriptor_pool);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateDescriptorPool failed for descriptor " + m_name + " !", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_descriptor_pool, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, m_name);
+    m_device.create_descriptor_pool(descriptor_pool_ci, &m_descriptor_pool, m_name);
 
     auto descriptor_set_layout_ci = make_info<VkDescriptorSetLayoutCreateInfo>();
     descriptor_set_layout_ci.bindingCount = static_cast<std::uint32_t>(m_descriptor_set_layout_bindings.size());

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -526,6 +526,16 @@ void Device::create_image_view(const VkImageViewCreateInfo &image_view_ci, VkIma
     set_debug_marker_name(&image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, name);
 }
 
+void Device::create_pipeline_layout(const VkPipelineLayoutCreateInfo &pipeline_layout_ci,
+                                    VkPipelineLayout *pipeline_layout, const std::string &name) const {
+    if (const auto result = vkCreatePipelineLayout(m_device, &pipeline_layout_ci, nullptr, pipeline_layout);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreatePipelineLayout failed for pipeline layout " + name + "!", result);
+    }
+
+    set_debug_marker_name(&pipeline_layout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, name);
+}
+
 void Device::create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
                               const std::string &name) const {
     if (const auto result = vkCreateSemaphore(m_device, &semaphore_ci, nullptr, semaphore); result != VK_SUCCESS) {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -466,6 +466,16 @@ void Device::end_debug_region(const VkCommandBuffer command_buffer) const {
 #endif
 }
 
+void Device::create_command_pool(const VkCommandPoolCreateInfo &command_pool_ci, VkCommandPool *command_pool,
+                                 const std::string &name) const {
+    if (const auto result = vkCreateCommandPool(m_device, &command_pool_ci, nullptr, command_pool);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateCommandPool failed for command pool " + name + "!", result);
+    }
+
+    set_debug_marker_name(&command_pool, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT, name);
+}
+
 void Device::create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
                                 const std::string &name) const {
     if (const auto result = vkCreateFramebuffer(m_device, &framebuffer_ci, nullptr, framebuffer);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -544,6 +544,15 @@ void Device::create_pipeline_layout(const VkPipelineLayoutCreateInfo &pipeline_l
     set_debug_marker_name(&pipeline_layout, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, name);
 }
 
+void Device::create_render_pass(const VkRenderPassCreateInfo &render_pass_ci, VkRenderPass *render_pass,
+                                const std::string &name) const {
+    if (const auto result = vkCreateRenderPass(m_device, &render_pass_ci, nullptr, render_pass); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateRenderPass failed for renderpass " + name + " !", result);
+    }
+
+    set_debug_marker_name(&render_pass, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, name);
+}
+
 void Device::create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
                               const std::string &name) const {
     if (const auto result = vkCreateSemaphore(m_device, &semaphore_ci, nullptr, semaphore); result != VK_SUCCESS) {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -466,6 +466,16 @@ void Device::end_debug_region(const VkCommandBuffer command_buffer) const {
 #endif
 }
 
+void Device::create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
+                                const std::string &name) const {
+    if (const auto result = vkCreateFramebuffer(m_device, &framebuffer_ci, nullptr, framebuffer);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateFramebuffer failed for framebuffer " + name + "!", result);
+    }
+
+    set_debug_marker_name(&framebuffer, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, name);
+}
+
 void Device::create_graphics_pipeline(const VkGraphicsPipelineCreateInfo &pipeline_ci, VkPipeline *pipeline,
                                       const std::string &name) const {
     if (const auto result = vkCreateGraphicsPipelines(m_device, nullptr, 1, &pipeline_ci, nullptr, pipeline);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -495,4 +495,13 @@ void Device::create_image_view(const VkImageViewCreateInfo &image_view_ci, VkIma
     set_debug_marker_name(&image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, name);
 }
 
+void Device::create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
+                              const std::string &name) const {
+    if (const auto result = vkCreateSemaphore(m_device, &semaphore_ci, nullptr, semaphore); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateSemaphore failed for " + name + " !", result);
+    }
+
+    set_debug_marker_name(&semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -466,4 +466,14 @@ void Device::end_debug_region(const VkCommandBuffer command_buffer) const {
 #endif
 }
 
+void Device::create_graphics_pipeline(const VkGraphicsPipelineCreateInfo &pipeline_ci, VkPipeline *pipeline,
+                                      const std::string &name) const {
+    if (const auto result = vkCreateGraphicsPipelines(m_device, nullptr, 1, &pipeline_ci, nullptr, pipeline);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateGraphicsPipelines failed for pipeline " + name + " !", result);
+    }
+
+    set_debug_marker_name(&pipeline, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -476,6 +476,16 @@ void Device::create_command_pool(const VkCommandPoolCreateInfo &command_pool_ci,
     set_debug_marker_name(&command_pool, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT, name);
 }
 
+void Device::create_descriptor_pool(const VkDescriptorPoolCreateInfo &descriptor_pool_ci,
+                                    VkDescriptorPool *descriptor_pool, const std::string &name) const {
+    if (const auto result = vkCreateDescriptorPool(m_device, &descriptor_pool_ci, nullptr, descriptor_pool);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateDescriptorPool failed for descriptor pool " + name + " !", result);
+    }
+
+    set_debug_marker_name(&descriptor_pool, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, name);
+}
+
 void Device::create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
                                 const std::string &name) const {
     if (const auto result = vkCreateFramebuffer(m_device, &framebuffer_ci, nullptr, framebuffer);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -553,6 +553,14 @@ void Device::create_render_pass(const VkRenderPassCreateInfo &render_pass_ci, Vk
     set_debug_marker_name(&render_pass, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, name);
 }
 
+void Device::create_sampler(const VkSamplerCreateInfo &sampler_ci, VkSampler *sampler, const std::string &name) const {
+    if (const auto result = vkCreateSampler(m_device, &sampler_ci, nullptr, sampler); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateSampler failed for sampler " + name + " !", result);
+    }
+
+    set_debug_marker_name(&sampler, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, name);
+}
+
 void Device::create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemaphore *semaphore,
                               const std::string &name) const {
     if (const auto result = vkCreateSemaphore(m_device, &semaphore_ci, nullptr, semaphore); result != VK_SUCCESS) {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -486,6 +486,17 @@ void Device::create_descriptor_pool(const VkDescriptorPoolCreateInfo &descriptor
     set_debug_marker_name(&descriptor_pool, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, name);
 }
 
+void Device::create_descriptor_set_layout(const VkDescriptorSetLayoutCreateInfo &descriptor_set_layout_ci,
+                                          VkDescriptorSetLayout *descriptor_set_layout, const std::string &name) const {
+    if (const auto result =
+            vkCreateDescriptorSetLayout(m_device, &descriptor_set_layout_ci, nullptr, descriptor_set_layout);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateDescriptorSetLayout failed for descriptor " + name + " !", result);
+    }
+
+    set_debug_marker_name(&descriptor_set_layout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, name);
+}
+
 void Device::create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
                                 const std::string &name) const {
     if (const auto result = vkCreateFramebuffer(m_device, &framebuffer_ci, nullptr, framebuffer);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -545,4 +545,14 @@ void Device::create_semaphore(const VkSemaphoreCreateInfo &semaphore_ci, VkSemap
     set_debug_marker_name(&semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
 }
 
+void Device::create_shader_module(const VkShaderModuleCreateInfo &shader_module_ci, VkShaderModule *shader_module,
+                                  const std::string &name) const {
+    if (const auto result = vkCreateShaderModule(m_device, &shader_module_ci, nullptr, shader_module);
+        result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateShaderModule failed for shader module " + name + "!", result);
+    }
+
+    set_debug_marker_name(&shader_module, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -497,6 +497,14 @@ void Device::create_descriptor_set_layout(const VkDescriptorSetLayoutCreateInfo 
     set_debug_marker_name(&descriptor_set_layout, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, name);
 }
 
+void Device::create_fence(const VkFenceCreateInfo &fence_ci, VkFence *fence, const std::string &name) const {
+    if (const auto result = vkCreateFence(m_device, &fence_ci, nullptr, fence); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateFence failed for fence " + name + "!", result);
+    }
+
+    set_debug_marker_name(&fence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, name);
+}
+
 void Device::create_framebuffer(const VkFramebufferCreateInfo &framebuffer_ci, VkFramebuffer *framebuffer,
                                 const std::string &name) const {
     if (const auto result = vkCreateFramebuffer(m_device, &framebuffer_ci, nullptr, framebuffer);

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -572,4 +572,13 @@ void Device::create_shader_module(const VkShaderModuleCreateInfo &shader_module_
     set_debug_marker_name(&shader_module, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
 }
 
+void Device::create_swapchain(const VkSwapchainCreateInfoKHR &swapchain_ci, VkSwapchainKHR *swapchain,
+                              const std::string &name) const {
+    if (const auto result = vkCreateSwapchainKHR(m_device, &swapchain_ci, nullptr, swapchain); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateSwapchainKHR failed for swapchain " + name + "!", result);
+    }
+
+    set_debug_marker_name(&swapchain, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, name);
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -486,4 +486,13 @@ void Device::create_graphics_pipeline(const VkGraphicsPipelineCreateInfo &pipeli
     set_debug_marker_name(&pipeline, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
 }
 
+void Device::create_image_view(const VkImageViewCreateInfo &image_view_ci, VkImageView *image_view,
+                               const std::string &name) const {
+    if (const auto result = vkCreateImageView(m_device, &image_view_ci, nullptr, image_view); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkCreateImageView failed for image view " + name + "!", result);
+    }
+
+    set_debug_marker_name(&image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, name);
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -19,12 +19,7 @@ Fence::Fence(const wrapper::Device &device, const std::string &name, const bool 
     auto fence_ci = make_info<VkFenceCreateInfo>();
     fence_ci.flags = in_signaled_state ? VK_FENCE_CREATE_SIGNALED_BIT : 0;
 
-    if (const auto result = vkCreateFence(device.device(), &fence_ci, nullptr, &m_fence); result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateFence failed!", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_fence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, m_name);
+    m_device.create_fence(fence_ci, &m_fence, m_name);
 }
 
 Fence::Fence(Fence &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -24,13 +24,7 @@ Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const s
     framebuffer_ci.layers = 1;
     framebuffer_ci.renderPass = render_pass;
 
-    if (const auto result = vkCreateFramebuffer(m_device.device(), &framebuffer_ci, nullptr, &m_framebuffer);
-        result != VK_SUCCESS) {
-        throw VulkanException("Failed to create framebuffer " + m_name + "!", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_framebuffer, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, m_name);
+    m_device.create_framebuffer(framebuffer_ci, &m_framebuffer, m_name);
 }
 
 Framebuffer::Framebuffer(Framebuffer &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -15,7 +15,8 @@ namespace inexor::vulkan_renderer::wrapper {
 GpuTexture::GpuTexture(const wrapper::Device &device, const CpuTexture &cpu_texture)
     : m_device(device), m_texture_width(cpu_texture.width()), m_texture_height(cpu_texture.height()),
       m_texture_channels(cpu_texture.channels()), m_mip_levels(cpu_texture.mip_levels()), m_name(cpu_texture.name()),
-      m_copy_command_buffer(device, device.graphics_queue(), device.graphics_queue_family_index()) {
+      m_copy_command_buffer(device, device.graphics_queue(), device.graphics_queue_family_index(),
+                            "Once command buffer") {
     create_texture(cpu_texture.data(), cpu_texture.data_size());
 }
 
@@ -23,7 +24,8 @@ GpuTexture::GpuTexture(const wrapper::Device &device, void *data, const std::siz
                        const int texture_height, const int texture_channels, const int mip_levels, std::string name)
     : m_device(device), m_texture_width(texture_width), m_texture_height(texture_height),
       m_texture_channels(texture_channels), m_mip_levels(mip_levels), m_name(std::move(name)),
-      m_copy_command_buffer(device, device.graphics_queue(), device.graphics_queue_family_index()) {
+      m_copy_command_buffer(device, device.graphics_queue(), device.graphics_queue_family_index(),
+                            "Once command buffer") {
     create_texture(data, data_size);
 }
 
@@ -118,7 +120,7 @@ void GpuTexture::transition_image_layout(VkImage image, VkImageLayout old_layout
     }
 
     OnceCommandBuffer image_transition_change(m_device, m_device.graphics_queue(),
-                                              m_device.graphics_queue_family_index());
+                                              m_device.graphics_queue_family_index(), "Once command buffer");
 
     image_transition_change.create_command_buffer();
     image_transition_change.start_recording();

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -185,13 +185,7 @@ void GpuTexture::create_texture_sampler() {
         sampler_ci.anisotropyEnable = VK_FALSE;
     }
 
-    if (const auto result = vkCreateSampler(m_device.device(), &sampler_ci, nullptr, &m_sampler);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateSampler failed for texture " + m_name + " !", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_sampler, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, m_name);
+    m_device.create_sampler(sampler_ci, &m_sampler, m_name);
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -64,13 +64,7 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
     image_view_ci.subresourceRange.baseArrayLayer = 0;
     image_view_ci.subresourceRange.layerCount = 1;
 
-    if (const auto result = vkCreateImageView(device.device(), &image_view_ci, nullptr, &m_image_view);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateImageView failed for image view " + m_name + "!", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_image_view, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
+    m_device.create_image_view(image_view_ci, &m_image_view, m_name);
 }
 
 Image::Image(Image &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/once_command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/once_command_buffer.cpp
@@ -12,8 +12,9 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-OnceCommandBuffer::OnceCommandBuffer(const Device &device, const VkQueue queue, const std::uint32_t queue_family_index)
-    : m_device(device), m_queue(queue), m_command_pool(device, queue_family_index) {
+OnceCommandBuffer::OnceCommandBuffer(const Device &device, const VkQueue queue, const std::uint32_t queue_family_index,
+                                     const std::string &name)
+    : m_device(device), m_queue(queue), m_name(name), m_command_pool(device, queue_family_index, name) {
     assert(device.device());
     m_recording_started = false;
 }
@@ -23,6 +24,7 @@ OnceCommandBuffer::OnceCommandBuffer(OnceCommandBuffer &&other) noexcept
     m_queue = other.m_queue;
     m_command_buffer = std::exchange(other.m_command_buffer, nullptr);
     m_recording_started = other.m_recording_started;
+    m_name = std::move(other.m_name);
 }
 
 OnceCommandBuffer::~OnceCommandBuffer() {

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -16,13 +16,7 @@ Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(d
     assert(!name.empty());
 
     auto semaphore_ci = make_info<VkSemaphoreCreateInfo>();
-    if (const auto result = vkCreateSemaphore(device.device(), &semaphore_ci, nullptr, &m_semaphore);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateSemaphore failed for " + name + " !", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_semaphore, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, name);
+    device.create_semaphore(semaphore_ci, &m_semaphore, m_name);
 }
 
 Semaphore::Semaphore(Semaphore &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -54,13 +54,7 @@ Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std
     // allocator already ensures that the data satisfies the worst case alignment requirements.
     shader_module_ci.pCode = reinterpret_cast<const std::uint32_t *>(code.data()); // NOLINT
 
-    if (const auto result = vkCreateShaderModule(device.device(), &shader_module_ci, nullptr, &m_shader_module);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateShaderModule failed for shader " + name + "!", result);
-    }
-
-    // Assign an internal name using Vulkan debug markers.
-    m_device.set_debug_marker_name(m_shader_module, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
+    m_device.create_shader_module(shader_module_ci, &m_shader_module, m_name);
 }
 
 Shader::Shader(Shader &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/staging_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/staging_buffer.cpp
@@ -12,7 +12,8 @@ StagingBuffer::StagingBuffer(const Device &device, const std::string &name, cons
                              const std::size_t data_size)
     : GPUMemoryBuffer(device, name, buffer_size, data, data_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                       VMA_MEMORY_USAGE_CPU_ONLY),
-      m_command_buffer_for_copying(device, device.transfer_queue(), device.transfer_queue_family_index()),
+      m_command_buffer_for_copying(device, device.transfer_queue(), device.transfer_queue_family_index(),
+                                   "Once command buffer"),
       m_device(device) {}
 
 StagingBuffer::StagingBuffer(StagingBuffer &&other) noexcept

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -143,15 +143,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
 
     for (std::size_t i = 0; i < m_swapchain_image_count; i++) {
         image_view_ci.image = m_swapchain_images[i];
-
-        if (const auto result =
-                vkCreateImageView(m_device.device(), &image_view_ci, nullptr, &m_swapchain_image_views[i]);
-            result != VK_SUCCESS) {
-            throw VulkanException("Error: vkCreateImageView failed!", result);
-        }
-
-        // Assign an internal name using Vulkan debug markers.
-        m_device.set_debug_marker_name(m_swapchain_image_views[i], VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, m_name);
+        m_device.create_image_view(image_view_ci, &m_swapchain_image_views[i], m_name);
     }
 }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -103,10 +103,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
         swapchain_ci.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 
-    if (const auto result = vkCreateSwapchainKHR(m_device.device(), &swapchain_ci, nullptr, &m_swapchain);
-        result != VK_SUCCESS) {
-        throw VulkanException("Error: vkCreateSwapchainKHR failed!", result);
-    }
+    m_device.create_swapchain(swapchain_ci, &m_swapchain, m_name);
 
     if (const auto result = vkGetSwapchainImagesKHR(m_device.device(), m_swapchain, &m_swapchain_image_count, nullptr);
         result != VK_SUCCESS) {


### PR DESCRIPTION
- [x] Move `vkCreate..` functions into device wrapper
- [x] Throw exceptions only in this file, so no error checks outside of it required.
- [x] Assign internal debug marker names inside of device wrapper.