### PR TITLE
[collision] Fix implicit lambda capture of 'this' using [=] which is deprecated in C++20

### DIFF
--- a/src/vulkan-renderer/world/collision.cpp
+++ b/src/vulkan-renderer/world/collision.cpp
@@ -25,7 +25,7 @@ RayCubeCollision<T>::RayCubeCollision(const T &cube, const glm::vec3 ray_pos, co
 
     // This lambda adjusts the center points on a cube's face to the size of the octree,
     // so collision works with cubes of any size. This does not yet account for rotations!
-    const auto adjust_coordinates = [=](const glm::vec3 pos) {
+    const auto adjust_coordinates = [&](const glm::vec3 pos) {
         // TODO: Take rotation of the cube into account.
         return m_cube.center() + pos * (m_cube.size() / 2);
     };


### PR DESCRIPTION
I fixed this:

```cpp
command-pool-refactoring/vulkan-renderer/src/vulkan-renderer/world/collision.cpp:28:37:
warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
   28 |     const auto adjust_coordinates = [=](const glm::vec3 pos) {
      |                                     ^
command-pool-refactoring/vulkan-renderer/src/vulkan-renderer/world/collision.cpp:28:37:
note: add explicit ‘this’ or ‘*this’ capture
```

I can really recommend this ebook btw: https://leanpub.com/cpplambda