### PR TITLE
Use C++20 source_location feature in exceptions

### DIFF
--- a/include/inexor/vulkan-renderer/exception.hpp
+++ b/include/inexor/vulkan-renderer/exception.hpp
@@ -2,24 +2,29 @@
 
 #include <vulkan/vulkan_core.h>
 
+#include <source_location>
 #include <stdexcept>
 #include <string>
 
 namespace inexor::vulkan_renderer {
 
-/// @brief A custom base class for exceptions
+/// A custom base class for exceptions
 class InexorException : public std::runtime_error {
 public:
-    // No need to define own constructors.
+    // There is no need to define our own constructors
     using std::runtime_error::runtime_error;
 };
 
-/// @brief InexorException for Vulkan specific things.
+/// Custom exception class for Vulkan related exceptions
 class VulkanException final : public InexorException {
 public:
-    /// @param message The exception message.
-    /// @param result The VkResult value of the Vulkan API call which failed.
-    VulkanException(std::string message, VkResult result);
+    /// Default constructor
+    /// Here we are using `C++20 source location feature <https://en.cppreference.com/w/cpp/utility/source_location>`__
+    /// @param message The exception message
+    /// @param result The VkResult value of the Vulkan API call which failed
+    /// @param location The source location
+    VulkanException(std::string message, VkResult result,
+                    std::source_location location = std::source_location::current());
 };
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/exception.cpp
+++ b/src/vulkan-renderer/exception.cpp
@@ -4,11 +4,20 @@
 
 namespace inexor::vulkan_renderer {
 
-VulkanException::VulkanException(std::string message, const VkResult result)
+VulkanException::VulkanException(std::string message, const VkResult result, const std::source_location location)
     : InexorException(message.append(" (")
                           .append(vk_tools::as_string(result))
                           .append(": ")
                           .append(vk_tools::result_to_description(result))
+                          .append(") (")
+                          .append("file: ")
+                          .append(location.file_name())
+                          .append(", line: ")
+                          .append(std::to_string(location.line()))
+                          .append(", column: ")
+                          .append(std::to_string(location.column()))
+                          .append(", function name: ")
+                          .append(location.function_name())
                           .append(")")) {}
 
 } // namespace inexor::vulkan_renderer


### PR DESCRIPTION
Closes #468 

## Source locations!
C++20 gives us a very nice new feature, [std::source_location](https://en.cppreference.com/w/cpp/utility/source_location)!

```cpp
VulkanException(std::string message, VkResult result,
                std::source_location location = std::source_location::current());
```

```cpp
VulkanException::VulkanException(std::string message, const VkResult result,
                                 const std::source_location location)
    : InexorException(message.append(" (")
                          .append(vk_tools::as_string(result))
                          .append(": ")
                          .append(vk_tools::result_to_description(result))
                          .append(") (")
                          .append("file: ")
                          .append(location.file_name())
                          .append(", line: ")
                          .append(std::to_string(location.line()))
                          .append(", column: ")
                          .append(std::to_string(location.column()))
                          .append(", function name: ")
                          .append(location.function_name())
                          .append(")")) {}
```

Throwing an example exception from rendergraph:
```cpp
throw VulkanException("I am throwing a new exception!", VK_ERROR_INCOMPATIBLE_DRIVER);
```

Results in:

> terminate called after throwing an instance of 'inexor::vulkan_renderer::VulkanException'
  what():  I am throwing a new exception! (VK_ERROR_INCOMPATIBLE_DRIVER: The requested version of Vulkan is not supported by the driver or is otherwise incompatible for implementation-specific reasons) (file: /home/johannes/Inexor/exception_refactoring/vulkan-renderer/src/vulkan-renderer/render_graph.cpp, line: 85, column: 89, function name: void inexor::vulkan_renderer::RenderGraph::build_buffer(const inexor::vulkan_renderer::BufferResource&, inexor::vulkan_renderer::PhysicalBuffer&) const)

(Note that I didn't add a catch block, so the exception will not be caught properly. However this was only a proof of concept)

This will make debugging a lot easier!

