### PR TITLE
Clean-up include directives, forward-declare, and clean-up namespaces

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,11 +1,11 @@
 ﻿#include "inexor/vulkan-renderer/application.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
-
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
+
+#include <stdexcept>
 
 int main(int argc, char *argv[]) {
     spdlog::init_thread_pool(8192, 2);

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -5,15 +5,7 @@
 #include "inexor/vulkan-renderer/world/collision_query.hpp"
 #include "inexor/vulkan-renderer/world/cube.hpp"
 
-#include <GLFW/glfw3.h>
-#include <volk.h>
-
-#include <cstdint>
-#include <memory>
-#include <string>
-#include <vector>
-
-// forward declarations
+// Forward declarations
 namespace inexor::vulkan_renderer::input {
 class KeyboardMouseInputData;
 } // namespace inexor::vulkan_renderer::input

--- a/include/inexor/vulkan-renderer/camera.hpp
+++ b/include/inexor/vulkan-renderer/camera.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/vec3.hpp>
 
 #include <algorithm>
 #include <array>

--- a/include/inexor/vulkan-renderer/imgui.hpp
+++ b/include/inexor/vulkan-renderer/imgui.hpp
@@ -12,11 +12,10 @@
 #include <memory>
 #include <vector>
 
+// Forward declarations
 namespace inexor::vulkan_renderer::wrapper {
-
 class Device;
 class Swapchain;
-
 } // namespace inexor::vulkan_renderer::wrapper
 
 namespace inexor::vulkan_renderer {

--- a/include/inexor/vulkan-renderer/io/byte_stream.hpp
+++ b/include/inexor/vulkan-renderer/io/byte_stream.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <filesystem>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/io/nxoc_parser.hpp
+++ b/include/inexor/vulkan-renderer/io/nxoc_parser.hpp
@@ -2,16 +2,14 @@
 
 #include "inexor/vulkan-renderer/io/octree_parser.hpp"
 
-#include <cstdint>
 #include <memory>
-#include <utility>
 
-// forward declaration
+// Forward declaration
 namespace inexor::vulkan_renderer::world {
 class Cube;
 } // namespace inexor::vulkan_renderer::world
 
-// forward declaration
+// Forward declaration
 namespace inexor::vulkan_renderer::io {
 class ByteStream;
 } // namespace inexor::vulkan_renderer::io

--- a/include/inexor/vulkan-renderer/io/octree_parser.hpp
+++ b/include/inexor/vulkan-renderer/io/octree_parser.hpp
@@ -2,19 +2,16 @@
 
 #include <cstdint>
 #include <memory>
-#include <utility>
 
-// forward declaration
+// Forward declaration
 namespace inexor::vulkan_renderer::world {
 class Cube;
 } // namespace inexor::vulkan_renderer::world
 
-// forward declaration
 namespace inexor::vulkan_renderer::io {
-class ByteStream;
-} // namespace inexor::vulkan_renderer::io
 
-namespace inexor::vulkan_renderer::io {
+// Forward declaration
+class ByteStream;
 
 class OctreeParser {
 public:

--- a/include/inexor/vulkan-renderer/render_graph.hpp
+++ b/include/inexor/vulkan-renderer/render_graph.hpp
@@ -1,31 +1,30 @@
 #pragma once
 
-// TODO: Forward declare.
-#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
-#include "inexor/vulkan-renderer/wrapper/fence.hpp"
 #include "inexor/vulkan-renderer/wrapper/framebuffer.hpp"
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
-#include "inexor/vulkan-renderer/wrapper/shader.hpp"
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 
 #include <spdlog/spdlog.h>
-#include <vk_mem_alloc.h>
-#include <volk.h>
 
 #include <functional>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 // TODO: Compute stages.
 // TODO: Uniform buffers.
 
+// Forward declarations
+namespace inexor::vulkan_renderer::wrapper {
+class CommandBuffer;
+class Shader;
+}; // namespace inexor::vulkan_renderer::wrapper
+
 namespace inexor::vulkan_renderer {
 
+// Forward declarations
 class PhysicalResource;
 class PhysicalStage;
 class RenderGraph;

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -5,30 +5,12 @@
 #include "inexor/vulkan-renderer/imgui.hpp"
 #include "inexor/vulkan-renderer/msaa_target.hpp"
 #include "inexor/vulkan-renderer/octree_gpu_vertex.hpp"
-#include "inexor/vulkan-renderer/render_graph.hpp"
 #include "inexor/vulkan-renderer/time_step.hpp"
 #include "inexor/vulkan-renderer/vk_tools/gpu_info.hpp"
-#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
-#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
-#include "inexor/vulkan-renderer/wrapper/descriptor.hpp"
-#include "inexor/vulkan-renderer/wrapper/device.hpp"
-#include "inexor/vulkan-renderer/wrapper/fence.hpp"
-#include "inexor/vulkan-renderer/wrapper/framebuffer.hpp"
-#include "inexor/vulkan-renderer/wrapper/gpu_texture.hpp"
-#include "inexor/vulkan-renderer/wrapper/image.hpp"
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
-#include "inexor/vulkan-renderer/wrapper/shader.hpp"
-#include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 #include "inexor/vulkan-renderer/wrapper/uniform_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/window.hpp"
 #include "inexor/vulkan-renderer/wrapper/window_surface.hpp"
-
-#include <volk.h>
-
-#include <cstdint>
-#include <memory>
-#include <vector>
 
 namespace inexor::vulkan_renderer {
 

--- a/include/inexor/vulkan-renderer/tools/file.hpp
+++ b/include/inexor/vulkan-renderer/tools/file.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/inexor/vulkan-renderer/vk_tools/representation.hpp
+++ b/include/inexor/vulkan-renderer/vk_tools/representation.hpp
@@ -2,7 +2,6 @@
 
 #include <volk.h>
 
-#include <array>
 #include <string>
 
 namespace inexor::vulkan_renderer::vk_tools {

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -2,25 +2,21 @@
 
 #include "inexor/vulkan-renderer/world/indentation.hpp"
 
-#include <glm/geometric.hpp>
 #include <glm/gtx/vector_angle.hpp>
 #include <glm/vec3.hpp>
-#include <spdlog/spdlog.h>
 
 #include <array>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
-#include <utility>
 #include <vector>
 
-// forward declaration
+// Forward declaration
 namespace inexor::vulkan_renderer::world {
 class Cube;
 } // namespace inexor::vulkan_renderer::world
 
-// forward declaration
+// Forward declarations
 namespace inexor::vulkan_renderer::io {
 class ByteStream;
 class NXOCParser;

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -1,19 +1,16 @@
 #pragma once
 
-#include <volk.h>
-
 #include "inexor/vulkan-renderer/wrapper/fence.hpp"
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
 
-#include <cstdint>
+#include <cassert>
 #include <memory>
 #include <span>
-#include <string>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for VkCommandBuffer.

--- a/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_buffer.hpp
@@ -20,7 +20,7 @@ class Device;
 /// @todo Make trivially copyable (this class doesn't really "own" the command buffer, more just an OOP wrapper).
 class CommandBuffer {
     VkCommandBuffer m_command_buffer{VK_NULL_HANDLE};
-    const wrapper::Device &m_device;
+    const Device &m_device;
     std::string m_name;
     std::unique_ptr<Fence> m_wait_fence;
 

--- a/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/command_pool.hpp
@@ -9,6 +9,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for VkCommandPool.

--- a/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/cpu_texture.hpp
@@ -1,7 +1,6 @@
 ﻿#pragma once
 
 #include <string>
-#include <vector>
 
 #include <stb_image.h>
 

--- a/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor.hpp
@@ -7,6 +7,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for resource descriptors.

--- a/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/descriptor_builder.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <volk.h>
-
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
+
+#include <volk.h>
 
 #include <cassert>
 #include <cstdint>
@@ -11,7 +11,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-// forward declarations
+// Forward declarations
 class Device;
 class ResourceDescriptor;
 

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
 #include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
-#include "inexor/vulkan-renderer/wrapper/instance.hpp"
-
-#include <vk_mem_alloc.h>
-#include <volk.h>
 
 #include <array>
-#include <cassert>
 #include <functional>
 #include <optional>
 #include <span>
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
+
+// Forward declaration
+class Instance;
 
 /// A wrapper struct for physical device data
 struct DeviceInfo {

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -2,13 +2,13 @@
 
 #include <volk.h>
 
-#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief A RAII wrapper for VkFences.

--- a/include/inexor/vulkan-renderer/wrapper/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/fence.hpp
@@ -13,7 +13,7 @@ class Device;
 
 /// @brief A RAII wrapper for VkFences.
 class Fence {
-    const wrapper::Device &m_device;
+    const Device &m_device;
     std::string m_name;
     VkFence m_fence{VK_NULL_HANDLE};
 
@@ -23,7 +23,7 @@ public:
     /// @param name The internal debug marker name of the VkFence.
     /// @param in_signaled_state True if the VkFence will be constructed in signaled state, false otherwise.
     /// @warning Make sure to specify in_signaled_state correctly as needed, otherwise synchronization problems occur.
-    Fence(const wrapper::Device &device, const std::string &name, bool in_signaled_state);
+    Fence(const Device &device, const std::string &name, bool in_signaled_state);
 
     Fence(const Fence &) = delete;
     Fence(Fence &&) noexcept;

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -7,6 +7,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declarations
 class Device;
 class Swapchain;
 

--- a/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/framebuffer.hpp
@@ -12,7 +12,7 @@ class Swapchain;
 
 /// @brief RAII wrapper class for VkFramebuffer.
 class Framebuffer {
-    const wrapper::Device &m_device;
+    const Device &m_device;
     VkFramebuffer m_framebuffer{VK_NULL_HANDLE};
     std::string m_name;
 

--- a/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp
@@ -1,12 +1,12 @@
 ﻿#pragma once
 
 #include <vk_mem_alloc.h>
-#include <volk.h>
 
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for GPU Memory buffers.

--- a/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
@@ -19,7 +19,7 @@ class GPUMemoryBuffer;
 /// @brief RAII wrapper class for textures which are stored in GPU memory.
 /// @todo Support 3D textures and cube maps (implement new and separate wrappers though).
 class GpuTexture {
-    std::unique_ptr<wrapper::Image> m_texture_image;
+    std::unique_ptr<Image> m_texture_image;
     VkSampler m_sampler{VK_NULL_HANDLE};
 
     int m_texture_width{0};
@@ -28,7 +28,7 @@ class GpuTexture {
     int m_mip_levels{0};
 
     std::string m_name;
-    const wrapper::Device &m_device;
+    const Device &m_device;
     const VkFormat m_texture_image_format{VK_FORMAT_R8G8B8A8_UNORM};
 
     /// @brief Create the texture.
@@ -50,7 +50,7 @@ public:
     /// @param device The const reference to a device RAII wrapper instance.
     /// @param file_name The name of the texture file.
     /// @param name The internal debug marker name of the texture.
-    GpuTexture(const wrapper::Device &device, const CpuTexture &cpu_texture);
+    GpuTexture(const Device &device, const CpuTexture &cpu_texture);
 
     /// @brief Construct a texture from a block of memory.
     /// @param device The const reference to a device RAII wrapper instance.
@@ -60,7 +60,7 @@ public:
     /// @param texture_height The height of the texture.
     /// @param texture_size The size of the texture.
     /// @param name The internal debug marker name of the texture.
-    GpuTexture(const wrapper::Device &device, void *data, std::size_t data_size, int texture_width, int texture_height,
+    GpuTexture(const Device &device, void *data, std::size_t data_size, int texture_width, int texture_height,
                int texture_channels, int mip_levels, std::string name);
 
     GpuTexture(const GpuTexture &) = delete;

--- a/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/gpu_texture.hpp
@@ -5,13 +5,11 @@
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/image.hpp"
 
-#include <volk.h>
-
 #include <memory>
-#include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declarations
 class Device;
 class GPUMemoryBuffer;
 

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -2,11 +2,11 @@
 
 #include <vk_mem_alloc.h>
 
-#include <cassert>
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for VkImage.

--- a/include/inexor/vulkan-renderer/wrapper/image.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/image.hpp
@@ -11,7 +11,7 @@ class Device;
 
 /// @brief RAII wrapper class for VkImage.
 class Image {
-    const wrapper::Device &m_device;
+    const Device &m_device;
     VmaAllocation m_allocation{VK_NULL_HANDLE};
     VmaAllocationInfo m_allocation_info{};
     VkImage m_image{VK_NULL_HANDLE};

--- a/include/inexor/vulkan-renderer/wrapper/shader.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/shader.hpp
@@ -7,6 +7,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for VkShaderModules.

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -2,14 +2,10 @@
 
 #include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
 
-#include <volk.h>
-
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
-#include <set>
-#include <span>
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/uniform_buffer.hpp
@@ -2,12 +2,9 @@
 
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
 
-#include <volk.h>
-
-#include <string>
-
 namespace inexor::vulkan_renderer::wrapper {
 
+// Forward declaration
 class Device;
 
 /// @brief RAII wrapper class for uniform buffers.

--- a/include/inexor/vulkan-renderer/wrapper/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
-#include <volk.h>
 
-#include <array>
 #include <cstdint>
 #include <string>
 

--- a/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window_surface.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
-#include <spdlog/spdlog.h>
 #include <volk.h>
-
-#include <cassert>
 
 namespace inexor::vulkan_renderer::wrapper {
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -7,15 +7,11 @@
 #include "inexor/vulkan-renderer/tools/cla_parser.hpp"
 #include "inexor/vulkan-renderer/vk_tools/enumerate.hpp"
 #include "inexor/vulkan-renderer/world/collision.hpp"
-#include "inexor/vulkan-renderer/world/cube.hpp"
 #include "inexor/vulkan-renderer/wrapper/cpu_texture.hpp"
 #include "inexor/vulkan-renderer/wrapper/descriptor_builder.hpp"
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
-#include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <glm/gtc/matrix_transform.hpp>
-#include <imgui.h>
-#include <spdlog/spdlog.h>
 #include <toml.hpp>
 
 #include <random>

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -1,6 +1,5 @@
 #include "inexor/vulkan-renderer/imgui.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/cpu_texture.hpp"
 #include "inexor/vulkan-renderer/wrapper/descriptor_builder.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -1,7 +1,9 @@
 #include "inexor/vulkan-renderer/render_graph.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
+#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
+#include "inexor/vulkan-renderer/wrapper/shader.hpp"
 
 #include <spdlog/spdlog.h>
 #include <vk_mem_alloc.h>
@@ -11,8 +13,7 @@
 #include <cassert>
 #include <functional>
 #include <stdexcept>
-#include <unordered_map>
-#include <vector>
+#include <utility>
 
 namespace inexor::vulkan_renderer {
 

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -1,18 +1,8 @@
 ﻿#include "inexor/vulkan-renderer/renderer.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
-#include "inexor/vulkan-renderer/octree_gpu_vertex.hpp"
 #include "inexor/vulkan-renderer/standard_ubo.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
-
-#include <imgui.h>
-#include <spdlog/spdlog.h>
-
-#include <array>
-#include <cassert>
-#include <fstream>
-#include <limits>
-#include <unordered_map>
 
 namespace inexor::vulkan_renderer {
 

--- a/src/vulkan-renderer/vk_tools/representation.cpp
+++ b/src/vulkan-renderer/vk_tools/representation.cpp
@@ -1,5 +1,6 @@
 #include "inexor/vulkan-renderer/vk_tools/representation.hpp"
 
+#include <array>
 #include <cassert>
 
 namespace inexor::vulkan_renderer::vk_tools {

--- a/src/vulkan-renderer/world/collision_query.cpp
+++ b/src/vulkan-renderer/world/collision_query.cpp
@@ -1,8 +1,7 @@
 #include "inexor/vulkan-renderer/world/collision_query.hpp"
 
-#include <inexor/vulkan-renderer/world/cube.hpp>
+#include "inexor/vulkan-renderer/world/cube.hpp"
 
-#include <array>
 #include <glm/gtx/intersect.hpp>
 
 namespace inexor::vulkan_renderer::world {

--- a/src/vulkan-renderer/wrapper/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/command_pool.cpp
@@ -4,6 +4,8 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
+#include <spdlog/spdlog.h>
+
 #include <thread>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -4,8 +4,6 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
-#include <spdlog/spdlog.h>
-
 #include <cassert>
 #include <utility>
 

--- a/src/vulkan-renderer/wrapper/descriptor.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor.cpp
@@ -45,7 +45,7 @@ ResourceDescriptor::ResourceDescriptor(const Device &device,
         pool_sizes.emplace_back(VkDescriptorPoolSize{descriptor_pool_type.descriptorType, 1});
     }
 
-    m_device.create_descriptor_pool(wrapper::make_info<VkDescriptorPoolCreateInfo>({
+    m_device.create_descriptor_pool(make_info<VkDescriptorPoolCreateInfo>({
                                         .maxSets = 1,
                                         .poolSizeCount = static_cast<std::uint32_t>(pool_sizes.size()),
                                         .pPoolSizes = pool_sizes.data(),
@@ -61,7 +61,7 @@ ResourceDescriptor::ResourceDescriptor(const Device &device,
 
     const std::vector<VkDescriptorSetLayout> descriptor_set_layouts(1, m_descriptor_set_layout);
 
-    const auto descriptor_set_ai = wrapper::make_info<VkDescriptorSetAllocateInfo>({
+    const auto descriptor_set_ai = make_info<VkDescriptorSetAllocateInfo>({
         .descriptorPool = m_descriptor_pool,
         .descriptorSetCount = 1,
         .pSetLayouts = descriptor_set_layouts.data(),

--- a/src/vulkan-renderer/wrapper/descriptor_builder.cpp
+++ b/src/vulkan-renderer/wrapper/descriptor_builder.cpp
@@ -3,8 +3,6 @@
 #include "inexor/vulkan-renderer/wrapper/descriptor.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 
-#include <spdlog/spdlog.h>
-
 #include <utility>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -4,6 +4,7 @@
 #include "inexor/vulkan-renderer/vk_tools/device_info.hpp"
 #include "inexor/vulkan-renderer/vk_tools/enumerate.hpp"
 #include "inexor/vulkan-renderer/vk_tools/representation.hpp"
+#include "inexor/vulkan-renderer/wrapper/instance.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #define VMA_IMPLEMENTATION
@@ -18,6 +19,7 @@
 #include <vk_mem_alloc.h>
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 
 namespace {

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -1,11 +1,9 @@
 #include "inexor/vulkan-renderer/wrapper/fence.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
-#include <spdlog/spdlog.h>
-
+#include <cassert>
 #include <stdexcept>
 #include <utility>
 

--- a/src/vulkan-renderer/wrapper/fence.cpp
+++ b/src/vulkan-renderer/wrapper/fence.cpp
@@ -11,7 +11,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Fence::Fence(const wrapper::Device &device, const std::string &name, const bool in_signaled_state)
+Fence::Fence(const Device &device, const std::string &name, const bool in_signaled_state)
     : m_device(device), m_name(name) {
     assert(!name.empty());
     assert(device.device());

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -13,7 +13,7 @@
 namespace inexor::vulkan_renderer::wrapper {
 
 Framebuffer::Framebuffer(const Device &device, VkRenderPass render_pass, const std::vector<VkImageView> &attachments,
-                         const wrapper::Swapchain &swapchain, std::string name)
+                         const Swapchain &swapchain, std::string name)
     : m_device(device), m_name(std::move(name)) {
     m_device.create_framebuffer(make_info<VkFramebufferCreateInfo>({
                                     .renderPass = render_pass,

--- a/src/vulkan-renderer/wrapper/framebuffer.cpp
+++ b/src/vulkan-renderer/wrapper/framebuffer.cpp
@@ -1,11 +1,8 @@
 #include "inexor/vulkan-renderer/wrapper/framebuffer.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
-
-#include <spdlog/spdlog.h>
 
 #include <array>
 #include <utility>

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -11,13 +11,13 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-GpuTexture::GpuTexture(const wrapper::Device &device, const CpuTexture &cpu_texture)
+GpuTexture::GpuTexture(const Device &device, const CpuTexture &cpu_texture)
     : m_device(device), m_texture_width(cpu_texture.width()), m_texture_height(cpu_texture.height()),
       m_texture_channels(cpu_texture.channels()), m_mip_levels(cpu_texture.mip_levels()), m_name(cpu_texture.name()) {
     create_texture(cpu_texture.data(), cpu_texture.data_size());
 }
 
-GpuTexture::GpuTexture(const wrapper::Device &device, void *data, const std::size_t data_size, const int texture_width,
+GpuTexture::GpuTexture(const Device &device, void *data, const std::size_t data_size, const int texture_width,
                        const int texture_height, const int texture_channels, const int mip_levels, std::string name)
     : m_device(device), m_texture_width(texture_width), m_texture_height(texture_height),
       m_texture_channels(texture_channels), m_mip_levels(mip_levels), m_name(std::move(name)) {
@@ -46,9 +46,9 @@ void GpuTexture::create_texture(void *texture_data, const std::size_t texture_si
         .height = static_cast<uint32_t>(m_texture_height),
     };
 
-    m_texture_image = std::make_unique<wrapper::Image>(
-        m_device, m_texture_image_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-        VK_IMAGE_ASPECT_COLOR_BIT, VK_SAMPLE_COUNT_1_BIT, m_name, extent);
+    m_texture_image = std::make_unique<Image>(m_device, m_texture_image_format,
+                                              VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                                              VK_IMAGE_ASPECT_COLOR_BIT, VK_SAMPLE_COUNT_1_BIT, m_name, extent);
 
     const VkBufferImageCopy copy_region{
         .bufferOffset = 0,

--- a/src/vulkan-renderer/wrapper/gpu_texture.cpp
+++ b/src/vulkan-renderer/wrapper/gpu_texture.cpp
@@ -1,10 +1,8 @@
 ﻿#include "inexor/vulkan-renderer/wrapper/gpu_texture.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/cpu_texture.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
-#include <spdlog/spdlog.h>
 #include <vk_mem_alloc.h>
 
 #include <utility>

--- a/src/vulkan-renderer/wrapper/image.cpp
+++ b/src/vulkan-renderer/wrapper/image.cpp
@@ -4,8 +4,7 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
-#include <spdlog/spdlog.h>
-
+#include <cassert>
 #include <utility>
 
 namespace inexor::vulkan_renderer::wrapper {

--- a/src/vulkan-renderer/wrapper/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/semaphore.cpp
@@ -3,8 +3,6 @@
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
-#include <spdlog/spdlog.h>
-
 #include <cassert>
 #include <utility>
 

--- a/src/vulkan-renderer/wrapper/shader.cpp
+++ b/src/vulkan-renderer/wrapper/shader.cpp
@@ -1,11 +1,8 @@
 #include "inexor/vulkan-renderer/wrapper/shader.hpp"
 
-#include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/tools/file.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
-
-#include <spdlog/spdlog.h>
 
 #include <cassert>
 #include <stdexcept>

--- a/src/vulkan-renderer/wrapper/uniform_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -1,8 +1,5 @@
 #include "inexor/vulkan-renderer/wrapper/uniform_buffer.hpp"
 
-#include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
-
-#include <cassert>
 #include <cstring>
 #include <utility>
 

--- a/src/vulkan-renderer/wrapper/window_surface.cpp
+++ b/src/vulkan-renderer/wrapper/window_surface.cpp
@@ -2,6 +2,9 @@
 
 #include "inexor/vulkan-renderer/exception.hpp"
 
+#include <spdlog/spdlog.h>
+
+#include <cassert>
 #include <utility>
 
 namespace inexor::vulkan_renderer::wrapper {


### PR DESCRIPTION
I am cleaning up the includes according to the following rules (the discussion is ongoing)

### Overview
* If a header file is not used, do not include it. No matter if in `.hpp` or `.cpp` file
* If a header is used only in the `.cpp` file, forward declare it and include it only in the `.cpp`
* Always include the standard library headers of everything you use (no indirect includes of standard headers)
* Try to include `vulkan/vulkan_core.h` instead of `vulkan/vulkan.h` if possible
* Follow the [order of includes according to our docs](https://inexor-vulkan-renderer.readthedocs.io/en/latest/development/engine-design/main.html#coding-style)

### Extra:
* In some cases I removed the unnecessary `wrapper::` namespace if we are already in that namespace

### TODO
* [x] Fix commit naming
* [x] Squash

We should add these rules to the wiki for clarity.
I need your feedback.