### PR TITLE
Use conan to get Vulkan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 on: [push, pull_request]
 
-env:
-  inexor_build_type: "Release"
-
 jobs:
   linux:
     name: ${{ matrix.config.name }}
@@ -11,6 +8,8 @@ jobs:
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"
+      CONAN_USER_HOME: "${{ github.workspace }}/conan/"
+      CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan/s"
       inexor_conan_path: "$HOME/.local/bin"
     strategy:
       fail-fast: false
@@ -21,11 +20,13 @@ jobs:
             artifact: "linux-clang.tar.xz",
             cc: "clang", cxx: "clang++",
             cmake_configure_options: '-DCMAKE_EXE_LINKER_FLAGS="-v -fuse-ld=lld"',
+            build_type: "Release",
           }
           - {
             name: "Ubuntu GCC",
             artifact: "linux-gcc.tar.xz",
             cc: "gcc", cxx: "g++",
+            build_type: "Release",
           }
 
     steps:
@@ -70,6 +71,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache Conan Dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: conan-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.build_type }}-${{ hashFiles('conanfile.py') }}
+
       - name: Configure CMake
         shell: bash
         run: |
@@ -79,13 +86,13 @@ jobs:
 
           # Setup conan
           # Note: libstdc++11 is needed to use new libc++ ABI
-          conan profile new default --detect
+          conan profile new default --detect --force
           conan profile update settings.compiler.libcxx=libstdc++11 default
 
           # Configure cmake
           cmake . \
             -Bbuild \
