### PR TITLE
Use C++20's designated initializers

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
@@ -2,6 +2,8 @@
 
 #include <vulkan/vulkan_core.h>
 
+#include "inexor/vulkan-renderer/wrapper/make_info.hpp"
+
 #include <cassert>
 #include <string>
 #include <vector>
@@ -67,32 +69,28 @@ DescriptorBuilder &DescriptorBuilder::add_uniform_buffer(const VkBuffer uniform_
                                                          const VkShaderStageFlagBits shader_stage) {
     assert(uniform_buffer);
 
-    VkDescriptorSetLayoutBinding layout_binding{};
-    layout_binding.binding = binding;
-    layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    layout_binding.descriptorCount = 1;
-    layout_binding.stageFlags = shader_stage;
-    layout_binding.pImmutableSamplers = nullptr;
+    m_layout_bindings.push_back({
+        .binding = binding,
+        .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .descriptorCount = 1,
+        .stageFlags = static_cast<VkShaderStageFlags>(shader_stage),
+        .pImmutableSamplers = nullptr,
+    });
 
-    m_layout_bindings.push_back(layout_binding);
+    m_descriptor_buffer_infos.push_back({
+        .buffer = uniform_buffer,
+        .offset = 0,
+        .range = sizeof(T),
+    });
 
-    VkDescriptorBufferInfo uniform_buffer_info{};
-    uniform_buffer_info.buffer = uniform_buffer;
-    uniform_buffer_info.offset = 0;
-    uniform_buffer_info.range = sizeof(T);
-
-    m_descriptor_buffer_infos.push_back(uniform_buffer_info);
-
-    VkWriteDescriptorSet descriptor_write{};
-    descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    descriptor_write.dstSet = nullptr;
-    descriptor_write.dstBinding = binding;
-    descriptor_write.dstArrayElement = 0;
-    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    descriptor_write.descriptorCount = 1;
-    descriptor_write.pBufferInfo = &m_descriptor_buffer_infos.back();
-
-    m_write_sets.push_back(descriptor_write);
+    m_write_sets.push_back(make_info<VkWriteDescriptorSet>({
+        .dstSet = nullptr,
+        .dstBinding = binding,
+        .dstArrayElement = 0,
+        .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .pBufferInfo = &m_descriptor_buffer_infos.back(),
+    }));
 
     return *this;
 }

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -20,7 +20,6 @@ protected:
     VkDeviceSize m_buffer_size{0};
     VmaAllocation m_allocation{VK_NULL_HANDLE};
     VmaAllocationInfo m_allocation_info{};
-    VmaAllocationCreateInfo m_allocation_ci{};
 
 public:
     /// @brief Construct the GPU memory buffer without specifying the actual data to fill in, only the memory size.
@@ -65,10 +64,6 @@ public:
 
     [[nodiscard]] VmaAllocationInfo allocation_info() const {
         return m_allocation_info;
-    }
-
-    [[nodiscard]] VmaAllocationCreateInfo allocation_create_info() const {
-        return m_allocation_ci;
     }
 };
 

