### PR TITLE
[swapchain] Fix destruction bug

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -325,6 +325,10 @@ public:
     /// @param usage The requested image usage
     /// @return ``true`` if the format feature is supported
     [[nodiscard]] bool surface_supports_usage(VkSurfaceKHR surface, VkImageUsageFlagBits usage) const;
+
+    /// Call vkDeviceWaitIdle
+    /// @exception VulkanException vkDeviceWaitIdle call failed
+    void wait_idle() const;
 };
 
 } // namespace inexor::vulkan_renderer::wrapper

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -36,16 +36,6 @@ private:
     /// @return A std::vector of swapchain images (this can be empty!)
     [[nodiscard]] std::vector<VkImage> get_swapchain_images();
 
-    /// Setup the swapchain
-    /// @param width The width of the swapchain images
-    /// @param height The height of the swapchain images
-    /// @param vsync_enabled ``true`` if vertical synchronization is enabled
-    /// @param old_swapchain The old swapchain which can be passed in to speed up swapchain recreation
-    /// @exception VulkanException vkCreateSwapchainKHR call failed
-    /// @exception VulkanException vkGetPhysicalDeviceSurfaceSupportKHR call failed
-    void setup_swapchain(std::uint32_t width, std::uint32_t height, bool vsync_enabled,
-                         VkSwapchainKHR old_swapchain = VK_NULL_HANDLE);
-
 public:
     /// Default constructor
     /// @param device The device wrapper
@@ -134,11 +124,13 @@ public:
     /// @exception VulkanException vkQueuePresentKHR call failed
     void present(std::uint32_t img_index);
 
-    /// Recreate the swapchain by calling ``setup_swapchain``
-    /// @param width The swapchain image width
-    /// @param height The swapchain image height
+    /// Setup the swapchain
+    /// @param width The width of the swapchain images
+    /// @param height The height of the swapchain images
     /// @param vsync_enabled ``true`` if vertical synchronization is enabled