-            -DCMAKE_BUILD_TYPE=${{ env.inexor_build_type }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -GNinja \
             ${{ matrix.config.cmake_configure_options }}
 
@@ -104,9 +111,19 @@ jobs:
           path: ${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
 
+      - name: Clean Up Conan
+        if: always()
+        shell: bash
+        run: |
+          conan remove "*" -f --builds --src
+          conan remove "*" -f --system-reqs
+
   windows:
     name: ${{ matrix.config.name }}
     runs-on: windows-latest
+    env:
+      CONAN_USER_HOME: "${{ github.workspace }}/conan/"
+      CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan/s"
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +132,7 @@ jobs:
             name: "Windows MSVC",
             artifact: "windows-msvc.zip",
             cc: "cl", cxx: "cl",
+            build_type: "Release",
             cmake_build_options: "--config Release",
             cmake_configure_options: '-G "Visual Studio 17 2022" -A x64',
             conan_profile_update: 'conan profile update settings.compiler="Visual Studio" default; conan profile update settings.compiler.version=17 default',
@@ -131,6 +149,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache Conan Dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: conan-${{ runner.os }}-${{ matrix.config.name }}-${{ matrix.config.build_type }}-${{ hashFiles('conanfile.py') }}
+
       - name: Configure CMake
         shell: pwsh
         run: |
@@ -144,7 +168,7 @@ jobs:
           # Configure CMake
           cmake . `
             -Bbuild `
-            -DCMAKE_BUILD_TYPE=${{ env.inexor_build_type }} `
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} `
             ${{ matrix.config.cmake_configure_options }}
 
       - name: Build
@@ -162,3 +186,10 @@ jobs:
         with:
           path: ${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
+
+      - name: Clean Up Conan
+        if: always()
+        shell: pwsh
+        run: |
+          conan remove "*" -f --builds --src
+          conan remove "*" -f --system-reqs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 
 env:
   inexor_build_type: "Release"
-  inexor_vulkan_version: "1.3.224.1"
-  inexor_vulkan_sdk: "$GITHUB_WORKSPACE/../vulkan_sdk/"
 
 jobs:
   linux:
@@ -69,17 +67,6 @@ jobs:
           pip3 install wheel setuptools
           pip3 install conan mako
 
-      - name: Install Vulkan SDK
-        shell: bash
-        run: |
-          # Download Vulkan SDK
-          curl -LS -o vulkansdk.tar.gz \
-            https://sdk.lunarg.com/sdk/download/${{ env.inexor_vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ env.inexor_vulkan_version }}.tar.gz
-
-          # Create Vulkan SDK directory and extract
-          mkdir "${{ env.inexor_vulkan_sdk }}"
-          tar xfz vulkansdk.tar.gz -C "${{ env.inexor_vulkan_sdk }}"
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -89,10 +76,6 @@ jobs:
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export PATH="${{ env.inexor_conan_path }}":$PATH
-          export VULKAN_SDK="${{ env.inexor_vulkan_sdk }}/${{ env.inexor_vulkan_version }}/x86_64"
-          export PATH=$VULKAN_SDK/bin:$PATH
-          export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
-          export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
 
           # Setup conan
           # Note: libstdc++11 is needed to use new libc++ ABI
@@ -145,14 +128,6 @@ jobs:
           pip3 install conan
           choco install ninja
 
-      - name: Install Vulkan SDK
-        shell: pwsh
-        run: |
-          curl -LS -o vulkansdk.exe `
-            https://sdk.lunarg.com/sdk/download/${{ env.inexor_vulkan_version }}/windows/VulkanSDK-${{ env.inexor_vulkan_version }}-Installer.exe?Human=true
-
-          7z x vulkansdk.exe -o"${{ env.inexor_vulkan_sdk }}"
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -161,7 +136,6 @@ jobs:
         run: |
           $env:CC="${{ matrix.config.cc }}"
           $env:CXX="${{ matrix.config.cxx }}"
-          $env:Path += ";${{ env.inexor_vulkan_sdk }}\;${{ env.inexor_vulkan_sdk }}\Bin\"
 
           # Setup conan
           conan profile new default --detect --force

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,10 +1,6 @@
 name: Static Analysis
 on: [push, pull_request]
 
-env:
-  inexor_vulkan_version: "1.2.189.0"
-  inexor_vulkan_sdk: "$GITHUB_WORKSPACE/../vulkan_sdk/"
-
 jobs:
   clang-tidy:
     name: Clang Tidy
@@ -12,6 +8,8 @@ jobs:
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"
+      CONAN_USER_HOME: "${{ github.workspace }}/conan/"
+      CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan/s"
       inexor_conan_path: "$HOME/.local/bin"
     steps:
       - name: Update environment
@@ -41,6 +39,7 @@ jobs:
             libxcb-xfixes0-dev \
             libxcb-xinerama0-dev \
             libxcb-xkb-dev \
+            ninja-build \
             parallel \
             pkg-config \
             python3 \
@@ -54,12 +53,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache Conan Dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: conan-${{ runner.os }}-Ubuntu GCC-Debug-${{ hashFiles('conanfile.py') }}
+
       - name: Configure CMake
         run: |
           export CC=gcc
           export CXX=g++
           export PATH="${{ env.inexor_conan_path }}":$PATH
-          cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+          conan profile new default --detect --force
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+
+          cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run clang-tidy
         run: |
@@ -70,3 +79,10 @@ jobs:
             clang-tidy -p build --header-filter=inexor/ --quiet {} 2>/dev/null |
           tee output
           if [ -s output ]; then exit 1; fi
+
+      - name: Clean Up Conan
+        if: always()
+        shell: bash
+        run: |
+          conan remove "*" -f --builds --src
+          conan remove "*" -f --system-reqs

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -51,15 +51,6 @@ jobs:
           pip3 install wheel setuptools
           pip3 install conan mako
 
-      - name: Install Vulkan SDK
-        run: |
-          # Download Vulkan SDK
-          curl -LS -o vulkansdk.tar.gz \
-            https://sdk.lunarg.com/sdk/download/${{ env.inexor_vulkan_version }}/linux/vulkansdk-linux-x86_64-${{ env.inexor_vulkan_version }}.tar.gz
-          # Create Vulkan SDK directory and extract
-          mkdir "${{ env.inexor_vulkan_sdk }}"
-          tar xfz vulkansdk.tar.gz -C "${{ env.inexor_vulkan_sdk }}"
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -68,10 +59,6 @@ jobs:
           export CC=gcc
           export CXX=g++
           export PATH="${{ env.inexor_conan_path }}":$PATH
-          export VULKAN_SDK="${{ env.inexor_vulkan_sdk }}/${{ env.inexor_vulkan_version }}/x86_64"
-          export PATH=$VULKAN_SDK/bin:$PATH
-          export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
-          export VK_LAYER_PATH=$VULKAN_SDK/etc/explicit_layer.d
           cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ message(STATUS "CXX Compiler executable: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Linker executable: ${CMAKE_LINKER}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-find_package(Vulkan REQUIRED)
-
 # Dependency setup with conan
 include(conan_setup)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,11 +12,14 @@ class InexorConan(ConanFile):
     requires = (
         "glfw/3.3.7",
         "glm/0.9.9.8",
+        "glslang/11.7.0",
         "imgui/1.88",
         "spdlog/1.10.0",
         "stb/cci.20210910",
         "tinygltf/2.5.0",
         "toml11/3.7.1",
+        "vulkan-headers/1.3.224.0",
+        "vulkan-loader/1.3.224.0",
         "vulkan-memory-allocator/3.0.1",
     )
 

--- a/documentation/source/development/ci.rst
+++ b/documentation/source/development/ci.rst
@@ -3,17 +3,13 @@ Continuous integration
 
 - The main branch and the build system must stay stable at all time.
 
-- You can see the current status of the main branch in the build batch:
+- You can see the current status of the main branch in the build badge:
 
   |github actions|
 
 - Currently we are using `GitHub Actions <https://github.com/features/actions>`__ for building with `gcc <https://gcc.gnu.org/>`__, `clang <https://clang.llvm.org/>`__ and `Microsoft Visual Studio <https://visualstudio.microsoft.com/en/downloads/>`__ on every push or pull request.
 
-- This `Continuous Integration (CI) <https://en.wikipedia.org/wiki/Continuous_integration>`__ allows for automatic building and testing of our software.
-
 - We also have a `webhook <https://gist.github.com/jagrosh/5b1761213e33fc5b54ec7f6379034a22>`__ which directly dispatches the build status into our `Discord <https://discord.com/invite/acUW8k7>`__. This allows us to spot and fix broken code easily.
-
-- `Our CI setup <https://github.com/inexorgame/vulkan-renderer/blob/main/.github/workflows/build.yml>`__ is inspired by a `blog entry <https://www.asawicki.info/news_1655_how_to_use_vulkan_sdk_with_appveyor_and_travis_ci>`__ by `Adam Sawicki <https://github.com/adam-sawicki-a>`__.
 
 .. Badges.
 

--- a/documentation/source/development/getting-started.rst
+++ b/documentation/source/development/getting-started.rst
@@ -20,13 +20,6 @@ Required Software
 `CMake <https://cmake.org/>`__
     The build generator which generates project files for various IDEs.
 
-`Vulkan SDK <https://vulkan.lunarg.com/sdk/home>`__
-    Vulkan SDK contains the libraries and tools which are necessary to work with Vulkan API.
-
-    Update your Vulkan SDK as often as possible, because new versions will be released frequently which contains new features and bug fixes.
-
-    Make sure you add the ``glslangValidator`` in the Vulkan SDK's bin folder to your path variable.
-
 Optional Software
 -----------------
 

--- a/helper/req_check.py
+++ b/helper/req_check.py
@@ -1,4 +1,6 @@
 """
+Check if all packages of a python requirement file are satisfied.
+
 Copyright 2021-present Iceflower - iceflower@gmx.de
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -188,7 +188,7 @@ public:
 /// empty: 30%
 /// solid: 30%
 /// normal: 40%
-/// The number of intendations are evenly distributed. Empty normal cubes are not generated.
+/// The number of indentations are evenly distributed. Empty normal cubes are not generated.
 /// @param max_depth The maximum of nested octants.
 /// @param position The position where the root cube is placed.
 /// @param seed The seed used for the random number generator.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,7 +117,6 @@ if(CONAN_LIBS)
 
         PUBLIC
         ${CONAN_LIBS}
-        Vulkan::Vulkan
     )
 else()
     foreach(_LIB ${CONAN_LIBS_RELEASE})
@@ -126,7 +125,6 @@ else()
             optimized
 
             ${_LIB}
-            Vulkan::Vulkan
         )
     endforeach()
     foreach(_LIB ${CONAN_LIBS_DEBUG})
@@ -135,7 +133,6 @@ else()
             debug
 
             ${_LIB}
-            Vulkan::Vulkan
         )
     endforeach()
 endif()


### PR DESCRIPTION
Added:
Conan dependency caching based on conanfile.py SHA. Whenever we change that file we have to compile the dependencies completly new.
We could still load the old cache in those cases, but we currently have no elegant way to delete the old files.
My experiment with a Python script were problematic here and there, not very easy to maintain.

Build Times:
- With cache:
  - Ubuntu: ~2min
  - Windows: ~3min
- Without cache:
  - Ubuntu: ~11-15min
  - Windows: ~10-13min
- Downloading SDK:
  - Ubuntu: ~2-3min
  - Windows: ~4min

With cache building we gain around 1min and also reduce the bandwidth consumption with servers outside of GitHub.
Also we have a better control over which vulkan headers and tools are used to build, also making reproduceable builds more likely.
The only downside is clang-tidy being 1min slower due to bigger cache. Also clang-tidy itself takes 2 min longer??

---

Close: #227 