--- a/include/inexor/vulkan-renderer/wrapper/make_info.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/make_info.hpp
@@ -8,6 +8,6 @@ namespace inexor::vulkan_renderer::wrapper {
 /// @endcode
 /// @note Also zeros the returned struct
 template <typename T>
-[[nodiscard]] T make_info();
+[[nodiscard]] T make_info(T = {});
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -101,24 +101,25 @@ ImGUIOverlay::ImGUIOverlay(const wrapper::Device &device, const wrapper::Swapcha
     m_stage->uses_shader(*m_vertex_shader);
     m_stage->uses_shader(*m_fragment_shader);
 
-    // Setup push constant range for global translation and scale.
-    VkPushConstantRange push_constant_range{};
-    push_constant_range.offset = 0;
-    push_constant_range.size = sizeof(PushConstBlock);
-    push_constant_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     m_stage->add_descriptor_layout(m_descriptor->descriptor_set_layout());
-    m_stage->add_push_constant_range(push_constant_range);
+
+    // Setup push constant range for global translation and scale.
+    m_stage->add_push_constant_range({
+        .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+        .offset = 0,
+        .size = sizeof(PushConstBlock),
+    });
 
     // Setup blend attachment.
-    VkPipelineColorBlendAttachmentState blend_attachment;
-    blend_attachment.blendEnable = VK_TRUE;
-    blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-    blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
-    blend_attachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-    blend_attachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
-    m_stage->set_blend_attachment(blend_attachment);
+    m_stage->set_blend_attachment({
+        .blendEnable = VK_TRUE,
+        .srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+        .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+        .colorBlendOp = VK_BLEND_OP_ADD,
+        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .alphaBlendOp = VK_BLEND_OP_ADD,
+    });
 }
 
 ImGUIOverlay::~ImGUIOverlay() {

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -41,7 +41,7 @@ void VulkanRenderer::setup_render_graph() {
     main_stage->set_depth_options(true, true);
     main_stage->set_on_record([&](const PhysicalStage &physical, const wrapper::CommandBuffer &cmd_buf) {
         cmd_buf.bind_descriptor_sets(m_descriptors[0].descriptor_sets(), physical.pipeline_layout());
-        cmd_buf.draw_indexed(m_octree_indices.size());
+        cmd_buf.draw_indexed(static_cast<std::uint32_t>(m_octree_indices.size()));
     });
 
     for (const auto &shader : m_shaders) {

--- a/src/vulkan-renderer/wrapper/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/command_buffer.cpp
@@ -277,7 +277,7 @@ const CommandBuffer &CommandBuffer::push_constants(const VkPipelineLayout layout
     assert(layout);
     assert(size > 0);
     assert(data);
-    vkCmdPushConstants(m_command_buffer, layout, stage, offset, size, data);
+    vkCmdPushConstants(m_command_buffer, layout, stage, static_cast<std::uint32_t>(offset), size, data);
     return *this;
 }
 

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -9,9 +9,10 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 CommandPool::CommandPool(const Device &device, std::string name) : m_device(device), m_name(std::move(name)) {
-    auto cmd_pool_ci = make_info<VkCommandPoolCreateInfo>();
-    cmd_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
-    cmd_pool_ci.queueFamilyIndex = device.graphics_queue_family_index();
+    const auto cmd_pool_ci = make_info<VkCommandPoolCreateInfo>({
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+        .queueFamilyIndex = device.graphics_queue_family_index(),
+    });
 
     // Get the thread id as string for naming the command pool and the command buffers
     const std::size_t thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -45,25 +45,27 @@ ResourceDescriptor::ResourceDescriptor(const Device &device,
         pool_sizes.emplace_back(VkDescriptorPoolSize{descriptor_pool_type.descriptorType, 1});
     }
 
-    auto descriptor_pool_ci = wrapper::make_info<VkDescriptorPoolCreateInfo>();
-    descriptor_pool_ci.poolSizeCount = static_cast<std::uint32_t>(pool_sizes.size());
-    descriptor_pool_ci.pPoolSizes = pool_sizes.data();
-    descriptor_pool_ci.maxSets = 1;
+    m_device.create_descriptor_pool(wrapper::make_info<VkDescriptorPoolCreateInfo>({
+                                        .maxSets = 1,
+                                        .poolSizeCount = static_cast<std::uint32_t>(pool_sizes.size()),
+                                        .pPoolSizes = pool_sizes.data(),
+                                    }),
+                                    &m_descriptor_pool, m_name);
 
-    m_device.create_descriptor_pool(descriptor_pool_ci, &m_descriptor_pool, m_name);
-
-    auto descriptor_set_layout_ci = make_info<VkDescriptorSetLayoutCreateInfo>();
-    descriptor_set_layout_ci.bindingCount = static_cast<std::uint32_t>(m_descriptor_set_layout_bindings.size());
-    descriptor_set_layout_ci.pBindings = m_descriptor_set_layout_bindings.data();
-
-    m_device.create_descriptor_set_layout(descriptor_set_layout_ci, &m_descriptor_set_layout, m_name);
+    m_device.create_descriptor_set_layout(
+        make_info<VkDescriptorSetLayoutCreateInfo>({
+            .bindingCount = static_cast<std::uint32_t>(m_descriptor_set_layout_bindings.size()),
+            .pBindings = m_descriptor_set_layout_bindings.data(),
+        }),
+        &m_descriptor_set_layout, m_name);
 
     const std::vector<VkDescriptorSetLayout> descriptor_set_layouts(1, m_descriptor_set_layout);
 
-    auto descriptor_set_ai = wrapper::make_info<VkDescriptorSetAllocateInfo>();
-    descriptor_set_ai.descriptorPool = m_descriptor_pool;
-    descriptor_set_ai.descriptorSetCount = 1;
-    descriptor_set_ai.pSetLayouts = descriptor_set_layouts.data();
+    const auto descriptor_set_ai = wrapper::make_info<VkDescriptorSetAllocateInfo>({
+        .descriptorPool = m_descriptor_pool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = descriptor_set_layouts.data(),
+    });
 
     m_descriptor_sets.resize(1);
 

--- a/src/vulkan-renderer/wrapper/descriptor_builder.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor_builder.cpp
@@ -35,31 +35,27 @@ DescriptorBuilder &DescriptorBuilder::add_combined_image_sampler(const VkSampler
     assert(image_sampler);
     assert(image_view);
 
-    VkDescriptorSetLayoutBinding layout_binding{};
-    layout_binding.binding = 0;
-    layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    layout_binding.descriptorCount = 1;
-    layout_binding.stageFlags = shader_stage;
+    m_layout_bindings.push_back({
+        .binding = 0,
+        .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .descriptorCount = 1,
+        .stageFlags = static_cast<VkShaderStageFlags>(shader_stage),
+    });
 
-    m_layout_bindings.push_back(layout_binding);
+    m_descriptor_image_infos.push_back({
+        .sampler = image_sampler,
+        .imageView = image_view,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    });
 
-    VkDescriptorImageInfo image_info{};
-    image_info.sampler = image_sampler;
-    image_info.imageView = image_view;
-    image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-    m_descriptor_image_infos.push_back(image_info);
-
-    VkWriteDescriptorSet descriptor_write{};
-    descriptor_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    descriptor_write.dstSet = nullptr;
-    descriptor_write.dstBinding = binding;
-    descriptor_write.dstArrayElement = 0;
-    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    descriptor_write.descriptorCount = 1;
-    descriptor_write.pImageInfo = &m_descriptor_image_infos.back();
-
-    m_write_sets.push_back(descriptor_write);
+    m_write_sets.push_back(make_info<VkWriteDescriptorSet>({
+        .dstSet = nullptr,
+        .dstBinding = binding,
+        .dstArrayElement = 0,
+        .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .pImageInfo = &m_descriptor_image_infos.back(),
+    }));
 
     return *this;
 }

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -241,9 +241,6 @@ Device::Device(const wrapper::Instance &instance, const VkSurfaceKHR surface, bo
     const auto device_ci = make_info<VkDeviceCreateInfo>({
         .queueCreateInfoCount = static_cast<std::uint32_t>(queues_to_create.size()),
         .pQueueCreateInfos = queues_to_create.data(),
-        // Device layers were deprecated in Vulkan some time ago, essentially making all layers instance layers.
-        .enabledLayerCount = 0,
-        .ppEnabledLayerNames = nullptr,
         .enabledExtensionCount = static_cast<std::uint32_t>(enabled_device_extensions.size()),
         .ppEnabledExtensionNames = enabled_device_extensions.data(),
         .pEnabledFeatures = &used_features,

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -16,10 +16,11 @@ Fence::Fence(const wrapper::Device &device, const std::string &name, const bool 
     assert(!name.empty());
     assert(device.device());
 
-    auto fence_ci = make_info<VkFenceCreateInfo>();
-    fence_ci.flags = in_signaled_state ? VK_FENCE_CREATE_SIGNALED_BIT : 0;
-
-    m_device.create_fence(fence_ci, &m_fence, m_name);
+    m_device.create_fence(
+        make_info<VkFenceCreateInfo>({
+            .flags = static_cast<VkFenceCreateFlags>(in_signaled_state ? VK_FENCE_CREATE_SIGNALED_BIT : 0),
+        }),
+        &m_fence, m_name);
 }
 
 Fence::Fence(Fence &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -15,16 +15,15 @@ namespace inexor::vulkan_renderer::wrapper {
 Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
                          const wrapper::Swapchain &swapchain, std::string name)
     : m_device(device), m_name(std::move(name)) {
-
-    auto framebuffer_ci = make_info<VkFramebufferCreateInfo>();
-    framebuffer_ci.attachmentCount = static_cast<std::uint32_t>(attachments.size());
-    framebuffer_ci.pAttachments = attachments.data();
-    framebuffer_ci.width = swapchain.extent().width;
-    framebuffer_ci.height = swapchain.extent().height;
-    framebuffer_ci.layers = 1;
-    framebuffer_ci.renderPass = render_pass;
-
-    m_device.create_framebuffer(framebuffer_ci, &m_framebuffer, m_name);
+    m_device.create_framebuffer(make_info<VkFramebufferCreateInfo>({
+                                    .renderPass = render_pass,
+                                    .attachmentCount = static_cast<std::uint32_t>(attachments.size()),
+                                    .pAttachments = attachments.data(),
+                                    .width = swapchain.extent().width,
+                                    .height = swapchain.extent().height,
+                                    .layers = 1,
+                                }),
+                                &m_framebuffer, m_name);
 }
 
 Framebuffer::Framebuffer(Framebuffer &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_memory_buffer.cpp
@@ -20,13 +20,16 @@ GPUMemoryBuffer::GPUMemoryBuffer(const Device &device, const std::string &name, 
 
     spdlog::trace("Creating GPU memory buffer of size {} for {}", size, name);
 
-    auto buffer_ci = make_info<VkBufferCreateInfo>();
-    buffer_ci.size = size;
-    buffer_ci.usage = buffer_usage;
-    buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    const auto buffer_ci = make_info<VkBufferCreateInfo>({
+        .size = size,
+        .usage = buffer_usage,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    });
 
-    m_allocation_ci.usage = memory_usage;
-    m_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    const VmaAllocationCreateInfo m_allocation_ci{
+        .flags = VMA_ALLOCATION_CREATE_MAPPED_BIT,
+        .usage = memory_usage,
+    };
 
     // TODO: Should we create this buffer as mapped?
     // TODO: Is it good to have memory mapped all the time?
@@ -64,7 +67,6 @@ GPUMemoryBuffer::GPUMemoryBuffer(GPUMemoryBuffer &&other) noexcept : m_device(ot
     m_buffer = std::exchange(other.m_buffer, nullptr);
     m_allocation = std::exchange(other.m_allocation, nullptr);
     m_allocation_info = other.m_allocation_info;
-    m_allocation_ci = other.m_allocation_ci;
 }
 
 GPUMemoryBuffer::~GPUMemoryBuffer() {

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -40,21 +40,25 @@ GpuTexture::~GpuTexture() {
 }
 
 void GpuTexture::create_texture(void *texture_data, const std::size_t texture_size) {
-    VkExtent2D extent;
-    extent.width = m_texture_width;
-    extent.height = m_texture_height;
+    const VkExtent2D extent{
+        // Because stb_image stored the texture's width and height as a normal int, we need a cast here
+        .width = static_cast<uint32_t>(m_texture_width),
+        .height = static_cast<uint32_t>(m_texture_height),
+    };
 
     m_texture_image = std::make_unique<wrapper::Image>(
         m_device, m_texture_image_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
         VK_IMAGE_ASPECT_COLOR_BIT, VK_SAMPLE_COUNT_1_BIT, m_name, extent);
 
-    VkBufferImageCopy copy_region{
+    const VkBufferImageCopy copy_region{
         .bufferOffset = 0,
         .bufferRowLength = 0,
         .bufferImageHeight = 0,
         .imageSubresource{.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .mipLevel = 0, .baseArrayLayer = 0, .layerCount = 1},
         .imageOffset = {0, 0, 0},
-        .imageExtent = {static_cast<uint32_t>(m_texture_width), static_cast<uint32_t>(m_texture_height), 1}};
+        // Because stb_image stored the texture's width and height as a normal int, we need a cast here
+        .imageExtent = {static_cast<uint32_t>(m_texture_width), static_cast<uint32_t>(m_texture_height), 1},
+    };
 
     m_device.execute(m_name, [&](const CommandBuffer &cmd_buf) {
         cmd_buf
@@ -70,58 +74,31 @@ void GpuTexture::create_texture(void *texture_data, const std::size_t texture_si
 }
 
 void GpuTexture::create_texture_sampler() {
-    auto sampler_ci = make_info<VkSamplerCreateInfo>();
-    sampler_ci.magFilter = VK_FILTER_LINEAR;
-    sampler_ci.minFilter = VK_FILTER_LINEAR;
-    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    sampler_ci.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-
-    // These two fields specify if anisotropic filtering should be used.
-    // There is no reason not to use this unless performance is a concern.
-    // The maxAnisotropy field limits the amount of texel samples that can
-    // be used to calculate the final color. A lower value results in better
-    // performance, but lower quality results. There is no graphics hardware
-    // available today that will use more than 16 samples, because the difference
-    // is negligible beyond that point.
-    sampler_ci.anisotropyEnable = VK_TRUE;
-    sampler_ci.maxAnisotropy = 16;
-
-    // The borderColor field specifies which color is returned when sampling beyond
-    // the image with clamp to border addressing mode. It is possible to return black,
-    // white or transparent in either float or int formats. You cannot specify an arbitrary color.
-    sampler_ci.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-
-    // The unnormalized coordinates field specifies which coordinate system you
-    // want to use to address texels in an image. If this field is VK_TRUE, then you
-    // can simply use coordinates within the [0, texWidth) and [0, texHeight)
-    // range. If it is VK_FALSE, then the texels are addressed using the [0, 1) range
-    // on all axes. Real-world applications almost always use normalized coordinates,
-    // because then it's possible to use textures of varying resolutions with the exact
-    // same coordinates.
-    sampler_ci.unnormalizedCoordinates = VK_FALSE;
-    sampler_ci.compareEnable = VK_FALSE;
-    sampler_ci.compareOp = VK_COMPARE_OP_ALWAYS;
-    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_ci.mipLodBias = 0.0f;
-    sampler_ci.minLod = 0.0f;
-    sampler_ci.maxLod = 0.0f;
-
     VkPhysicalDeviceFeatures device_features;
     vkGetPhysicalDeviceFeatures(m_device.physical_device(), &device_features);
 
     VkPhysicalDeviceProperties graphics_card_properties;
     vkGetPhysicalDeviceProperties(m_device.physical_device(), &graphics_card_properties);
 
-    if (VK_TRUE == device_features.samplerAnisotropy) {
-        // Anisotropic filtering is available.
-        sampler_ci.maxAnisotropy = graphics_card_properties.limits.maxSamplerAnisotropy;
-        sampler_ci.anisotropyEnable = VK_TRUE;
-    } else {
-        // The device does not support anisotropic filtering
-        sampler_ci.maxAnisotropy = 1.0;
-        sampler_ci.anisotropyEnable = VK_FALSE;
-    }
+    const auto sampler_ci = make_info<VkSamplerCreateInfo>({
+        .magFilter = VK_FILTER_LINEAR,
+        .minFilter = VK_FILTER_LINEAR,
+        .mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT,
+        .mipLodBias = 0.0f,
+        .anisotropyEnable = device_features.samplerAnisotropy,
+        .maxAnisotropy = (device_features.samplerAnisotropy == VK_TRUE)
+                             ? graphics_card_properties.limits.maxSamplerAnisotropy
+                             : 1.0f,
+        .compareEnable = VK_FALSE,
+        .compareOp = VK_COMPARE_OP_ALWAYS,
+        .minLod = 0.0f,
+        .maxLod = 0.0f,
+        .borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK,
+        .unnormalizedCoordinates = VK_FALSE,
+    });
 
     m_device.create_sampler(sampler_ci, &m_sampler, m_name);
 }

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -21,23 +21,27 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
     assert(image_extent.height > 0);
     assert(!name.empty());
 
-    auto image_ci = make_info<VkImageCreateInfo>();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
-    image_ci.extent.width = image_extent.width;
-    image_ci.extent.height = image_extent.height;
-    image_ci.extent.depth = 1;
-    image_ci.mipLevels = 1;
-    image_ci.arrayLayers = 1;
-    image_ci.format = format;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    image_ci.usage = image_usage;
-    image_ci.samples = sample_count;
-    image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    const auto image_ci = make_info<VkImageCreateInfo>({
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = format,
+        .extent{
+            .width = image_extent.width,
+            .height = image_extent.height,
+            .depth = 1,
+        },
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = sample_count,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage = image_usage,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    });
 
-    VmaAllocationCreateInfo vma_allocation_ci{};
-    vma_allocation_ci.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-    vma_allocation_ci.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    const VmaAllocationCreateInfo vma_allocation_ci{
+        .flags = VMA_ALLOCATION_CREATE_MAPPED_BIT,
+        .usage = VMA_MEMORY_USAGE_GPU_ONLY,
+    };
 
     if (const auto result = vmaCreateImage(m_device.allocator(), &image_ci, &vma_allocation_ci, &m_image, &m_allocation,
                                            &m_allocation_info);
@@ -50,17 +54,19 @@ Image::Image(const Device &device, const VkFormat format, const VkImageUsageFlag
     // Assign an internal name using Vulkan debug markers.
     m_device.set_debug_marker_name(m_image, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, m_name);
 
-    auto image_view_ci = make_info<VkImageViewCreateInfo>();
-    image_view_ci.image = m_image;
-    image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    image_view_ci.format = format;
-    image_view_ci.subresourceRange.aspectMask = aspect_flags;
-    image_view_ci.subresourceRange.baseMipLevel = 0;
-    image_view_ci.subresourceRange.levelCount = 1;
-    image_view_ci.subresourceRange.baseArrayLayer = 0;
-    image_view_ci.subresourceRange.layerCount = 1;
-
-    m_device.create_image_view(image_view_ci, &m_image_view, m_name);
+    m_device.create_image_view(make_info<VkImageViewCreateInfo>({
+                                   .image = m_image,
+                                   .viewType = VK_IMAGE_VIEW_TYPE_2D,
+                                   .format = format,
+                                   .subresourceRange{
+                                       .aspectMask = aspect_flags,
+                                       .baseMipLevel = 0,
+                                       .levelCount = 1,
+                                       .baseArrayLayer = 0,
+                                       .layerCount = 1,
+                                   },
+                               }),
+                               &m_image_view, m_name);
 }
 
 Image::Image(Image &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -109,12 +109,13 @@ Instance::Instance(const std::string &application_name, const std::string &engin
         throw std::runtime_error(exception_message);
     }
 
-    auto app_info = make_info<VkApplicationInfo>();
-    app_info.pApplicationName = application_name.c_str();
-    app_info.applicationVersion = application_version;
-    app_info.pEngineName = engine_name.c_str();
-    app_info.engineVersion = engine_version;
-    app_info.apiVersion = REQUIRED_VK_API_VERSION;
+    const auto app_info = make_info<VkApplicationInfo>({
+        .pApplicationName = application_name.c_str(),
+        .applicationVersion = application_version,
+        .pEngineName = engine_name.c_str(),
+        .engineVersion = engine_version,
+        .apiVersion = REQUIRED_VK_API_VERSION,
+    });
 
     std::vector<const char *> instance_extension_wishlist = {
 #ifndef NDEBUG
@@ -216,12 +217,13 @@ Instance::Instance(const std::string &application_name, const std::string &engin
         }
     }
 
-    auto instance_ci = make_info<VkInstanceCreateInfo>();
-    instance_ci.pApplicationInfo = &app_info;
-    instance_ci.ppEnabledExtensionNames = enabled_instance_extensions.data();
-    instance_ci.enabledExtensionCount = static_cast<std::uint32_t>(enabled_instance_extensions.size());
-    instance_ci.ppEnabledLayerNames = enabled_instance_layers.data();
-    instance_ci.enabledLayerCount = static_cast<std::uint32_t>(enabled_instance_layers.size());
+    const auto instance_ci = make_info<VkInstanceCreateInfo>({
+        .pApplicationInfo = &app_info,
+        .enabledLayerCount = static_cast<std::uint32_t>(enabled_instance_layers.size()),
+        .ppEnabledLayerNames = enabled_instance_layers.data(),
+        .enabledExtensionCount = static_cast<std::uint32_t>(enabled_instance_extensions.size()),
+        .ppEnabledExtensionNames = enabled_instance_extensions.data(),
+    });
 
     if (const auto result = vkCreateInstance(&instance_ci, nullptr, &m_instance); result != VK_SUCCESS) {
         throw VulkanException("Error: vkCreateInstance failed!", result);

--- a/src/vulkan-renderer/wrapper/make_info.cpp
+++ b/src/vulkan-renderer/wrapper/make_info.cpp
@@ -238,4 +238,10 @@ VkSwapchainCreateInfoKHR make_info(VkSwapchainCreateInfoKHR info) {
     return info;
 }
 
+template <>
+VkWriteDescriptorSet make_info(VkWriteDescriptorSet info) {
+    info.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    return info;
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/make_info.cpp
+++ b/src/vulkan-renderer/wrapper/make_info.cpp
@@ -5,274 +5,237 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 template <>
-VkApplicationInfo make_info() {
-    VkApplicationInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    return ret;
+VkApplicationInfo make_info(VkApplicationInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    return info;
 }
 
 template <>
-VkBufferCreateInfo make_info() {
-    VkBufferCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    return ret;
+VkBufferCreateInfo make_info(VkBufferCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkCommandBufferAllocateInfo make_info() {
-    VkCommandBufferAllocateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-    return ret;
+VkCommandBufferAllocateInfo make_info(VkCommandBufferAllocateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    return info;
 }
 
 template <>
-VkCommandBufferBeginInfo make_info() {
-    VkCommandBufferBeginInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    return ret;
+VkCommandBufferBeginInfo make_info(VkCommandBufferBeginInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    return info;
 }
 
 template <>
-VkCommandPoolCreateInfo make_info() {
-    VkCommandPoolCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-    return ret;
+VkCommandPoolCreateInfo make_info(VkCommandPoolCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkDebugMarkerMarkerInfoEXT make_info() {
-    VkDebugMarkerMarkerInfoEXT ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
-    return ret;
+VkDebugMarkerMarkerInfoEXT make_info(VkDebugMarkerMarkerInfoEXT info) {
+    info.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
+    return info;
 }
 
 template <>
-VkDebugMarkerObjectNameInfoEXT make_info() {
-    VkDebugMarkerObjectNameInfoEXT ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-    return ret;
+VkDebugMarkerObjectNameInfoEXT make_info(VkDebugMarkerObjectNameInfoEXT info) {
+    info.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
+    return info;
 }
 
 template <>
-VkDebugMarkerObjectTagInfoEXT make_info() {
-    VkDebugMarkerObjectTagInfoEXT ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
-    return ret;
+VkDebugMarkerObjectTagInfoEXT make_info(VkDebugMarkerObjectTagInfoEXT info) {
+    info.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT;
+    return info;
 }
 
 template <>
-VkDebugReportCallbackCreateInfoEXT make_info() {
-    VkDebugReportCallbackCreateInfoEXT ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
-    return ret;
+VkDebugReportCallbackCreateInfoEXT make_info(VkDebugReportCallbackCreateInfoEXT info) {
+    info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
+    return info;
 }
 
 template <>
-VkDescriptorPoolCreateInfo make_info() {
-    VkDescriptorPoolCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    return ret;
+VkDescriptorPoolCreateInfo make_info(VkDescriptorPoolCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkDescriptorSetAllocateInfo make_info() {
-    VkDescriptorSetAllocateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    return ret;
+VkDescriptorSetAllocateInfo make_info(VkDescriptorSetAllocateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    return info;
 }
 
 template <>
-VkDescriptorSetLayoutCreateInfo make_info() {
-    VkDescriptorSetLayoutCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    return ret;
+VkDescriptorSetLayoutCreateInfo make_info(VkDescriptorSetLayoutCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkDeviceCreateInfo make_info() {
-    VkDeviceCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-    return ret;
+VkDeviceCreateInfo make_info(VkDeviceCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkDeviceQueueCreateInfo make_info() {
-    VkDeviceQueueCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    return ret;
+VkDeviceQueueCreateInfo make_info(VkDeviceQueueCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkFenceCreateInfo make_info() {
-    VkFenceCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    return ret;
+VkFenceCreateInfo make_info(VkFenceCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkFramebufferCreateInfo make_info() {
-    VkFramebufferCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    return ret;
+VkFramebufferCreateInfo make_info(VkFramebufferCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkGraphicsPipelineCreateInfo make_info() {
-    VkGraphicsPipelineCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    return ret;
+VkGraphicsPipelineCreateInfo make_info(VkGraphicsPipelineCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkImageCreateInfo make_info() {
-    VkImageCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    return ret;
+VkImageCreateInfo make_info(VkImageCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkImageMemoryBarrier make_info() {
-    VkImageMemoryBarrier ret{};
-    ret.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    return ret;
+VkImageMemoryBarrier make_info(VkImageMemoryBarrier info) {
+    info.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    return info;
 }
 
 template <>
-VkImageViewCreateInfo make_info() {
-    VkImageViewCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    return ret;
+VkImageViewCreateInfo make_info(VkImageViewCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkInstanceCreateInfo make_info() {
-    VkInstanceCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    return ret;
+VkInstanceCreateInfo make_info(VkInstanceCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkMemoryBarrier make_info() {
-    return {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+VkMemoryBarrier make_info(VkMemoryBarrier info) {
+    info.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    return info;
 }
 
 template <>
-VkPipelineColorBlendStateCreateInfo make_info() {
-    VkPipelineColorBlendStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    return ret;
+VkPipelineColorBlendStateCreateInfo make_info(VkPipelineColorBlendStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineDepthStencilStateCreateInfo make_info() {
-    VkPipelineDepthStencilStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    return ret;
+VkPipelineDepthStencilStateCreateInfo make_info(VkPipelineDepthStencilStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineInputAssemblyStateCreateInfo make_info() {
-    VkPipelineInputAssemblyStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    return ret;
+VkPipelineInputAssemblyStateCreateInfo make_info(VkPipelineInputAssemblyStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineLayoutCreateInfo make_info() {
-    VkPipelineLayoutCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    return ret;
+VkPipelineLayoutCreateInfo make_info(VkPipelineLayoutCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineMultisampleStateCreateInfo make_info() {
-    VkPipelineMultisampleStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    return ret;
+VkPipelineMultisampleStateCreateInfo make_info(VkPipelineMultisampleStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineRasterizationStateCreateInfo make_info() {
-    VkPipelineRasterizationStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    return ret;
+VkPipelineRasterizationStateCreateInfo make_info(VkPipelineRasterizationStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineShaderStageCreateInfo make_info() {
-    VkPipelineShaderStageCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    return ret;
+VkPipelineShaderStageCreateInfo make_info(VkPipelineShaderStageCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineVertexInputStateCreateInfo make_info() {
-    VkPipelineVertexInputStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    return ret;
+VkPipelineVertexInputStateCreateInfo make_info(VkPipelineVertexInputStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPipelineViewportStateCreateInfo make_info() {
-    VkPipelineViewportStateCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    return ret;
+VkPipelineViewportStateCreateInfo make_info(VkPipelineViewportStateCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkPresentInfoKHR make_info() {
-    VkPresentInfoKHR ret{};
-    ret.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-    return ret;
+VkPresentInfoKHR make_info(VkPresentInfoKHR info) {
+    info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    return info;
 }
 
 template <>
-VkRenderPassBeginInfo make_info() {
-    VkRenderPassBeginInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-    return ret;
+VkRenderPassBeginInfo make_info(VkRenderPassBeginInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    return info;
 }
 
 template <>
-VkRenderPassCreateInfo make_info() {
-    VkRenderPassCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    return ret;
+VkRenderPassCreateInfo make_info(VkRenderPassCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkSamplerCreateInfo make_info() {
-    VkSamplerCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    return ret;
+VkSamplerCreateInfo make_info(VkSamplerCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkSemaphoreCreateInfo make_info() {
-    VkSemaphoreCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-    return ret;
+VkSemaphoreCreateInfo make_info(VkSemaphoreCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkShaderModuleCreateInfo make_info() {
-    VkShaderModuleCreateInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    return ret;
+VkShaderModuleCreateInfo make_info(VkShaderModuleCreateInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    return info;
 }
 
 template <>
-VkSubmitInfo make_info() {
-    VkSubmitInfo ret{};
-    ret.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    return ret;
+VkSubmitInfo make_info(VkSubmitInfo info) {
+    info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    return info;
 }
 
 template <>
-VkSwapchainCreateInfoKHR make_info() {
-    VkSwapchainCreateInfoKHR ret{};
-    ret.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-    return ret;
+VkSwapchainCreateInfoKHR make_info(VkSwapchainCreateInfoKHR info) {
+    info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    return info;
 }
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -14,9 +14,7 @@ namespace inexor::vulkan_renderer::wrapper {
 Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(device), m_name(name) {
     assert(device.device());
     assert(!name.empty());
-
-    auto semaphore_ci = make_info<VkSemaphoreCreateInfo>();
-    device.create_semaphore(semaphore_ci, &m_semaphore, m_name);
+    device.create_semaphore(make_info<VkSemaphoreCreateInfo>(), &m_semaphore, m_name);
 }
 
 Semaphore::Semaphore(Semaphore &&other) noexcept : m_device(other.m_device) {

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -25,15 +25,15 @@ Shader::Shader(const Device &device, const VkShaderStageFlagBits type, const std
     assert(!code.empty());
     assert(!entry_point.empty());
 
-    auto shader_module_ci = make_info<VkShaderModuleCreateInfo>();
-    shader_module_ci.codeSize = code.size();
-
-    // When you perform a cast like this, you also need to ensure that the data satisfies the alignment
-    // requirements of std::uint32_t. Lucky for us, the data is stored in an std::vector where the default
-    // allocator already ensures that the data satisfies the worst case alignment requirements.
-    shader_module_ci.pCode = reinterpret_cast<const std::uint32_t *>(code.data()); // NOLINT
-
-    m_device.create_shader_module(shader_module_ci, &m_shader_module, m_name);
+    m_device.create_shader_module(
+        make_info<VkShaderModuleCreateInfo>({
+            .codeSize = code.size(),
+            // When you perform a cast like this, you also need to ensure that the data satisfies the alignment
+            // requirements of std::uint32_t. Lucky for us, the data is stored in an std::vector where the default
+            // allocator already ensures that the data satisfies the worst case alignment requirements.
+            .pCode = reinterpret_cast<const std::uint32_t *>(code.data()), // NOLINT
+        }),
+        &m_shader_module, m_name);
 }
 
 Shader::Shader(Shader &&other) noexcept : m_device(other.m_device) {


### PR DESCRIPTION
## Introduction
[Designated initializers](https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers) are a C++20 feature that makes initialization code more readable. In addition it enforces that the order of initialization is the same as the order of declaration in the struct. Compare those two code parts:

**Old code:**
```cpp
VkImageMemoryBarrier barrier{};
barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
barrier.oldLayout = old_layout;
barrier.newLayout = new_layout;
barrier.image = image;
barrier.subresourceRange = subres_range;
```

**New code with designated initializers**:
```cpp
const auto barrier = make_info<VkImageMemoryBarrier>({
    .oldLayout = old_layout,
    .newLayout = new_layout,
    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
    .image = image,
    .subresourceRange = subres_range,
});
```

This code example uses the following `make_info` template:

```cpp
template <>
VkImageMemoryBarrier make_info(VkImageMemoryBarrier info) {
    info.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
    return info;
}
```

## Summary
Designated initializers
* make the code shorter
* make the code easier to read
* allows us to inline some create info structs directly
* allows us to make more variables `const` :)

## Notes
* In https://github.com/inexorgame/vulkan-renderer/commit/1608cb86f98d21f5253acc687f114853432061e4 I fixed two MSVC warnings about missing `static_cast`.
* There are some code parts where I decided not to use them though, because while we could make the following struct `const` by introducing lambdas, it would maybe make the code harder to read:

```cpp
// This struct is not const, and not all members are set in here because some are set depending on certain conditions
// See code below
auto barrier = make_info<VkImageMemoryBarrier>({
    .oldLayout = old_layout,
    .newLayout = new_layout,
    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
    .image = image,
    .subresourceRange = subres_range,
});

// This could be part of the struct by using lambdas, but will it make it easier to read?
switch (old_layout) {
case VK_IMAGE_LAYOUT_UNDEFINED:
    barrier.srcAccessMask = 0;
    break;
case VK_IMAGE_LAYOUT_PREINITIALIZED:
    barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
    barrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
    barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
    break;
case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
    barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
    break;
default:
    break;
}

switch (new_layout) {
case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
    barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
    break;
case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
    barrier.dstAccessMask = barrier.dstAccessMask | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
    break;
case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
    if (barrier.srcAccessMask == 0) {
        barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
    }
    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
    break;
default:
    break;
}

```