-    void recreate(std::uint32_t width, std::uint32_t height, bool vsync_enabled);
+    /// @exception VulkanException vkCreateSwapchainKHR call failed
+    /// @exception VulkanException vkGetPhysicalDeviceSurfaceSupportKHR call failed
+    void setup_swapchain(std::uint32_t width, std::uint32_t height, bool vsync_enabled);
 
     [[nodiscard]] const VkSwapchainKHR *swapchain() const {
         return &m_swapchain;

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -71,8 +71,8 @@ void VulkanRenderer::generate_octree_indices() {
 }
 
 void VulkanRenderer::recreate_swapchain() {
+    m_device->wait_idle();
     m_window->wait_for_focus();
-    vkDeviceWaitIdle(m_device->device());
 
     // TODO: This is quite naive, we don't need to recompile the whole render graph on swapchain invalidation.
     m_render_graph.reset();
@@ -137,7 +137,7 @@ VulkanRenderer::~VulkanRenderer() {
         return;
     }
 
-    vkDeviceWaitIdle(m_device->device());
+    m_device->wait_idle();
 
     if (!m_debug_report_callback_initialised) {
         return;

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -121,15 +121,7 @@ void VulkanRenderer::render_frame() {
         .pCommandBuffers = cmd_buf.ptr(),
     }));
 
-    const auto present_info = wrapper::make_info<VkPresentInfoKHR>({
-        .swapchainCount = 1,
-        .pSwapchains = m_swapchain->swapchain(),
-        .pImageIndices = &image_index,
-    });
-
-    if (const auto result = vkQueuePresentKHR(m_device->present_queue(), &present_info); result != VK_SUCCESS) {
-        throw VulkanException("Error: vkQueuePresentKHR failed!", result);
-    }
+    m_swapchain->present(image_index);
 
     if (auto fps_value = m_fps_counter.update()) {
         m_window->set_title("Inexor Vulkan API renderer demo - " + std::to_string(*fps_value) + " FPS");

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -71,13 +71,20 @@ void VulkanRenderer::generate_octree_indices() {
 }
 
 void VulkanRenderer::recreate_swapchain() {
-    m_device->wait_idle();
     m_window->wait_for_focus();
+    m_device->wait_idle();
+
+    // Query the framebuffer size here again although the window width is set during framebuffer resize callback
+    // The reason for this is that the framebuffer size could already be different again because we missed a poll
+    // This seems to be an issue on Linux only though
+    int window_width = 0;
+    int window_height = 0;
+    glfwGetFramebufferSize(m_window->get(), &window_width, &window_height);
 
     // TODO: This is quite naive, we don't need to recompile the whole render graph on swapchain invalidation.
     m_render_graph.reset();
     // Recreate the swapchain
-    m_swapchain->setup_swapchain(m_window->width(), m_window->height(), m_vsync_enabled);
+    m_swapchain->setup_swapchain(window_width, window_height, m_vsync_enabled);
     m_render_graph = std::make_unique<RenderGraph>(*m_device, *m_swapchain);
     setup_render_graph();
 

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -76,7 +76,8 @@ void VulkanRenderer::recreate_swapchain() {
 
     // TODO: This is quite naive, we don't need to recompile the whole render graph on swapchain invalidation.
     m_render_graph.reset();
-    m_swapchain->recreate(m_window->width(), m_window->height(), m_vsync_enabled);
+    // Recreate the swapchain
+    m_swapchain->setup_swapchain(m_window->width(), m_window->height(), m_vsync_enabled);
     m_render_graph = std::make_unique<RenderGraph>(*m_device, *m_swapchain);
     setup_render_graph();
 

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -699,4 +699,10 @@ const CommandBuffer &Device::request_command_buffer(const std::string &name) {
     return thread_graphics_pool().request_command_buffer(name);
 }
 
+void Device::wait_idle() const {
+    if (const auto result = vkDeviceWaitIdle(m_device); result != VK_SUCCESS) {
+        throw VulkanException("Error: vkDeviceWaitIdle failed!", result);
+    }
+}
+
 } // namespace inexor::vulkan_renderer::wrapper

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -17,7 +17,7 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 
-Swapchain::Swapchain(Device &device, VkSurfaceKHR surface, const std::uint32_t width, const std::uint32_t height,
+Swapchain::Swapchain(Device &device, const VkSurfaceKHR surface, const std::uint32_t width, const std::uint32_t height,
                      const bool vsync_enabled)
     : m_device(device), m_surface(surface), m_vsync_enabled(vsync_enabled) {
     m_img_available = std::make_unique<Semaphore>(m_device, "Swapchain image available");
@@ -42,7 +42,7 @@ std::uint32_t Swapchain::acquire_next_image_index(const std::uint64_t timeout) {
         result != VK_SUCCESS) {
         if (result == VK_SUBOPTIMAL_KHR) {
             // We need to recreate the swapchain
-            recreate(m_extent.width, m_extent.height, m_vsync_enabled);
+            setup_swapchain(m_extent.width, m_extent.height, m_vsync_enabled);
         } else {
             throw VulkanException("Error: vkAcquireNextImageKHR failed!", result);
         }
@@ -172,7 +172,7 @@ void Swapchain::present(const std::uint32_t img_index) {
     if (const auto result = vkQueuePresentKHR(m_device.present_queue(), &present_info); result != VK_SUCCESS) {
         if (result == VK_SUBOPTIMAL_KHR) {
             // We need to recreate the swapchain
-            recreate(m_extent.width, m_extent.height, m_vsync_enabled);
+            setup_swapchain(m_extent.width, m_extent.height, m_vsync_enabled);
         } else {
             // Exception is thrown if result is not VK_SUCCESS but also not VK_SUBOPTIMAL_KHR
             throw VulkanException("Error: vkQueuePresentKHR failed!", result);
@@ -180,19 +180,7 @@ void Swapchain::present(const std::uint32_t img_index) {
     }
 }
 
-void Swapchain::recreate(const std::uint32_t width, const std::uint32_t height, const bool vsync_enabled) {
-    // Store the old swapchain to speed up recreation later
-    auto *const old_swapchain = m_swapchain;
-    for (auto *const img_view : m_img_views) {
-        vkDestroyImageView(m_device.device(), img_view, nullptr);
-    }
-    m_imgs.clear();
-    m_img_views.clear();
-    setup_swapchain(width, height, vsync_enabled, old_swapchain);
-}
-
-void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t height, const bool vsync_enabled,
-                                const VkSwapchainKHR old_swapchain) {
+void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t height, const bool vsync_enabled) {
     const auto caps = m_device.get_surface_capabilities(m_surface);
     m_surface_format = choose_surface_format(vk_tools::get_surface_formats(m_device.physical_device(), m_surface));
     const VkExtent2D requested_extent{.width = width, .height = height};
@@ -211,6 +199,8 @@ void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t h
         throw std::runtime_error(
             "Error: Swapchain image usage flag bit VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT is not supported!");
     }
+
+    const VkSwapchainKHR old_swapchain = m_swapchain;
 
     const auto swapchain_ci = make_info<VkSwapchainCreateInfoKHR>({
         .surface = m_surface,
@@ -239,6 +229,16 @@ void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t h
     if (const auto result = vkCreateSwapchainKHR(m_device.device(), &swapchain_ci, nullptr, &m_swapchain);
         result != VK_SUCCESS) {
         throw VulkanException("Error: vkCreateSwapchainKHR failed!", result);
+    }
+
+    // We need to destroy the old swapchain if specified
+    if (old_swapchain != VK_NULL_HANDLE) {
+        for (auto *const img_view : m_img_views) {
+            vkDestroyImageView(m_device.device(), img_view, nullptr);
+        }
+        m_imgs.clear();
+        m_img_views.clear();
+        vkDestroySwapchainKHR(m_device.device(), old_swapchain, nullptr);
     }
 
     m_extent.width = width;

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -170,7 +170,7 @@ void Swapchain::present(const std::uint32_t img_index) {
         .pImageIndices = &img_index,
     });
     if (const auto result = vkQueuePresentKHR(m_device.present_queue(), &present_info); result != VK_SUCCESS) {
-        if (result == VK_SUBOPTIMAL_KHR) {
+        if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
             // We need to recreate the swapchain
             setup_swapchain(m_extent.width, m_extent.height, m_vsync_enabled);
         } else {


### PR DESCRIPTION
Closes #517 

* [x] Rebase onto `main`
* [x] Get rid of inconvenient `recreate` method
* [x] Store old swapchain automatically for swapchain recreation and destroy if properly
* [x] Fix another bug by using swapchain wrapper method for presenting
* [x] Fix https://github.com/inexorgame/vulkan-renderer/issues/366
* [x] Test this on Windows
* [x] Recreate swapchain in case `vkQueuePresentKHR` returns `VK_ERROR_OUT_OF_DATE_KHR`