### PR TITLE
[docs] Added build dependencies and tools for Arch Linux systems

### DIFF
--- a/documentation/source/development/building.rst
+++ b/documentation/source/development/building.rst
@@ -213,6 +213,45 @@ Install dependencies and tools:
 |        |         conan                        |
 |        |                                      |
 +--------+--------------------------------------+
+| Arch   | Follow the                           |
+|        | `Install the SDK`_-instructions on   |
+|        | the vulkan-sdk page.                 |
+|        |                                      |
+|        | Install the required packages:[#f1]_ |
+|        |                                      |
+|        | .. code-block:: shell-session        |
+|        |                                      |
+|        |     # pacman -S \                    |
+|        |         pkg-config \                 |
+|        |         glslang \                    |
+|        |         spirv-tools \                |
+|        |         glm \                        |
+|        |         libice \                     |
+|        |         libpciaccess \               |
+|        |         libpng \                     |
+|        |         libx11 \                     |
+|        |         libxres \                    |
+|        |         xkeyboard-config \           |
+|        |         libxrandr \                  |
+|        |         libxcb \                     |
+|        |         libxaw \                     |
+|        |         xcb-util \                   |
+|        |         xtrans \                     |
+|        |         libxvmc                      |
+|        |     # pacman -S \                    |
+|        |         cmake \                      |
+|        |         ninja \                      |
+|        |         vulkan-headers \             |
+|        |         vulkan-tools \               |
+|        |         vulkan-validation-layers \   |
+|        |         python3 \                    |
+|        |         python-pip                   |
+|        |     $ pip3 install \                 |
+|        |         wheel \                      |
+|        |         setuptools \                 |
+|        |         conan                        |
+|        |                                      |
++--------+--------------------------------------+
 | Other  | Planned. `We would love to see a     |
 |        | pull request on this file if you get |
 |        | it running on other                  |

--- a/documentation/source/development/platforms.rst
+++ b/documentation/source/development/platforms.rst
@@ -17,7 +17,7 @@ Linux
 ------
 
 - We support every x64 Linux distribution for which Vulkan drivers exist.
-- We have specific :ref:`build instructions for Gentoo and Ubuntu <BUILDING linux>`.
+- We have specific :ref:`build instructions for Gentoo, Ubuntu, Debian, and Arch. <BUILDING linux>`.
 - If you have found a way to set it up for other Linux distributions, please `open a pull request <https://github.com/inexorgame/vulkan-renderer/pulls>`__ and let us know!
 
 macOS and iOS


### PR DESCRIPTION
Added the instructions for installing dependencies and tools on an Arch Linux system.

Kept installing every package I needed until the example binary compiled, wrote down all required packages here.
Tested on an Arch Linux machine, of course :) 