### PR TITLE
[*] Cleanup of spdlog messages

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -21,8 +21,8 @@ int main(int argc, char *argv[]) {
 
     spdlog::set_default_logger(vulkan_renderer_log);
 
-    spdlog::debug("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
-    spdlog::debug("Parsing command line arguments.");
+    spdlog::trace("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
+    spdlog::trace("Parsing command line arguments");
 
     std::unique_ptr<inexor::vulkan_renderer::Application> renderer;
 
@@ -38,5 +38,5 @@ int main(int argc, char *argv[]) {
 
     renderer->run();
     renderer->calculate_memory_budget();
-    spdlog::debug("Window closed");
+    spdlog::trace("Window closed");
 }

--- a/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/mesh_buffer.hpp
@@ -74,8 +74,8 @@ public:
         std::size_t vertex_buffer_size = sizeof(VertexType) * vertex_count;
         std::size_t index_buffer_size = sizeof(IndexType) * index_count;
 
-        spdlog::debug("Creating vertex buffer of size {} for mesh {}.", vertex_buffer_size, name);
-        spdlog::debug("Creating index buffer of size {} for mesh {}.", index_buffer_size, name);
+        spdlog::trace("Creating vertex buffer of size {} for mesh {}", vertex_buffer_size, name);
+        spdlog::trace("Creating index buffer of size {} for mesh {}", index_buffer_size, name);
     }
 
     /// @brief Creates a mesh buffer of type VertexType without a corresponding index buffer by specifying the number of
@@ -96,7 +96,7 @@ public:
 
         std::size_t vertex_buffer_size = sizeof(VertexType) * vertex_count;
 
-        spdlog::debug("Creating vertex buffer of size {} for mesh {}.", vertex_buffer_size, name);
+        spdlog::trace("Creating vertex buffer of size {} for mesh {}", vertex_buffer_size, name);
     }
 
     /// @brief Constructs a mesh buffer of type VertexType with a corresponding index buffer of type IndexType.
@@ -110,8 +110,8 @@ public:
         std::size_t vertex_buffer_size = sizeof(VertexType) * vertices.size();
         std::size_t index_buffer_size = sizeof(IndexType) * indices.size();
 
-        spdlog::debug("Creating vertex buffer of size {} for mesh {}.", vertex_buffer_size, name);
-        spdlog::debug("Creating index buffer of size {} for mesh {}.", index_buffer_size, name);
+        spdlog::trace("Creating vertex buffer of size {} for mesh {}", vertex_buffer_size, name);
+        spdlog::trace("Creating index buffer of size {} for mesh {}", index_buffer_size, name);
 
         // Not using an index buffer can decrease performance drastically!
         if (index_buffer_size == 0) {
@@ -148,7 +148,7 @@ public:
         : MeshBuffer(device, name, vertices.size()) {
         std::size_t size_of_vertex_buffer = sizeof(VertexType) * vertices.size();
 
-        spdlog::debug("Creating vertex buffer of size {} for mesh {}.", size_of_vertex_buffer, name);
+        spdlog::trace("Creating vertex buffer of size {} for mesh {}", size_of_vertex_buffer, name);
 
         // Not using an index buffer can decrease performance drastically!
         spdlog::warn("Creating a vertex buffer without an index buffer!");

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -65,13 +65,13 @@ void Application::mouse_scroll_callback(GLFWwindow * /*window*/, double /*x_offs
 }
 
 void Application::load_toml_configuration_file(const std::string &file_name) {
-    spdlog::debug("Loading TOML configuration file: '{}'", file_name);
+    spdlog::trace("Loading TOML configuration file: {}", file_name);
 
     std::ifstream toml_file(file_name, std::ios::in);
     if (!toml_file) {
         // If you are using CLion, go to "Edit Configurations" and select "Working Directory".
         throw std::runtime_error("Could not find configuration file: " + file_name +
-                                 "! You must set the working directory properly in your IDE.");
+                                 "! You must set the working directory properly in your IDE");
     }
 
     toml_file.close();
@@ -81,7 +81,7 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
 
     // Search for the title of the configuration file and print it to debug output.
     const auto &configuration_title = toml::find<std::string>(renderer_configuration, "title");
-    spdlog::debug("Title: '{}'", configuration_title);
+    spdlog::trace("Title: {}", configuration_title);
 
     using WindowMode = ::inexor::vulkan_renderer::wrapper::Window::Mode;
     const auto &wmodestr = toml::find<std::string>(renderer_configuration, "application", "window", "mode");
@@ -99,39 +99,39 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     m_window_width = toml::find<int>(renderer_configuration, "application", "window", "width");
     m_window_height = toml::find<int>(renderer_configuration, "application", "window", "height");
     m_window_title = toml::find<std::string>(renderer_configuration, "application", "window", "name");
-    spdlog::debug("Window: '{}', {} x {}", m_window_title, m_window_width, m_window_height);
+    spdlog::trace("Window: {}, {} x {}", m_window_title, m_window_width, m_window_height);
 
     m_texture_files = toml::find<std::vector<std::string>>(renderer_configuration, "textures", "files");
 
-    spdlog::debug("Textures:");
+    spdlog::trace("Textures:");
 
     for (const auto &texture_file : m_texture_files) {
-        spdlog::debug("{}", texture_file);
+        spdlog::trace("   - {}", texture_file);
     }
 
     m_gltf_model_files = toml::find<std::vector<std::string>>(renderer_configuration, "glTFmodels", "files");
 
-    spdlog::debug("glTF 2.0 models:");
+    spdlog::trace("glTF 2.0 models:");
 
     for (const auto &gltf_model_file : m_gltf_model_files) {
-        spdlog::debug("{}", gltf_model_file);
+        spdlog::trace("   - {}", gltf_model_file);
     }
 
     m_vertex_shader_files = toml::find<std::vector<std::string>>(renderer_configuration, "shaders", "vertex", "files");
 
-    spdlog::debug("Vertex shaders:");
+    spdlog::trace("Vertex shaders:");
 
     for (const auto &vertex_shader_file : m_vertex_shader_files) {
-        spdlog::debug("{}", vertex_shader_file);
+        spdlog::trace("   - {}", vertex_shader_file);
     }
 
     m_fragment_shader_files =
         toml::find<std::vector<std::string>>(renderer_configuration, "shaders", "fragment", "files");
 
-    spdlog::debug("Fragment shaders:");
+    spdlog::trace("Fragment shaders:");
 
     for (const auto &fragment_shader_file : m_fragment_shader_files) {
-        spdlog::debug("{}", fragment_shader_file);
+        spdlog::trace("   - {}", fragment_shader_file);
     }
 
     // TODO: Load more info from TOML file.
@@ -145,7 +145,11 @@ void Application::load_textures() {
     // Insert the new texture into the list of textures.
     std::string texture_name = "unnamed texture";
 
+    spdlog::trace("Loading texture files:");
+
     for (const auto &texture_file : m_texture_files) {
+        spdlog::trace("   - {}", texture_file);
+
         wrapper::CpuTexture cpu_texture(texture_file, texture_name);
         m_textures.emplace_back(*m_device, cpu_texture);
     }
@@ -154,7 +158,7 @@ void Application::load_textures() {
 void Application::load_shaders() {
     assert(m_device->device());
 
-    spdlog::debug("Loading vertex shaders.");
+    spdlog::trace("Loading vertex shaders:");
 
     if (m_vertex_shader_files.empty()) {
         spdlog::error("No vertex shaders to load!");
@@ -162,13 +166,13 @@ void Application::load_shaders() {
 
     // Loop through the list of vertex shaders and initialise all of them.
     for (const auto &vertex_shader_file : m_vertex_shader_files) {
-        spdlog::debug("Loading vertex shader file {}.", vertex_shader_file);
+        spdlog::trace("   - {}", vertex_shader_file);
 
         // Insert the new shader into the list of shaders.
         m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_VERTEX_BIT, "unnamed vertex shader", vertex_shader_file);
     }
 
-    spdlog::debug("Loading fragment shaders.");
+    spdlog::trace("Loading fragment shaders:");
 
     if (m_fragment_shader_files.empty()) {
         spdlog::error("No fragment shaders to load!");
@@ -176,18 +180,18 @@ void Application::load_shaders() {
 
     // Loop through the list of fragment shaders and initialise all of them.
     for (const auto &fragment_shader_file : m_fragment_shader_files) {
-        spdlog::debug("Loading fragment shader file {}.", fragment_shader_file);
+        spdlog::trace("   - {}", fragment_shader_file);
 
         // Insert the new shader into the list of shaders.
         m_shaders.emplace_back(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, "unnamed fragment shader",
                                fragment_shader_file);
     }
 
-    spdlog::debug("Loading shaders finished.");
+    spdlog::trace("Loading shaders finished");
 }
 
 void Application::load_octree_geometry(bool initialize) {
-    spdlog::debug("Creating octree geometry.");
+    spdlog::trace("Creating octree geometry");
 
     // 4: 23 012 | 5: 184352 | 6: 1474162 | 7: 11792978 cubes, DO NOT USE 7!
     m_worlds.clear();
@@ -224,28 +228,26 @@ void Application::check_application_specific_features() {
     if (graphics_card_features.samplerAnisotropy != VK_TRUE) {
         spdlog::warn("The selected graphics card does not support anisotropic filtering!");
     } else {
-        spdlog::debug("The selected graphics card does support anisotropic filtering.");
+        spdlog::trace("The selected graphics card does support anisotropic filtering");
     }
 
     // TODO: Add more checks if necessary.
 }
 
 void Application::setup_window_and_input_callbacks() {
-    spdlog::debug("Storing GLFW window user pointer.");
-
     m_window->set_user_ptr(this);
 
-    spdlog::debug("Setting up framebuffer resize callback.");
+    spdlog::trace("Setting up window callback:");
 
     auto lambda_frame_buffer_resize_callback = [](GLFWwindow *window, int width, int height) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
-        spdlog::debug("Frame buffer resize callback called. window width: {}, height: {}", width, height);
+        spdlog::trace("Frame buffer resize callback called. window width: {}, height: {}", width, height);
         app->m_window_resized = true;
     };
 
     m_window->set_resize_callback(lambda_frame_buffer_resize_callback);
 
-    spdlog::debug("Setting up keyboard button callback.");
+    spdlog::trace("   - keyboard button callback");
 
     auto lambda_key_callback = [](GLFWwindow *window, int key, int scancode, int action, int mods) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
@@ -254,7 +256,7 @@ void Application::setup_window_and_input_callbacks() {
 
     m_window->set_keyboard_button_callback(lambda_key_callback);
 
-    spdlog::debug("Setting up cursor position callback.");
+    spdlog::trace("   - cursor position callback");
 
     auto lambda_cursor_position_callback = [](GLFWwindow *window, double xpos, double ypos) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
@@ -263,7 +265,7 @@ void Application::setup_window_and_input_callbacks() {
 
     m_window->set_cursor_position_callback(lambda_cursor_position_callback);
 
-    spdlog::debug("Setting up mouse button callback.");
+    spdlog::trace("   - mouse button callback");
 
     auto lambda_mouse_button_callback = [](GLFWwindow *window, int button, int action, int mods) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
@@ -272,7 +274,7 @@ void Application::setup_window_and_input_callbacks() {
 
     m_window->set_mouse_button_callback(lambda_mouse_button_callback);
 
-    spdlog::debug("Setting up mouse wheel scroll callback.");
+    spdlog::trace("   - mouse wheel scroll callback");
 
     auto lambda_mouse_scroll_callback = [](GLFWwindow *window, double xoffset, double yoffset) {
         auto *app = static_cast<Application *>(glfwGetWindowUserPointer(window));
@@ -285,7 +287,7 @@ void Application::setup_window_and_input_callbacks() {
 void Application::setup_vulkan_debug_callback() {
     // Check if validation is enabled check for availability of VK_EXT_debug_utils.
     if (m_enable_validation_layers) {
-        spdlog::debug("Khronos validation layer is enabled.");
+        spdlog::trace("Khronos validation layer is enabled");
 
         if (wrapper::Instance::is_extension_supported(VK_EXT_DEBUG_REPORT_EXTENSION_NAME)) {
             auto debug_report_ci = wrapper::make_info<VkDebugReportCallbackCreateInfoEXT>();
@@ -316,7 +318,7 @@ void Application::setup_vulkan_debug_callback() {
                     if (user_data != nullptr) {
                         // This feature stops command lines from overflowing with messages in case many validation
                         // layer messages are reported in a short amount of time.
-                        spdlog::critical("Command line argument --stop-on-validation-message is enabled.");
+                        spdlog::critical("Command line argument --stop-on-validation-message is enabled");
                         spdlog::critical("Application will cause a break point now!");
 
                         // Wait for spdlog to shut down before aborting.
@@ -336,28 +338,27 @@ void Application::setup_vulkan_debug_callback() {
                     result != VK_SUCCESS) {
                     throw VulkanException("Error: vkCreateDebugReportCallbackEXT failed!", result);
                 }
-                spdlog::debug("Creating Vulkan debug callback.");
+                spdlog::trace("Creating Vulkan debug callback");
                 m_debug_report_callback_initialised = true;
             } else {
-                spdlog::error("vkCreateDebugReportCallbackEXT is a null-pointer! Function not available.");
+                spdlog::error("vkCreateDebugReportCallbackEXT is a null-pointer! Function not available");
             }
         } else {
             spdlog::warn("Khronos validation layer is not available!");
         }
     } else {
-        spdlog::warn("Khronos validation layer is DISABLED.");
+        spdlog::warn("Khronos validation layer is DISABLED");
     }
 }
 
 Application::Application(int argc, char **argv) {
-    spdlog::debug("Initialising vulkan-renderer.");
-    spdlog::debug("Initialising thread-pool with {} threads.", std::thread::hardware_concurrency());
+    spdlog::trace("Initialising vulkan-renderer");
 
     tools::CommandLineArgumentParser cla_parser;
     cla_parser.parse_args(argc, argv);
 
-    spdlog::debug("application version: {}.{}.{}", APP_VERSION[0], APP_VERSION[1], APP_VERSION[2]);
-    spdlog::debug("engine version: {}.{}.{}", ENGINE_VERSION[0], ENGINE_VERSION[1], ENGINE_VERSION[2]);
+    spdlog::trace("Application version: {}.{}.{}", APP_VERSION[0], APP_VERSION[1], APP_VERSION[2]);
+    spdlog::trace("Engine version: {}.{}.{}", ENGINE_VERSION[0], ENGINE_VERSION[1], ENGINE_VERSION[2]);
 
     // Load the configuration from the TOML file.
     load_toml_configuration_file("configuration/renderer.toml");
@@ -367,11 +368,11 @@ Application::Application(int argc, char **argv) {
     auto enable_renderdoc = cla_parser.arg<bool>("--renderdoc");
     if (enable_renderdoc) {
 #ifdef NDEBUG
-        spdlog::warn("You can't use -renderdoc command line argument in release mode. You have to download the code "
-                     "and compile it yourself in debug mode.");
+        spdlog::warn("You can't use --renderdoc command line argument in release mode. You have to download the code "
+                     "and compile it yourself in debug mode");
 #else
         if (*enable_renderdoc) {
-            spdlog::debug("--renderdoc specified, enabling renderdoc instance layer.");
+            spdlog::trace("--renderdoc specified, enabling renderdoc instance layer");
             enable_renderdoc_instance_layer = true;
         }
 #endif
@@ -381,11 +382,11 @@ Application::Application(int argc, char **argv) {
     // disabled. For debug builds, this is not advisable! Always use validation layers during development!
     const auto disable_validation = cla_parser.arg<bool>("--no-validation");
     if (disable_validation.value_or(false)) {
-        spdlog::warn("--no-validation specified, disabling validation layers.");
+        spdlog::warn("--no-validation specified, disabling validation layers");
         m_enable_validation_layers = false;
     }
 
-    spdlog::debug("Creating Vulkan instance.");
+    spdlog::trace("Creating Vulkan instance");
 
     m_window =
         std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true, m_window_mode);
@@ -406,19 +407,19 @@ Application::Application(int argc, char **argv) {
 #ifndef NDEBUG
     if (cla_parser.arg<bool>("--stop-on-validation-message").value_or(false)) {
         spdlog::warn("--stop-on-validation-message specified. Application will call a breakpoint after reporting a "
-                     "validation layer message.");
+                     "validation layer message");
         m_stop_on_validation_message = true;
     }
 
     setup_vulkan_debug_callback();
 #endif
 
-    spdlog::debug("Creating window surface.");
+    spdlog::trace("Creating window surface");
 
     // The user can specify with "--gpu <number>" which graphics card to prefer.
     auto preferred_graphics_card = cla_parser.arg<std::uint32_t>("--gpu");
     if (preferred_graphics_card) {
-        spdlog::debug("Preferential graphics card index {} specified.", *preferred_graphics_card);
+        spdlog::trace("Preferential graphics card index {} specified", *preferred_graphics_card);
     }
 
     bool display_graphics_card_info = true;
@@ -427,7 +428,7 @@ Application::Application(int argc, char **argv) {
     // displayed about all the graphics cards which are available on the system.
     const auto hide_gpu_stats = cla_parser.arg<bool>("--no-stats");
     if (hide_gpu_stats.value_or(false)) {
-        spdlog::debug("--no-stats specified, no extended information about graphics cards will be shown.");
+        spdlog::trace("--no-stats specified, no extended information about graphics cards will be shown");
         display_graphics_card_info = false;
     }
 
@@ -435,10 +436,10 @@ Application::Application(int argc, char **argv) {
     // for the next vertical blanking period to update the current image.
     const auto enable_vertical_synchronisation = cla_parser.arg<bool>("--vsync");
     if (enable_vertical_synchronisation.value_or(false)) {
-        spdlog::debug("V-sync enabled!");
+        spdlog::trace("V-sync enabled!");
         m_vsync_enabled = true;
     } else {
-        spdlog::debug("V-sync disabled!");
+        spdlog::trace("V-sync disabled!");
         m_vsync_enabled = false;
     }
 
@@ -451,8 +452,8 @@ Application::Application(int argc, char **argv) {
     // Ignore distinct data transfer queue
     const auto forbid_distinct_data_transfer_queue = cla_parser.arg<bool>("--no-separate-data-queue");
     if (forbid_distinct_data_transfer_queue.value_or(false)) {
-        spdlog::warn("Command line argument --no-separate-data-queue specified.");
-        spdlog::warn("This will force the application to avoid using a distinct queue for data transfer to GPU.");
+        spdlog::warn("Command line argument --no-separate-data-queue specified");
+        spdlog::warn("This will force the application to avoid using a distinct queue for data transfer to GPU");
         spdlog::warn("Performance loss might be a result of this!");
         use_distinct_data_transfer_queue = false;
     }
@@ -499,9 +500,6 @@ Application::Application(int argc, char **argv) {
 
     load_octree_geometry(true);
     generate_octree_indices();
-
-    spdlog::debug("Vulkan initialisation finished.");
-    spdlog::debug("Showing window.");
 
     m_window->show();
     recreate_swapchain();
@@ -598,7 +596,7 @@ void Application::check_octree_collisions() {
 }
 
 void Application::run() {
-    spdlog::debug("Running Application.");
+    spdlog::trace("Running Application");
 
     while (!m_window->should_close()) {
         m_window->poll();

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -13,7 +13,7 @@ namespace inexor::vulkan_renderer {
 ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapchain &swapchain,
                            RenderGraph *render_graph, TextureResource *back_buffer)
     : m_device(device), m_swapchain(swapchain) {
-    spdlog::debug("Creating ImGUI context");
+    spdlog::trace("Creating ImGUI context");
     ImGui::CreateContext();
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -37,7 +37,7 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     ImGuiIO &io = ImGui::GetIO();
     io.FontGlobalScale = m_scale;
 
-    spdlog::debug("Loading ImGUI shaders");
+    spdlog::trace("Loading ImGUI shaders");
     m_vertex_shader = std::make_unique<wrapper::Shader>(m_device, VK_SHADER_STAGE_VERTEX_BIT, "ImGUI vertex shader",
                                                         "shaders/ui.vert.spv");
     m_fragment_shader = std::make_unique<wrapper::Shader>(m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -49,7 +49,7 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     constexpr const char *FONT_FILE_PATH = "assets/fonts/NotoSans-Bold.ttf";
     constexpr float FONT_SIZE = 18.0f;
 
-    spdlog::debug("Loading front '{}'", FONT_FILE_PATH);
+    spdlog::trace("Loading front {}", FONT_FILE_PATH);
 
     ImFont *font = io.Fonts->AddFontFromFileTTF(FONT_FILE_PATH, FONT_SIZE);
 
@@ -59,10 +59,10 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     io.Fonts->GetTexDataAsRGBA32(&font_texture_data, &font_texture_width, &font_texture_height);
 
     if (font == nullptr || font_texture_data == nullptr) {
-        spdlog::error("Unable to load font {}.  Falling back to error texture.", FONT_FILE_PATH);
+        spdlog::error("Unable to load font {}.  Falling back to error texture", FONT_FILE_PATH);
         m_imgui_texture = std::make_unique<wrapper::GpuTexture>(m_device, wrapper::CpuTexture());
     } else {
-        spdlog::debug("Creating ImGUI font texture");
+        spdlog::trace("Creating ImGUI font texture");
 
         // Our font textures always have 4 channels and a single mip level by definition.
         constexpr int FONT_TEXTURE_CHANNELS{4};

--- a/src/vulkan-renderer/io/nxoc_parser.cpp
+++ b/src/vulkan-renderer/io/nxoc_parser.cpp
@@ -64,27 +64,27 @@ std::shared_ptr<world::Cube> NXOCParser::deserialize_impl<0>(const ByteStream &s
 
 ByteStream NXOCParser::serialize(const std::shared_ptr<const world::Cube> cube, const std::uint32_t version) {
     if (cube == nullptr) {
-        throw std::invalid_argument("cube cannot be a nullptr.");
+        throw std::invalid_argument("cube cannot be a nullptr");
     }
     switch (version) { // NOLINT
     case 0:
         return serialize_impl<0>(cube);
     default:
-        throw IoException("Unsupported octree version.");
+        throw IoException("Unsupported octree version");
     }
 }
 
 std::shared_ptr<world::Cube> NXOCParser::deserialize(const ByteStream &stream) {
     ByteStreamReader reader(stream);
     if (reader.read<std::string>(13ull) != "Inexor Octree") {
-        throw IoException("Wrong identifier.");
+        throw IoException("Wrong identifier");
     }
     const auto version = reader.read<std::uint32_t>();
     switch (version) { // NOLINT
     case 0:
         return deserialize_impl<0>(stream);
     default:
-        throw IoException("Unsupported octree version.");
+        throw IoException("Unsupported octree version");
     }
 }
 } // namespace inexor::vulkan_renderer::io

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -121,7 +121,7 @@ void VulkanRenderer::render_frame() {
 
     if (auto fps_value = m_fps_counter.update()) {
         m_window->set_title("Inexor Vulkan API renderer demo - " + std::to_string(*fps_value) + " FPS");
-        spdlog::debug("FPS: {}, window size: {} x {}.", *fps_value, m_window->width(), m_window->height());
+        spdlog::trace("FPS: {}, window size: {} x {}", *fps_value, m_window->width(), m_window->height());
     }
 }
 
@@ -129,21 +129,20 @@ void VulkanRenderer::calculate_memory_budget() {
     VmaStats memory_stats;
     vmaCalculateStats(m_device->allocator(), &memory_stats);
 
-    spdlog::debug("-------------VMA stats-------------");
-    spdlog::debug("Number of `VkDeviceMemory` (physical memory) blocks allocated: {} still alive, {} in total",
-                  memory_stats.memoryHeap->blockCount, memory_stats.total.blockCount);
-    spdlog::debug("Number of VmaAlllocation objects allocated (requested memory): {} still alive, {} in total",
-                  memory_stats.memoryHeap->allocationCount, memory_stats.total.allocationCount);
-    spdlog::debug("Number of free ranges of memory between allocations: {}", memory_stats.memoryHeap->unusedRangeCount);
-    spdlog::debug("Total number of bytes occupied by all allocations: {}", memory_stats.memoryHeap->usedBytes);
-    spdlog::debug("Total number of bytes occupied by unused ranges: {}", memory_stats.memoryHeap->unusedBytes);
-    spdlog::debug("memory_stats.memoryHeap->allocationSizeMin: {}", memory_stats.memoryHeap->allocationSizeMin);
-    spdlog::debug("memory_stats.memoryHeap->allocationSizeAvg: {}", memory_stats.memoryHeap->allocationSizeAvg);
-    spdlog::debug("memory_stats.memoryHeap->allocationSizeMax: {}", memory_stats.memoryHeap->allocationSizeMax);
-    spdlog::debug("memory_stats.memoryHeap->unusedRangeSizeMin: {}", memory_stats.memoryHeap->unusedRangeSizeMin);
-    spdlog::debug("memory_stats.memoryHeap->unusedRangeSizeAvg: {}", memory_stats.memoryHeap->unusedRangeSizeAvg);
-    spdlog::debug("memory_stats.memoryHeap->unusedRangeSizeMax: {}", memory_stats.memoryHeap->unusedRangeSizeMax);
-    spdlog::debug("-------------VMA stats-------------");
+    spdlog::trace("Vulkan Memory Allocator statistics:");
+    spdlog::trace("   total.blockCount: {}", memory_stats.total.blockCount);
+    spdlog::trace("   total.allocationCount: {}", memory_stats.total.allocationCount);
+    spdlog::trace("   memoryHeap->blockCount: {}", memory_stats.memoryHeap->blockCount);
+    spdlog::trace("   memoryHeap->allocationCount: {}", memory_stats.memoryHeap->allocationCount);
+    spdlog::trace("   memoryHeap->unusedRangeCount: {}", memory_stats.memoryHeap->unusedRangeCount);
+    spdlog::trace("   memoryHeap->usedBytes: {}", memory_stats.memoryHeap->usedBytes);
+    spdlog::trace("   memoryHeap->unusedBytes: {}", memory_stats.memoryHeap->unusedBytes);
+    spdlog::trace("   memoryHeap->allocationSizeMin: {}", memory_stats.memoryHeap->allocationSizeMin);
+    spdlog::trace("   memoryHeap->allocationSizeAvg: {}", memory_stats.memoryHeap->allocationSizeAvg);
+    spdlog::trace("   memoryHeap->allocationSizeMax: {}", memory_stats.memoryHeap->allocationSizeMax);
+    spdlog::trace("   memoryHeap->unusedRangeSizeMin: {}", memory_stats.memoryHeap->unusedRangeSizeMin);
+    spdlog::trace("   memoryHeap->unusedRangeSizeAvg: {}", memory_stats.memoryHeap->unusedRangeSizeAvg);
+    spdlog::trace("   memoryHeap->unusedRangeSizeMax: {}", memory_stats.memoryHeap->unusedRangeSizeMax);
 
     char *vma_stats_string = nullptr;
     vmaBuildStatsString(m_device->allocator(), &vma_stats_string, VK_TRUE);
@@ -157,7 +156,7 @@ void VulkanRenderer::calculate_memory_budget() {
 }
 
 VulkanRenderer::~VulkanRenderer() {
-    spdlog::debug("Shutting down vulkan renderer");
+    spdlog::trace("Shutting down vulkan renderer");
 
     if (m_device == nullptr) {
         return;

--- a/src/vulkan-renderer/vk_tools/gpu_info.cpp
+++ b/src/vulkan-renderer/vk_tools/gpu_info.cpp
@@ -18,7 +18,7 @@ void print_driver_vulkan_version() {
         return;
     }
 
-    spdlog::debug("Supported Vulkan API version: {}.{}.{}", VK_VERSION_MAJOR(api_version),
+    spdlog::trace("Supported Vulkan API version: {}.{}.{}", VK_VERSION_MAJOR(api_version),
                   VK_VERSION_MINOR(api_version), VK_VERSION_PATCH(api_version));
 }
 
@@ -29,7 +29,7 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceQueueFamilyProperties(gpu, &queue_family_count, nullptr);
 
-    spdlog::debug("Number of queue families: {}", queue_family_count);
+    spdlog::trace("Number of queue families: {}", queue_family_count);
 
     if (queue_family_count == 0) {
         return;
@@ -44,17 +44,17 @@ void print_physical_device_queue_families(const VkPhysicalDevice gpu) {
                                     VK_QUEUE_SPARSE_BINDING_BIT, VK_QUEUE_PROTECTED_BIT};
 
     for (std::size_t i = 0; i < queue_family_count; i++) {
-        spdlog::debug("Queue family: {}", i);
-        spdlog::debug("Queue count: {}", queue_family_properties[i].queueCount);
-        spdlog::debug("Timestamp valid bits: {}", queue_family_properties[i].timestampValidBits);
+        spdlog::trace("Queue family: {}", i);
+        spdlog::trace("Queue count: {}", queue_family_properties[i].queueCount);
+        spdlog::trace("Timestamp valid bits: {}", queue_family_properties[i].timestampValidBits);
 
         for (const auto &queue_bit : QUEUE_BITS) {
             if (static_cast<bool>(queue_family_properties[i].queueFlags & queue_bit)) {
-                spdlog::debug("{}", vk_tools::as_string(queue_bit));
+                spdlog::trace("{}", vk_tools::as_string(queue_bit));
             }
         }
 
-        spdlog::debug("Min image transfer granularity: width {}, height {}, depth {}",
+        spdlog::trace("Min image transfer granularity: width {}, height {}, depth {}",
                       queue_family_properties[i].minImageTransferGranularity.width,
                       queue_family_properties[i].minImageTransferGranularity.height,
                       queue_family_properties[i].minImageTransferGranularity.depth);
@@ -70,7 +70,7 @@ void print_instance_layers() {
         return;
     }
 
-    spdlog::debug("Number of instance layers: {}", instance_layer_count);
+    spdlog::trace("Number of instance layers: {}", instance_layer_count);
 
     if (instance_layer_count == 0) {
         // This is not an error. Some platforms simply don't have any instance layers.
@@ -88,11 +88,11 @@ void print_instance_layers() {
     }
 
     for (const auto &layer : instance_layers) {
-        spdlog::debug("Name: {}", layer.layerName);
-        spdlog::debug("Spec Version: {}", VK_VERSION_MAJOR(layer.specVersion), VK_VERSION_MINOR(layer.specVersion),
+        spdlog::trace("Name: {}", layer.layerName);
+        spdlog::trace("Spec Version: {}", VK_VERSION_MAJOR(layer.specVersion), VK_VERSION_MINOR(layer.specVersion),
                       VK_VERSION_PATCH(layer.specVersion));
-        spdlog::debug("Impl Version: {}", layer.implementationVersion);
-        spdlog::debug("Description: {}", layer.description);
+        spdlog::trace("Impl Version: {}", layer.implementationVersion);
+        spdlog::trace("Description: {}", layer.description);
     }
 }
 
@@ -106,7 +106,7 @@ void print_instance_extensions() {
         return;
     }
 
-    spdlog::debug("Number of instance extensions: {} ", instance_extension_count);
+    spdlog::trace("Number of instance extensions: {} ", instance_extension_count);
 
     if (instance_extension_count == 0) {
         // This is not an error. Some platforms simply don't have any instance extensions.
@@ -125,7 +125,7 @@ void print_instance_extensions() {
     }
 
     for (const auto &extension : extensions) {
-        spdlog::debug("Spec version: {}.{}.{}\t Name: {}", VK_VERSION_MAJOR(extension.specVersion),
+        spdlog::trace("Spec version: {}.{}.{}\t Name: {}", VK_VERSION_MAJOR(extension.specVersion),
                       VK_VERSION_MINOR(extension.specVersion), VK_VERSION_PATCH(extension.specVersion),
                       extension.extensionName);
     }
@@ -143,7 +143,7 @@ void print_device_extensions(const VkPhysicalDevice gpu) {
         return;
     }
 
-    spdlog::debug("Number of device extensions: {}", device_extension_count);
+    spdlog::trace("Number of device extensions: {}", device_extension_count);
 
     if (device_extension_count == 0) {
         // This is not an error. Some platforms simply don't have any device extensions.
@@ -162,7 +162,7 @@ void print_device_extensions(const VkPhysicalDevice gpu) {
     }
 
     for (const auto &extension : device_extensions) {
-        spdlog::debug("Spec version: {}.{}.{}\t Name: {}", VK_VERSION_MAJOR(extension.specVersion),
+        spdlog::trace("Spec version: {}.{}.{}\t Name: {}", VK_VERSION_MAJOR(extension.specVersion),
                       VK_VERSION_MINOR(extension.specVersion), VK_VERSION_PATCH(extension.specVersion),
                       extension.extensionName);
     }
@@ -172,7 +172,7 @@ void print_surface_capabilities(const VkPhysicalDevice gpu, const VkSurfaceKHR s
     assert(gpu);
     assert(surface);
 
-    spdlog::debug("Printing surface capabilities.");
+    spdlog::trace("Printing surface capabilities");
 
     VkSurfaceCapabilitiesKHR surface_capabilities;
 
@@ -182,19 +182,19 @@ void print_surface_capabilities(const VkPhysicalDevice gpu, const VkSurfaceKHR s
         return;
     }
 
-    spdlog::debug("minImageCount: {}", surface_capabilities.minImageCount);
-    spdlog::debug("maxImageCount: {}", surface_capabilities.maxImageCount);
-    spdlog::debug("currentExtent.width: {}", surface_capabilities.currentExtent.width);
-    spdlog::debug("currentExtent.height: {}", surface_capabilities.currentExtent.height);
-    spdlog::debug("minImageExtent.width: {}", surface_capabilities.minImageExtent.width);
-    spdlog::debug("minImageExtent.height: {}", surface_capabilities.minImageExtent.height);
-    spdlog::debug("maxImageExtent.width: {}", surface_capabilities.maxImageExtent.width);
-    spdlog::debug("maxImageExtent.height: {}", surface_capabilities.maxImageExtent.height);
-    spdlog::debug("maxImageArrayLayers: {}", surface_capabilities.maxImageArrayLayers);
-    spdlog::debug("supportedTransforms: {}", surface_capabilities.supportedTransforms);
-    spdlog::debug("currentTransform: {}", surface_capabilities.currentTransform);
-    spdlog::debug("supportedCompositeAlpha: {}", surface_capabilities.supportedCompositeAlpha);
-    spdlog::debug("supportedUsageFlags: {}", surface_capabilities.supportedUsageFlags);
+    spdlog::trace("minImageCount: {}", surface_capabilities.minImageCount);
+    spdlog::trace("maxImageCount: {}", surface_capabilities.maxImageCount);
+    spdlog::trace("currentExtent.width: {}", surface_capabilities.currentExtent.width);
+    spdlog::trace("currentExtent.height: {}", surface_capabilities.currentExtent.height);
+    spdlog::trace("minImageExtent.width: {}", surface_capabilities.minImageExtent.width);
+    spdlog::trace("minImageExtent.height: {}", surface_capabilities.minImageExtent.height);
+    spdlog::trace("maxImageExtent.width: {}", surface_capabilities.maxImageExtent.width);
+    spdlog::trace("maxImageExtent.height: {}", surface_capabilities.maxImageExtent.height);
+    spdlog::trace("maxImageArrayLayers: {}", surface_capabilities.maxImageArrayLayers);
+    spdlog::trace("supportedTransforms: {}", surface_capabilities.supportedTransforms);
+    spdlog::trace("currentTransform: {}", surface_capabilities.currentTransform);
+    spdlog::trace("supportedCompositeAlpha: {}", surface_capabilities.supportedCompositeAlpha);
+    spdlog::trace("supportedUsageFlags: {}", surface_capabilities.supportedUsageFlags);
 }
 
 void print_supported_surface_formats(const VkPhysicalDevice gpu, const VkSurfaceKHR surface) {
@@ -210,7 +210,7 @@ void print_supported_surface_formats(const VkPhysicalDevice gpu, const VkSurface
         return;
     }
 
-    spdlog::debug("Supported surface formats: {}", format_count);
+    spdlog::trace("Supported surface formats: {}", format_count);
 
     if (format_count == 0) {
         return;
@@ -226,7 +226,7 @@ void print_supported_surface_formats(const VkPhysicalDevice gpu, const VkSurface
     }
 
     for (const auto &format : surface_formats) {
-        spdlog::debug("Surface format: {}", vk_tools::as_string(format.format));
+        spdlog::trace("Surface format: {}", vk_tools::as_string(format.format));
     }
 }
 
@@ -243,7 +243,7 @@ void print_presentation_modes(const VkPhysicalDevice gpu, const VkSurfaceKHR sur
         return;
     }
 
-    spdlog::debug("Available present modes: ", present_mode_count);
+    spdlog::trace("Available present modes: ", present_mode_count);
 
     if (present_mode_count == 0) {
         return;
@@ -260,7 +260,7 @@ void print_presentation_modes(const VkPhysicalDevice gpu, const VkSurfaceKHR sur
     }
 
     for (const auto &mode : present_modes) {
-        spdlog::debug("Present mode: {}", vk_tools::as_string(mode));
+        spdlog::trace("Present mode: {}", vk_tools::as_string(mode));
     }
 }
 
@@ -271,30 +271,30 @@ void print_physical_device_info(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceProperties(gpu, &gpu_properties);
 
-    spdlog::debug("Gpu: {}", gpu_properties.deviceName);
+    spdlog::trace("Gpu: {}", gpu_properties.deviceName);
 
-    spdlog::debug("Vulkan API supported version: {}.{}.{}", VK_VERSION_MAJOR(gpu_properties.apiVersion),
+    spdlog::trace("Vulkan API supported version: {}.{}.{}", VK_VERSION_MAJOR(gpu_properties.apiVersion),
                   VK_VERSION_MINOR(gpu_properties.apiVersion), VK_VERSION_PATCH(gpu_properties.apiVersion));
 
     // The driver version format is not standardised. It's not even always the same for one vendor!
-    spdlog::debug("Vulkan API supported version: {}.{}.{}", VK_VERSION_MAJOR(gpu_properties.driverVersion),
+    spdlog::trace("Vulkan API supported version: {}.{}.{}", VK_VERSION_MAJOR(gpu_properties.driverVersion),
                   VK_VERSION_MINOR(gpu_properties.driverVersion), VK_VERSION_PATCH(gpu_properties.driverVersion));
-    spdlog::debug("Vendor ID: {}", gpu_properties.vendorID);
-    spdlog::debug("Device ID: {}", gpu_properties.deviceID);
-    spdlog::debug("Device type: {}", vk_tools::as_string(gpu_properties.deviceType));
+    spdlog::trace("Vendor ID: {}", gpu_properties.vendorID);
+    spdlog::trace("Device ID: {}", gpu_properties.deviceID);
+    spdlog::trace("Device type: {}", vk_tools::as_string(gpu_properties.deviceType));
 }
 
 void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
     assert(gpu);
 
-    spdlog::debug("Gpu memory properties:");
+    spdlog::trace("Gpu memory properties:");
 
     VkPhysicalDeviceMemoryProperties gpu_mem_properties;
 
     vkGetPhysicalDeviceMemoryProperties(gpu, &gpu_mem_properties);
 
-    spdlog::debug("Number of memory types: {}", gpu_mem_properties.memoryTypeCount);
-    spdlog::debug("Number of heap types: {}", gpu_mem_properties.memoryHeapCount);
+    spdlog::trace("Number of memory types: {}", gpu_mem_properties.memoryTypeCount);
+    spdlog::trace("Number of heap types: {}", gpu_mem_properties.memoryHeapCount);
 
     constexpr std::array MEM_PROP_FLAGS{
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
@@ -303,11 +303,11 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
         VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD, VK_MEMORY_PROPERTY_DEVICE_UNCACHED_BIT_AMD};
 
     for (std::size_t i = 0; i < gpu_mem_properties.memoryTypeCount; i++) {
-        spdlog::debug("[{}] Heap index: {}", i, gpu_mem_properties.memoryTypes[i].heapIndex);
+        spdlog::trace("[{}] Heap index: {}", i, gpu_mem_properties.memoryTypes[i].heapIndex);
 
         for (const auto &mem_prop_flag : MEM_PROP_FLAGS) {
             if (static_cast<bool>(gpu_mem_properties.memoryTypes[i].propertyFlags & mem_prop_flag)) {
-                spdlog::debug("{}", vk_tools::as_string(mem_prop_flag));
+                spdlog::trace("{}", vk_tools::as_string(mem_prop_flag));
             }
         }
     }
@@ -316,11 +316,11 @@ void print_physical_device_memory_properties(const VkPhysicalDevice gpu) {
                                              VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR, VK_MEMORY_HEAP_FLAG_BITS_MAX_ENUM};
 
     for (std::size_t i = 0; i < gpu_mem_properties.memoryHeapCount; i++) {
-        spdlog::debug("Heap [{}], memory size: {}", i, gpu_mem_properties.memoryHeaps[i].size / (1000 * 1000));
+        spdlog::trace("Heap [{}], memory size: {}", i, gpu_mem_properties.memoryHeaps[i].size / (1000 * 1000));
 
         for (const auto &mem_heap_prop_flag : MEM_HEAP_PROP_FLAGS) {
             if (static_cast<bool>(gpu_mem_properties.memoryHeaps[i].flags & mem_heap_prop_flag)) {
-                spdlog::debug("{}", vk_tools::as_string(mem_heap_prop_flag));
+                spdlog::trace("{}", vk_tools::as_string(mem_heap_prop_flag));
             }
         }
     }
@@ -333,63 +333,63 @@ void print_physical_device_features(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceFeatures(gpu, &gpu_features);
 
-    spdlog::debug("Gpu features:");
+    spdlog::trace("Gpu features:");
 
-    spdlog::debug("robustBufferAccess: {}", gpu_features.robustBufferAccess);
-    spdlog::debug("fullDrawIndexUint32: {}", gpu_features.fullDrawIndexUint32);
-    spdlog::debug("imageCubeArray: {}", gpu_features.imageCubeArray);
-    spdlog::debug("independentBlend: {}", gpu_features.independentBlend);
-    spdlog::debug("geometryShader: {}", gpu_features.geometryShader);
-    spdlog::debug("tessellationShader: {}", gpu_features.tessellationShader);
-    spdlog::debug("sampleRateShading: {}", gpu_features.sampleRateShading);
-    spdlog::debug("dualSrcBlend: {}", gpu_features.dualSrcBlend);
-    spdlog::debug("logicOp: {}", gpu_features.logicOp);
-    spdlog::debug("multiDrawIndirect: {}", gpu_features.multiDrawIndirect);
-    spdlog::debug("drawIndirectFirstInstance: {}", gpu_features.drawIndirectFirstInstance);
-    spdlog::debug("depthClamp: {}", gpu_features.depthClamp);
-    spdlog::debug("depthBiasClamp: {}", gpu_features.depthBiasClamp);
-    spdlog::debug("fillModeNonSolid: {}", gpu_features.fillModeNonSolid);
-    spdlog::debug("depthBounds: {}", gpu_features.depthBounds);
-    spdlog::debug("wideLines: {}", gpu_features.wideLines);
-    spdlog::debug("largePoints: {}", gpu_features.largePoints);
-    spdlog::debug("alphaToOne: {}", gpu_features.alphaToOne);
-    spdlog::debug("multiViewport: {}", gpu_features.multiViewport);
-    spdlog::debug("samplerAnisotropy: {}", gpu_features.samplerAnisotropy);
-    spdlog::debug("textureCompressionETC2: {}", gpu_features.textureCompressionETC2);
-    spdlog::debug("textureCompressionASTC_LDR: {}", gpu_features.textureCompressionASTC_LDR);
-    spdlog::debug("textureCompressionBC: {}", gpu_features.textureCompressionBC);
-    spdlog::debug("occlusionQueryPrecise: {}", gpu_features.occlusionQueryPrecise);
-    spdlog::debug("pipelineStatisticsQuery: {}", gpu_features.pipelineStatisticsQuery);
-    spdlog::debug("vertexPipelineStoresAndAtomics: {}", gpu_features.vertexPipelineStoresAndAtomics);
-    spdlog::debug("fragmentStoresAndAtomics: {}", gpu_features.fragmentStoresAndAtomics);
-    spdlog::debug("shaderTessellationAndGeometryPointSize: {}", gpu_features.shaderTessellationAndGeometryPointSize);
-    spdlog::debug("shaderImageGatherExtended: {}", gpu_features.shaderImageGatherExtended);
-    spdlog::debug("shaderStorageImageExtendedFormats: {}", gpu_features.shaderStorageImageExtendedFormats);
-    spdlog::debug("shaderStorageImageMultisample: {}", gpu_features.shaderStorageImageMultisample);
-    spdlog::debug("shaderStorageImageReadWithoutFormat: {}", gpu_features.shaderStorageImageReadWithoutFormat);
-    spdlog::debug("shaderStorageImageWriteWithoutFormat: {}", gpu_features.shaderStorageImageWriteWithoutFormat);
-    spdlog::debug("shaderUniformBufferArrayDynamicIndexing: {}", gpu_features.shaderUniformBufferArrayDynamicIndexing);
-    spdlog::debug("shaderSampledImageArrayDynamicIndexing: {}", gpu_features.shaderSampledImageArrayDynamicIndexing);
-    spdlog::debug("shaderStorageBufferArrayDynamicIndexing: {}", gpu_features.shaderStorageBufferArrayDynamicIndexing);
-    spdlog::debug("shaderStorageImageArrayDynamicIndexing: {}", gpu_features.shaderStorageImageArrayDynamicIndexing);
-    spdlog::debug("shaderClipDistance: {}", gpu_features.shaderClipDistance);
-    spdlog::debug("shaderCullDistance: {}", gpu_features.shaderCullDistance);
-    spdlog::debug("shaderFloat64: {}", gpu_features.shaderFloat64);
-    spdlog::debug("shaderInt64: {}", gpu_features.shaderInt64);
-    spdlog::debug("shaderInt16: {}", gpu_features.shaderInt16);
-    spdlog::debug("shaderResourceResidency: {}", gpu_features.shaderResourceResidency);
-    spdlog::debug("shaderResourceMinLod: {}", gpu_features.shaderResourceMinLod);
-    spdlog::debug("sparseBinding: {}", gpu_features.sparseBinding);
-    spdlog::debug("sparseResidencyBuffer: {}", gpu_features.sparseResidencyBuffer);
-    spdlog::debug("sparseResidencyImage2D: {}", gpu_features.sparseResidencyImage2D);
-    spdlog::debug("sparseResidencyImage3D: {}", gpu_features.sparseResidencyImage3D);
-    spdlog::debug("sparseResidency2Samples: {}", gpu_features.sparseResidency2Samples);
-    spdlog::debug("sparseResidency4Samples: {}", gpu_features.sparseResidency4Samples);
-    spdlog::debug("sparseResidency8Samples: {}", gpu_features.sparseResidency8Samples);
-    spdlog::debug("sparseResidency16Samples: {}", gpu_features.sparseResidency16Samples);
-    spdlog::debug("sparseResidencyAliased: {}", gpu_features.sparseResidencyAliased);
-    spdlog::debug("variableMultisampleRate: {}", gpu_features.variableMultisampleRate);
-    spdlog::debug("inheritedQueries: {}", gpu_features.inheritedQueries);
+    spdlog::trace("robustBufferAccess: {}", gpu_features.robustBufferAccess);
+    spdlog::trace("fullDrawIndexUint32: {}", gpu_features.fullDrawIndexUint32);
+    spdlog::trace("imageCubeArray: {}", gpu_features.imageCubeArray);
+    spdlog::trace("independentBlend: {}", gpu_features.independentBlend);
+    spdlog::trace("geometryShader: {}", gpu_features.geometryShader);
+    spdlog::trace("tessellationShader: {}", gpu_features.tessellationShader);
+    spdlog::trace("sampleRateShading: {}", gpu_features.sampleRateShading);
+    spdlog::trace("dualSrcBlend: {}", gpu_features.dualSrcBlend);
+    spdlog::trace("logicOp: {}", gpu_features.logicOp);
+    spdlog::trace("multiDrawIndirect: {}", gpu_features.multiDrawIndirect);
+    spdlog::trace("drawIndirectFirstInstance: {}", gpu_features.drawIndirectFirstInstance);
+    spdlog::trace("depthClamp: {}", gpu_features.depthClamp);
+    spdlog::trace("depthBiasClamp: {}", gpu_features.depthBiasClamp);
+    spdlog::trace("fillModeNonSolid: {}", gpu_features.fillModeNonSolid);
+    spdlog::trace("depthBounds: {}", gpu_features.depthBounds);
+    spdlog::trace("wideLines: {}", gpu_features.wideLines);
+    spdlog::trace("largePoints: {}", gpu_features.largePoints);
+    spdlog::trace("alphaToOne: {}", gpu_features.alphaToOne);
+    spdlog::trace("multiViewport: {}", gpu_features.multiViewport);
+    spdlog::trace("samplerAnisotropy: {}", gpu_features.samplerAnisotropy);
+    spdlog::trace("textureCompressionETC2: {}", gpu_features.textureCompressionETC2);
+    spdlog::trace("textureCompressionASTC_LDR: {}", gpu_features.textureCompressionASTC_LDR);
+    spdlog::trace("textureCompressionBC: {}", gpu_features.textureCompressionBC);
+    spdlog::trace("occlusionQueryPrecise: {}", gpu_features.occlusionQueryPrecise);
+    spdlog::trace("pipelineStatisticsQuery: {}", gpu_features.pipelineStatisticsQuery);
+    spdlog::trace("vertexPipelineStoresAndAtomics: {}", gpu_features.vertexPipelineStoresAndAtomics);
+    spdlog::trace("fragmentStoresAndAtomics: {}", gpu_features.fragmentStoresAndAtomics);
+    spdlog::trace("shaderTessellationAndGeometryPointSize: {}", gpu_features.shaderTessellationAndGeometryPointSize);
+    spdlog::trace("shaderImageGatherExtended: {}", gpu_features.shaderImageGatherExtended);
+    spdlog::trace("shaderStorageImageExtendedFormats: {}", gpu_features.shaderStorageImageExtendedFormats);
+    spdlog::trace("shaderStorageImageMultisample: {}", gpu_features.shaderStorageImageMultisample);
+    spdlog::trace("shaderStorageImageReadWithoutFormat: {}", gpu_features.shaderStorageImageReadWithoutFormat);
+    spdlog::trace("shaderStorageImageWriteWithoutFormat: {}", gpu_features.shaderStorageImageWriteWithoutFormat);
+    spdlog::trace("shaderUniformBufferArrayDynamicIndexing: {}", gpu_features.shaderUniformBufferArrayDynamicIndexing);
+    spdlog::trace("shaderSampledImageArrayDynamicIndexing: {}", gpu_features.shaderSampledImageArrayDynamicIndexing);
+    spdlog::trace("shaderStorageBufferArrayDynamicIndexing: {}", gpu_features.shaderStorageBufferArrayDynamicIndexing);
+    spdlog::trace("shaderStorageImageArrayDynamicIndexing: {}", gpu_features.shaderStorageImageArrayDynamicIndexing);
+    spdlog::trace("shaderClipDistance: {}", gpu_features.shaderClipDistance);
+    spdlog::trace("shaderCullDistance: {}", gpu_features.shaderCullDistance);
+    spdlog::trace("shaderFloat64: {}", gpu_features.shaderFloat64);
+    spdlog::trace("shaderInt64: {}", gpu_features.shaderInt64);
+    spdlog::trace("shaderInt16: {}", gpu_features.shaderInt16);
+    spdlog::trace("shaderResourceResidency: {}", gpu_features.shaderResourceResidency);
+    spdlog::trace("shaderResourceMinLod: {}", gpu_features.shaderResourceMinLod);
+    spdlog::trace("sparseBinding: {}", gpu_features.sparseBinding);
+    spdlog::trace("sparseResidencyBuffer: {}", gpu_features.sparseResidencyBuffer);
+    spdlog::trace("sparseResidencyImage2D: {}", gpu_features.sparseResidencyImage2D);
+    spdlog::trace("sparseResidencyImage3D: {}", gpu_features.sparseResidencyImage3D);
+    spdlog::trace("sparseResidency2Samples: {}", gpu_features.sparseResidency2Samples);
+    spdlog::trace("sparseResidency4Samples: {}", gpu_features.sparseResidency4Samples);
+    spdlog::trace("sparseResidency8Samples: {}", gpu_features.sparseResidency8Samples);
+    spdlog::trace("sparseResidency16Samples: {}", gpu_features.sparseResidency16Samples);
+    spdlog::trace("sparseResidencyAliased: {}", gpu_features.sparseResidencyAliased);
+    spdlog::trace("variableMultisampleRate: {}", gpu_features.variableMultisampleRate);
+    spdlog::trace("inheritedQueries: {}", gpu_features.inheritedQueries);
 }
 
 void print_physical_device_sparse_properties(const VkPhysicalDevice gpu) {
@@ -399,15 +399,15 @@ void print_physical_device_sparse_properties(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceProperties(gpu, &gpu_properties);
 
-    spdlog::debug("Gpu sparse properties:");
+    spdlog::trace("Gpu sparse properties:");
 
     const auto props = gpu_properties.sparseProperties;
 
-    spdlog::debug("residencyStandard2DBlockShape: {}", props.residencyStandard2DBlockShape);
-    spdlog::debug("residencyStandard2DMultisampleBlockShape: {}", props.residencyStandard2DMultisampleBlockShape);
-    spdlog::debug("residencyStandard3DBlockShape: {}", props.residencyStandard3DBlockShape);
-    spdlog::debug("residencyAlignedMipSize: {}", props.residencyAlignedMipSize);
-    spdlog::debug("residencyNonResidentStrict: {}", props.residencyNonResidentStrict);
+    spdlog::trace("residencyStandard2DBlockShape: {}", props.residencyStandard2DBlockShape);
+    spdlog::trace("residencyStandard2DMultisampleBlockShape: {}", props.residencyStandard2DMultisampleBlockShape);
+    spdlog::trace("residencyStandard3DBlockShape: {}", props.residencyStandard3DBlockShape);
+    spdlog::trace("residencyAlignedMipSize: {}", props.residencyAlignedMipSize);
+    spdlog::trace("residencyNonResidentStrict: {}", props.residencyNonResidentStrict);
 }
 
 void print_physical_device_limits(const VkPhysicalDevice gpu) {
@@ -417,128 +417,128 @@ void print_physical_device_limits(const VkPhysicalDevice gpu) {
 
     vkGetPhysicalDeviceProperties(gpu, &gpu_properties);
 
-    spdlog::debug("Gpu limits:");
+    spdlog::trace("Gpu limits:");
 
     const auto limits = gpu_properties.limits;
 
-    spdlog::debug("maxImageDimension1D: {}", limits.maxImageDimension1D);
-    spdlog::debug("maxImageDimension2D: {}", limits.maxImageDimension2D);
-    spdlog::debug("maxImageDimension3D: {}", limits.maxImageDimension3D);
-    spdlog::debug("maxImageDimensionCube: {}", limits.maxImageDimensionCube);
-    spdlog::debug("maxImageArrayLayers: {}", limits.maxImageArrayLayers);
-    spdlog::debug("maxTexelBufferElements: {}", limits.maxTexelBufferElements);
-    spdlog::debug("maxUniformBufferRange: {}", limits.maxUniformBufferRange);
-    spdlog::debug("maxStorageBufferRange: {}", limits.maxStorageBufferRange);
-    spdlog::debug("maxPushConstantsSize: {}", limits.maxPushConstantsSize);
-    spdlog::debug("maxMemoryAllocationCount: {}", limits.maxMemoryAllocationCount);
-    spdlog::debug("maxSamplerAllocationCount: {}", limits.maxSamplerAllocationCount);
-    spdlog::debug("bufferImageGranularity: {}", limits.bufferImageGranularity);
-    spdlog::debug("sparseAddressSpaceSize: {}", limits.sparseAddressSpaceSize);
-    spdlog::debug("maxBoundDescriptorSets: {}", limits.maxBoundDescriptorSets);
-    spdlog::debug("maxPerStageDescriptorSamplers: {}", limits.maxPerStageDescriptorSamplers);
-    spdlog::debug("maxPerStageDescriptorUniformBuffers: {}", limits.maxPerStageDescriptorUniformBuffers);
-    spdlog::debug("maxPerStageDescriptorStorageBuffers: {}", limits.maxPerStageDescriptorStorageBuffers);
-    spdlog::debug("maxPerStageDescriptorSampledImages: {}", limits.maxPerStageDescriptorSampledImages);
-    spdlog::debug("maxPerStageDescriptorStorageImages: {}", limits.maxPerStageDescriptorStorageImages);
-    spdlog::debug("maxPerStageDescriptorInputAttachments: {}", limits.maxPerStageDescriptorInputAttachments);
-    spdlog::debug("maxPerStageResources: {}", limits.maxPerStageResources);
-    spdlog::debug("maxDescriptorSetSamplers: {}", limits.maxDescriptorSetSamplers);
-    spdlog::debug("maxDescriptorSetUniformBuffers: {}", limits.maxDescriptorSetUniformBuffers);
-    spdlog::debug("maxDescriptorSetUniformBuffersDynamic: {}", limits.maxDescriptorSetUniformBuffersDynamic);
-    spdlog::debug("maxDescriptorSetStorageBuffers: {}", limits.maxDescriptorSetStorageBuffers);
-    spdlog::debug("maxDescriptorSetStorageBuffersDynamic: {}", limits.maxDescriptorSetStorageBuffersDynamic);
-    spdlog::debug("maxDescriptorSetSampledImages: {}", limits.maxDescriptorSetSampledImages);
-    spdlog::debug("maxDescriptorSetStorageImages: {}", limits.maxDescriptorSetStorageImages);
-    spdlog::debug("maxDescriptorSetInputAttachments: {}", limits.maxDescriptorSetInputAttachments);
-    spdlog::debug("maxVertexInputAttributes: {}", limits.maxVertexInputAttributes);
-    spdlog::debug("maxVertexInputBindings: {}", limits.maxVertexInputBindings);
-    spdlog::debug("maxVertexInputAttributeOffset: {}", limits.maxVertexInputAttributeOffset);
-    spdlog::debug("maxVertexInputBindingStride: {}", limits.maxVertexInputBindingStride);
-    spdlog::debug("maxVertexOutputComponents: {}", limits.maxVertexOutputComponents);
-    spdlog::debug("maxTessellationGenerationLevel: {}", limits.maxTessellationGenerationLevel);
-    spdlog::debug("maxTessellationPatchSize: {}", limits.maxTessellationPatchSize);
-    spdlog::debug("maxTessellationControlPerVertexInputComponents: {}",
+    spdlog::trace("maxImageDimension1D: {}", limits.maxImageDimension1D);
+    spdlog::trace("maxImageDimension2D: {}", limits.maxImageDimension2D);
+    spdlog::trace("maxImageDimension3D: {}", limits.maxImageDimension3D);
+    spdlog::trace("maxImageDimensionCube: {}", limits.maxImageDimensionCube);
+    spdlog::trace("maxImageArrayLayers: {}", limits.maxImageArrayLayers);
+    spdlog::trace("maxTexelBufferElements: {}", limits.maxTexelBufferElements);
+    spdlog::trace("maxUniformBufferRange: {}", limits.maxUniformBufferRange);
+    spdlog::trace("maxStorageBufferRange: {}", limits.maxStorageBufferRange);
+    spdlog::trace("maxPushConstantsSize: {}", limits.maxPushConstantsSize);
+    spdlog::trace("maxMemoryAllocationCount: {}", limits.maxMemoryAllocationCount);
+    spdlog::trace("maxSamplerAllocationCount: {}", limits.maxSamplerAllocationCount);
+    spdlog::trace("bufferImageGranularity: {}", limits.bufferImageGranularity);
+    spdlog::trace("sparseAddressSpaceSize: {}", limits.sparseAddressSpaceSize);
+    spdlog::trace("maxBoundDescriptorSets: {}", limits.maxBoundDescriptorSets);
+    spdlog::trace("maxPerStageDescriptorSamplers: {}", limits.maxPerStageDescriptorSamplers);
+    spdlog::trace("maxPerStageDescriptorUniformBuffers: {}", limits.maxPerStageDescriptorUniformBuffers);
+    spdlog::trace("maxPerStageDescriptorStorageBuffers: {}", limits.maxPerStageDescriptorStorageBuffers);
+    spdlog::trace("maxPerStageDescriptorSampledImages: {}", limits.maxPerStageDescriptorSampledImages);
+    spdlog::trace("maxPerStageDescriptorStorageImages: {}", limits.maxPerStageDescriptorStorageImages);
+    spdlog::trace("maxPerStageDescriptorInputAttachments: {}", limits.maxPerStageDescriptorInputAttachments);
+    spdlog::trace("maxPerStageResources: {}", limits.maxPerStageResources);
+    spdlog::trace("maxDescriptorSetSamplers: {}", limits.maxDescriptorSetSamplers);
+    spdlog::trace("maxDescriptorSetUniformBuffers: {}", limits.maxDescriptorSetUniformBuffers);
+    spdlog::trace("maxDescriptorSetUniformBuffersDynamic: {}", limits.maxDescriptorSetUniformBuffersDynamic);
+    spdlog::trace("maxDescriptorSetStorageBuffers: {}", limits.maxDescriptorSetStorageBuffers);
+    spdlog::trace("maxDescriptorSetStorageBuffersDynamic: {}", limits.maxDescriptorSetStorageBuffersDynamic);
+    spdlog::trace("maxDescriptorSetSampledImages: {}", limits.maxDescriptorSetSampledImages);
+    spdlog::trace("maxDescriptorSetStorageImages: {}", limits.maxDescriptorSetStorageImages);
+    spdlog::trace("maxDescriptorSetInputAttachments: {}", limits.maxDescriptorSetInputAttachments);
+    spdlog::trace("maxVertexInputAttributes: {}", limits.maxVertexInputAttributes);
+    spdlog::trace("maxVertexInputBindings: {}", limits.maxVertexInputBindings);
+    spdlog::trace("maxVertexInputAttributeOffset: {}", limits.maxVertexInputAttributeOffset);
+    spdlog::trace("maxVertexInputBindingStride: {}", limits.maxVertexInputBindingStride);
+    spdlog::trace("maxVertexOutputComponents: {}", limits.maxVertexOutputComponents);
+    spdlog::trace("maxTessellationGenerationLevel: {}", limits.maxTessellationGenerationLevel);
+    spdlog::trace("maxTessellationPatchSize: {}", limits.maxTessellationPatchSize);
+    spdlog::trace("maxTessellationControlPerVertexInputComponents: {}",
                   limits.maxTessellationControlPerVertexInputComponents);
-    spdlog::debug("maxTessellationControlPerVertexOutputComponents: {}",
+    spdlog::trace("maxTessellationControlPerVertexOutputComponents: {}",
                   limits.maxTessellationControlPerVertexOutputComponents);
-    spdlog::debug("maxTessellationControlPerPatchOutputComponents: {}",
+    spdlog::trace("maxTessellationControlPerPatchOutputComponents: {}",
                   limits.maxTessellationControlPerPatchOutputComponents);
-    spdlog::debug("maxTessellationControlTotalOutputComponents: {}",
+    spdlog::trace("maxTessellationControlTotalOutputComponents: {}",
                   limits.maxTessellationControlTotalOutputComponents);
-    spdlog::debug("maxTessellationEvaluationInputComponents: {}", limits.maxTessellationEvaluationInputComponents);
-    spdlog::debug("maxTessellationEvaluationOutputComponents: {}", limits.maxTessellationEvaluationOutputComponents);
-    spdlog::debug("maxGeometryShaderInvocations: {}", limits.maxGeometryShaderInvocations);
-    spdlog::debug("maxGeometryInputComponents: {}", limits.maxGeometryInputComponents);
-    spdlog::debug("maxGeometryOutputComponents: {}", limits.maxGeometryOutputComponents);
-    spdlog::debug("maxGeometryOutputVertices: {}", limits.maxGeometryOutputVertices);
-    spdlog::debug("maxGeometryTotalOutputComponents: {}", limits.maxGeometryTotalOutputComponents);
-    spdlog::debug("maxFragmentInputComponents: {}", limits.maxFragmentInputComponents);
-    spdlog::debug("maxFragmentOutputAttachments: {}", limits.maxFragmentOutputAttachments);
-    spdlog::debug("maxFragmentDualSrcAttachments: {}", limits.maxFragmentDualSrcAttachments);
-    spdlog::debug("maxFragmentCombinedOutputResources: {}", limits.maxFragmentCombinedOutputResources);
-    spdlog::debug("maxComputeSharedMemorySize: {}", limits.maxComputeSharedMemorySize);
-    spdlog::debug("maxComputeWorkGroupCount[0]: {}", limits.maxComputeWorkGroupCount[0]);
-    spdlog::debug("maxComputeWorkGroupCount[1]: {}", limits.maxComputeWorkGroupCount[1]);
-    spdlog::debug("maxComputeWorkGroupCount[2]: {}", limits.maxComputeWorkGroupCount[2]);
-    spdlog::debug("maxComputeWorkGroupInvocations: {}", limits.maxComputeWorkGroupInvocations);
-    spdlog::debug("maxComputeWorkGroupSize[0]: {}", limits.maxComputeWorkGroupSize[0]);
-    spdlog::debug("maxComputeWorkGroupSize[1]: {}", limits.maxComputeWorkGroupSize[1]);
-    spdlog::debug("maxComputeWorkGroupSize[2]: {}", limits.maxComputeWorkGroupSize[2]);
-    spdlog::debug("subPixelPrecisionBits: {}", limits.subPixelPrecisionBits);
-    spdlog::debug("subTexelPrecisionBits: {}", limits.subTexelPrecisionBits);
-    spdlog::debug("mipmapPrecisionBits: {}", limits.mipmapPrecisionBits);
-    spdlog::debug("maxDrawIndexedIndexValue: {}", limits.maxDrawIndexedIndexValue);
-    spdlog::debug("maxDrawIndirectCount: {}", limits.maxDrawIndirectCount);
-    spdlog::debug("maxSamplerLodBias: {}", limits.maxSamplerLodBias);
-    spdlog::debug("maxSamplerAnisotropy: {}", limits.maxSamplerAnisotropy);
-    spdlog::debug("maxViewports: {}", limits.maxViewports);
-    spdlog::debug("maxViewportDimensions[0]: {}", limits.maxViewportDimensions[0]);
-    spdlog::debug("maxViewportDimensions[1]: {}", limits.maxViewportDimensions[1]);
-    spdlog::debug("viewportBoundsRange[0]: {}", limits.viewportBoundsRange[0]);
-    spdlog::debug("viewportBoundsRange[1]: {}", limits.viewportBoundsRange[1]);
-    spdlog::debug("viewportSubPixelBits: {}", limits.viewportSubPixelBits);
-    spdlog::debug("minMemoryMapAlignment: {}", limits.minMemoryMapAlignment);
-    spdlog::debug("minTexelBufferOffsetAlignment: {}", limits.minTexelBufferOffsetAlignment);
-    spdlog::debug("minUniformBufferOffsetAlignment: {}", limits.minUniformBufferOffsetAlignment);
-    spdlog::debug("minStorageBufferOffsetAlignment: {}", limits.minStorageBufferOffsetAlignment);
-    spdlog::debug("minTexelOffset: {}", limits.minTexelOffset);
-    spdlog::debug("maxTexelOffset: {}", limits.maxTexelOffset);
-    spdlog::debug("minTexelGatherOffset: {}", limits.minTexelGatherOffset);
-    spdlog::debug("maxTexelGatherOffset: {}", limits.maxTexelGatherOffset);
-    spdlog::debug("minInterpolationOffset: {}", limits.minInterpolationOffset);
-    spdlog::debug("maxInterpolationOffset: {}", limits.maxInterpolationOffset);
-    spdlog::debug("subPixelInterpolationOffsetBits: {}", limits.subPixelInterpolationOffsetBits);
-    spdlog::debug("maxFramebufferWidth: {}", limits.maxFramebufferWidth);
-    spdlog::debug("maxFramebufferHeight: {}", limits.maxFramebufferHeight);
-    spdlog::debug("maxFramebufferLayers: {}", limits.maxFramebufferLayers);
-    spdlog::debug("framebufferColorSampleCounts: {}", limits.framebufferColorSampleCounts);
-    spdlog::debug("framebufferDepthSampleCounts: {}", limits.framebufferDepthSampleCounts);
-    spdlog::debug("framebufferStencilSampleCounts: {}", limits.framebufferStencilSampleCounts);
-    spdlog::debug("framebufferNoAttachmentsSampleCounts: {}", limits.framebufferNoAttachmentsSampleCounts);
-    spdlog::debug("maxColorAttachments: {}", limits.maxColorAttachments);
-    spdlog::debug("sampledImageColorSampleCounts: {}", limits.sampledImageColorSampleCounts);
-    spdlog::debug("sampledImageIntegerSampleCounts: {}", limits.sampledImageIntegerSampleCounts);
-    spdlog::debug("sampledImageDepthSampleCounts: {}", limits.sampledImageDepthSampleCounts);
-    spdlog::debug("sampledImageStencilSampleCounts: {}", limits.sampledImageStencilSampleCounts);
-    spdlog::debug("storageImageSampleCounts: {}", limits.storageImageSampleCounts);
-    spdlog::debug("maxSampleMaskWords: {}", limits.maxSampleMaskWords);
-    spdlog::debug("timestampComputeAndGraphics: {}", limits.timestampComputeAndGraphics);
-    spdlog::debug("timestampPeriod: {}", limits.timestampPeriod);
-    spdlog::debug("maxClipDistances: {}", limits.maxClipDistances);
-    spdlog::debug("maxCullDistances: {}", limits.maxCullDistances);
-    spdlog::debug("maxCombinedClipAndCullDistances: {}", limits.maxCombinedClipAndCullDistances);
-    spdlog::debug("discreteQueuePriorities: {}", limits.discreteQueuePriorities);
-    spdlog::debug("pointSizeRange[0]: {}", limits.pointSizeRange[0]);
-    spdlog::debug("pointSizeRange[1]: {}", limits.pointSizeRange[1]);
-    spdlog::debug("lineWidthRange[0]: {}", limits.lineWidthRange[0]);
-    spdlog::debug("lineWidthRange[1]: {}", limits.lineWidthRange[1]);
-    spdlog::debug("pointSizeGranularity: {}", limits.pointSizeGranularity);
-    spdlog::debug("lineWidthGranularity: {}", limits.lineWidthGranularity);
-    spdlog::debug("strictLines: {}", limits.strictLines);
-    spdlog::debug("standardSampleLocations: {}", limits.standardSampleLocations);
-    spdlog::debug("optimalBufferCopyOffsetAlignment: {}", limits.optimalBufferCopyOffsetAlignment);
-    spdlog::debug("optimalBufferCopyRowPitchAlignment: {}", limits.optimalBufferCopyRowPitchAlignment);
-    spdlog::debug("nonCoherentAtomSize: {}", limits.nonCoherentAtomSize);
+    spdlog::trace("maxTessellationEvaluationInputComponents: {}", limits.maxTessellationEvaluationInputComponents);
+    spdlog::trace("maxTessellationEvaluationOutputComponents: {}", limits.maxTessellationEvaluationOutputComponents);
+    spdlog::trace("maxGeometryShaderInvocations: {}", limits.maxGeometryShaderInvocations);
+    spdlog::trace("maxGeometryInputComponents: {}", limits.maxGeometryInputComponents);
+    spdlog::trace("maxGeometryOutputComponents: {}", limits.maxGeometryOutputComponents);
+    spdlog::trace("maxGeometryOutputVertices: {}", limits.maxGeometryOutputVertices);
+    spdlog::trace("maxGeometryTotalOutputComponents: {}", limits.maxGeometryTotalOutputComponents);
+    spdlog::trace("maxFragmentInputComponents: {}", limits.maxFragmentInputComponents);
+    spdlog::trace("maxFragmentOutputAttachments: {}", limits.maxFragmentOutputAttachments);
+    spdlog::trace("maxFragmentDualSrcAttachments: {}", limits.maxFragmentDualSrcAttachments);
+    spdlog::trace("maxFragmentCombinedOutputResources: {}", limits.maxFragmentCombinedOutputResources);
+    spdlog::trace("maxComputeSharedMemorySize: {}", limits.maxComputeSharedMemorySize);
+    spdlog::trace("maxComputeWorkGroupCount[0]: {}", limits.maxComputeWorkGroupCount[0]);
+    spdlog::trace("maxComputeWorkGroupCount[1]: {}", limits.maxComputeWorkGroupCount[1]);
+    spdlog::trace("maxComputeWorkGroupCount[2]: {}", limits.maxComputeWorkGroupCount[2]);
+    spdlog::trace("maxComputeWorkGroupInvocations: {}", limits.maxComputeWorkGroupInvocations);
+    spdlog::trace("maxComputeWorkGroupSize[0]: {}", limits.maxComputeWorkGroupSize[0]);
+    spdlog::trace("maxComputeWorkGroupSize[1]: {}", limits.maxComputeWorkGroupSize[1]);
+    spdlog::trace("maxComputeWorkGroupSize[2]: {}", limits.maxComputeWorkGroupSize[2]);
+    spdlog::trace("subPixelPrecisionBits: {}", limits.subPixelPrecisionBits);
+    spdlog::trace("subTexelPrecisionBits: {}", limits.subTexelPrecisionBits);
+    spdlog::trace("mipmapPrecisionBits: {}", limits.mipmapPrecisionBits);
+    spdlog::trace("maxDrawIndexedIndexValue: {}", limits.maxDrawIndexedIndexValue);
+    spdlog::trace("maxDrawIndirectCount: {}", limits.maxDrawIndirectCount);
+    spdlog::trace("maxSamplerLodBias: {}", limits.maxSamplerLodBias);
+    spdlog::trace("maxSamplerAnisotropy: {}", limits.maxSamplerAnisotropy);
+    spdlog::trace("maxViewports: {}", limits.maxViewports);
+    spdlog::trace("maxViewportDimensions[0]: {}", limits.maxViewportDimensions[0]);
+    spdlog::trace("maxViewportDimensions[1]: {}", limits.maxViewportDimensions[1]);
+    spdlog::trace("viewportBoundsRange[0]: {}", limits.viewportBoundsRange[0]);
+    spdlog::trace("viewportBoundsRange[1]: {}", limits.viewportBoundsRange[1]);
+    spdlog::trace("viewportSubPixelBits: {}", limits.viewportSubPixelBits);
+    spdlog::trace("minMemoryMapAlignment: {}", limits.minMemoryMapAlignment);
+    spdlog::trace("minTexelBufferOffsetAlignment: {}", limits.minTexelBufferOffsetAlignment);
+    spdlog::trace("minUniformBufferOffsetAlignment: {}", limits.minUniformBufferOffsetAlignment);
+    spdlog::trace("minStorageBufferOffsetAlignment: {}", limits.minStorageBufferOffsetAlignment);
+    spdlog::trace("minTexelOffset: {}", limits.minTexelOffset);
+    spdlog::trace("maxTexelOffset: {}", limits.maxTexelOffset);
+    spdlog::trace("minTexelGatherOffset: {}", limits.minTexelGatherOffset);
+    spdlog::trace("maxTexelGatherOffset: {}", limits.maxTexelGatherOffset);
+    spdlog::trace("minInterpolationOffset: {}", limits.minInterpolationOffset);
+    spdlog::trace("maxInterpolationOffset: {}", limits.maxInterpolationOffset);
+    spdlog::trace("subPixelInterpolationOffsetBits: {}", limits.subPixelInterpolationOffsetBits);
+    spdlog::trace("maxFramebufferWidth: {}", limits.maxFramebufferWidth);
+    spdlog::trace("maxFramebufferHeight: {}", limits.maxFramebufferHeight);
+    spdlog::trace("maxFramebufferLayers: {}", limits.maxFramebufferLayers);
+    spdlog::trace("framebufferColorSampleCounts: {}", limits.framebufferColorSampleCounts);
+    spdlog::trace("framebufferDepthSampleCounts: {}", limits.framebufferDepthSampleCounts);
+    spdlog::trace("framebufferStencilSampleCounts: {}", limits.framebufferStencilSampleCounts);
+    spdlog::trace("framebufferNoAttachmentsSampleCounts: {}", limits.framebufferNoAttachmentsSampleCounts);
+    spdlog::trace("maxColorAttachments: {}", limits.maxColorAttachments);
+    spdlog::trace("sampledImageColorSampleCounts: {}", limits.sampledImageColorSampleCounts);
+    spdlog::trace("sampledImageIntegerSampleCounts: {}", limits.sampledImageIntegerSampleCounts);
+    spdlog::trace("sampledImageDepthSampleCounts: {}", limits.sampledImageDepthSampleCounts);
+    spdlog::trace("sampledImageStencilSampleCounts: {}", limits.sampledImageStencilSampleCounts);
+    spdlog::trace("storageImageSampleCounts: {}", limits.storageImageSampleCounts);
+    spdlog::trace("maxSampleMaskWords: {}", limits.maxSampleMaskWords);
+    spdlog::trace("timestampComputeAndGraphics: {}", limits.timestampComputeAndGraphics);
+    spdlog::trace("timestampPeriod: {}", limits.timestampPeriod);
+    spdlog::trace("maxClipDistances: {}", limits.maxClipDistances);
+    spdlog::trace("maxCullDistances: {}", limits.maxCullDistances);
+    spdlog::trace("maxCombinedClipAndCullDistances: {}", limits.maxCombinedClipAndCullDistances);
+    spdlog::trace("discreteQueuePriorities: {}", limits.discreteQueuePriorities);
+    spdlog::trace("pointSizeRange[0]: {}", limits.pointSizeRange[0]);
+    spdlog::trace("pointSizeRange[1]: {}", limits.pointSizeRange[1]);
+    spdlog::trace("lineWidthRange[0]: {}", limits.lineWidthRange[0]);
+    spdlog::trace("lineWidthRange[1]: {}", limits.lineWidthRange[1]);
+    spdlog::trace("pointSizeGranularity: {}", limits.pointSizeGranularity);
+    spdlog::trace("lineWidthGranularity: {}", limits.lineWidthGranularity);
+    spdlog::trace("strictLines: {}", limits.strictLines);
+    spdlog::trace("standardSampleLocations: {}", limits.standardSampleLocations);
+    spdlog::trace("optimalBufferCopyOffsetAlignment: {}", limits.optimalBufferCopyOffsetAlignment);
+    spdlog::trace("optimalBufferCopyRowPitchAlignment: {}", limits.optimalBufferCopyRowPitchAlignment);
+    spdlog::trace("nonCoherentAtomSize: {}", limits.nonCoherentAtomSize);
 }
 
 void print_all_physical_devices(const VkInstance instance, const VkSurfaceKHR surface) {
@@ -553,7 +553,7 @@ void print_all_physical_devices(const VkInstance instance, const VkSurfaceKHR su
         return;
     }
 
-    spdlog::debug("Number of available gpus: {}", gpu_count);
+    spdlog::trace("Number of available gpus: {}", gpu_count);
 
     if (gpu_count == 0) {
         return;

--- a/src/vulkan-renderer/wrapper/cpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/cpu_texture.cpp
@@ -18,14 +18,12 @@ CpuTexture::CpuTexture(const std::string &file_name, std::string name) : m_name(
     assert(!file_name.empty());
     assert(!m_name.empty());
 
-    spdlog::trace("Loading texture file {}.", file_name);
-
     // Load the texture file using stb_image library.
     // Force stb_image to load an alpha channel as well.
     m_texture_data = stbi_load(file_name.c_str(), &m_texture_width, &m_texture_height, nullptr, STBI_rgb_alpha);
 
     if (m_texture_data == nullptr) {
-        spdlog::error("Could not load texture file {} using stbi_load!  Falling back to error texture.", file_name);
+        spdlog::error("Could not load texture file {} using stbi_load!  Falling back to error texture", file_name);
         generate_error_texture_data();
     } else {
 
@@ -40,7 +38,7 @@ CpuTexture::CpuTexture(const std::string &file_name, std::string name) : m_name(
         // TODO: We are currently only supporting 1 mip level.
         m_mip_levels = 1;
 
-        spdlog::trace("Texture dimensions: width: {}, height: {}, channels: {} mip levels: {}.", m_texture_width,
+        spdlog::trace("Texture dimensions: width: {}, height: {}, channels: {} mip levels: {}", m_texture_width,
                       m_texture_height, m_texture_channels, m_mip_levels);
     }
 }

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -18,7 +18,7 @@ GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, 
     assert(device.allocator());
     assert(!name.empty());
 
-    spdlog::trace("Creating GPU memory buffer of size {} for '{}'.", size, name);
+    spdlog::trace("Creating GPU memory buffer of size {} for {}", size, name);
 
     auto buffer_ci = make_info<VkBufferCreateInfo>();
     buffer_ci.size = size;

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -121,7 +121,7 @@ void Swapchain::setup_swapchain(const VkSwapchainKHR old_swapchain, std::uint32_
     // Assign an internal name using Vulkan debug markers.
     m_device.set_debug_marker_name(m_swapchain, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, m_name);
 
-    spdlog::trace("Creating {} swapchain image views.", m_swapchain_image_count);
+    spdlog::trace("Creating {} swapchain image views", m_swapchain_image_count);
 
     m_swapchain_image_views.resize(m_swapchain_image_count);
 

--- a/src/vulkan-renderer/wrapper/window.cpp
+++ b/src/vulkan-renderer/wrapper/window.cpp
@@ -20,7 +20,7 @@ Window::Window(const std::string &title, const std::uint32_t width, const std::u
     glfwWindowHint(GLFW_VISIBLE, visible ? GLFW_TRUE : GLFW_FALSE);
     glfwWindowHint(GLFW_RESIZABLE, resizable ? GLFW_TRUE : GLFW_FALSE);
 
-    spdlog::debug("Creating window");
+    spdlog::trace("Creating window");
 
     GLFWmonitor *monitor = nullptr;
     if (m_mode != Mode::WINDOWED) {

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -10,7 +10,7 @@ WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_
     assert(instance);
     assert(window);
 
-    spdlog::trace("Creating window surface.");
+    spdlog::trace("Creating window surface");
 
     if (const auto result = glfwCreateWindowSurface(instance, window, nullptr, &m_surface); result != VK_SUCCESS) {
         throw VulkanException("Error: glfwCreateWindowSurface failed!", result);


### PR DESCRIPTION
- Remove unnecessary log messages
- Use log level trace consistently
- Do not end messages with `.`
- Do not print names of objects using ' '
- Use list style consistently when printing multiple items:
```
2022-05-14 21:12:30.551076 trace 43790 [vulkan-renderer] Window: Inexor-Vulkan-Renderer, 1280 x 720
2022-05-14 21:12:30.551122 trace 43790 [vulkan-renderer]    - assets/textures/texture_A_1024.jpg
2022-05-14 21:12:30.551127 trace 43790 [vulkan-renderer]    - assets/textures/texture_C_1024.jpg
2022-05-14 21:12:30.551124 trace 43790 [vulkan-renderer]    - assets/textures/texture_B_1024.jpg
2022-05-14 21:12:30.551129 trace 43790 [vulkan-renderer]    - assets/textures/texture_D_1024.jpg
2022-05-14 21:12:30.551131 trace 43790 [vulkan-renderer]    - assets/textures/texture_E_1024.jpg
2022-05-14 21:12:30.551134 trace 43790 [vulkan-renderer]    - assets/textures/texture_F_1024.jpg
2022-05-14 21:12:30.551136 trace 43790 [vulkan-renderer]    - assets/textures/texture_G_1024.jpg
2022-05-14 21:12:30.551138 trace 43790 [vulkan-renderer]    - assets/textures/logo_rendered.png
```
