### PR TITLE
[*] Refactor rendergraph

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -24,18 +24,11 @@ int main(int argc, char *argv[]) {
     spdlog::trace("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
     spdlog::trace("Parsing command line arguments");
 
-    std::unique_ptr<inexor::vulkan_renderer::Application> renderer;
-
     try {
-        renderer = std::make_unique<inexor::vulkan_renderer::Application>(argc, argv);
-    } catch (const std::runtime_error &exception) {
-        spdlog::critical(exception.what());
-        return 1;
+        auto renderer = std::make_unique<inexor::vulkan_renderer::Application>(argc, argv);
+        renderer->run();
     } catch (const std::exception &exception) {
         spdlog::critical(exception.what());
         return 1;
     }
-
-    renderer->run();
-    spdlog::trace("Window closed");
 }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,34 +1,15 @@
 ﻿#include "inexor/vulkan-renderer/application.hpp"
 
-#include <spdlog/async.h>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
 #include <stdexcept>
 
 int main(int argc, char *argv[]) {
-    spdlog::init_thread_pool(8192, 2);
-
-    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("vulkan-renderer.log", true);
-    auto vulkan_renderer_log =
-        std::make_shared<spdlog::async_logger>("vulkan-renderer", spdlog::sinks_init_list{console_sink, file_sink},
-                                               spdlog::thread_pool(), spdlog::async_overflow_policy::block);
-    vulkan_renderer_log->set_level(spdlog::level::trace);
-    vulkan_renderer_log->set_pattern("%Y-%m-%d %T.%f %^%l%$ %5t [%-10n] %v");
-    vulkan_renderer_log->flush_on(spdlog::level::debug); // TODO: as long as we don't have a flush on crash
-
-    spdlog::set_default_logger(vulkan_renderer_log);
-
-    spdlog::trace("Inexor vulkan-renderer, BUILD " + std::string(__DATE__) + ", " + __TIME__);
-    spdlog::trace("Parsing command line arguments");
-
     try {
-        auto renderer = std::make_unique<inexor::vulkan_renderer::Application>(argc, argv);
+        using inexor::vulkan_renderer::Application;
+        auto renderer = std::make_unique<Application>(argc, argv);
         renderer->run();
     } catch (const std::exception &exception) {
         spdlog::critical(exception.what());
         return 1;
     }
+    return 0;
 }

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -42,7 +42,6 @@ class Application : public VulkanRenderer {
     /// Use the camera's position and view direction vector to check for ray-octree collisions with all octrees.
     void check_octree_collisions();
     void process_input();
-
     void initialize_spdlog();
 
 public:

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -44,6 +44,8 @@ class Application : public VulkanRenderer {
     void check_octree_collisions();
     void process_input();
 
+    void initialize_spdlog();
+
 public:
     Application(int argc, char **argv);
 

--- a/include/inexor/vulkan-renderer/application.hpp
+++ b/include/inexor/vulkan-renderer/application.hpp
@@ -32,7 +32,6 @@ class Application : public VulkanRenderer {
     /// @brief file_name The TOML configuration file.
     /// @note It was collectively decided not to use JSON for configuration files.
     void load_toml_configuration_file(const std::string &file_name);
-    void load_textures();
     void load_shaders();
     /// @param initialize Initialize worlds with a fixed seed, which is useful for benchmarking and testing
     void load_octree_geometry(bool initialize);

--- a/include/inexor/vulkan-renderer/render_graph.hpp
+++ b/include/inexor/vulkan-renderer/render_graph.hpp
@@ -16,11 +16,15 @@
 // TODO: Compute stages.
 // TODO: Uniform buffers.
 
-// Forward declarations
 namespace inexor::vulkan_renderer::wrapper {
-class CommandBuffer;
+// Forward declaration
 class Shader;
 }; // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::commands {
+// Forward declaration
+class CommandBuffer;
+} // namespace inexor::vulkan_renderer::wrapper::commands
 
 namespace inexor::vulkan_renderer {
 
@@ -28,6 +32,9 @@ namespace inexor::vulkan_renderer {
 class PhysicalResource;
 class PhysicalStage;
 class RenderGraph;
+
+// Using declaration
+using wrapper::commands::CommandBuffer;
 
 /// @brief Base class of all render graph objects (resources and stages).
 /// @note This is just for internal use.
@@ -167,7 +174,7 @@ private:
 
     std::vector<VkDescriptorSetLayout> m_descriptor_layouts;
     std::vector<VkPushConstantRange> m_push_constant_ranges;
-    std::function<void(const PhysicalStage &, const wrapper::CommandBuffer &)> m_on_record{[](auto &, auto &) {}};
+    std::function<void(const PhysicalStage &, const CommandBuffer &)> m_on_record{[](auto &, auto &) {}};
 
 protected:
     explicit RenderStage(std::string name) : m_name(std::move(name)) {}
@@ -393,7 +400,7 @@ private:
 
     // Functions for building stage related vulkan objects.
     void build_pipeline_layout(const RenderStage *, PhysicalStage &) const;
-    void record_command_buffer(const RenderStage *, const wrapper::CommandBuffer &cmd_buf,
+    void record_command_buffer(const RenderStage *, const wrapper::commands::CommandBuffer &cmd_buf,
                                std::uint32_t image_index) const;
 
     // Functions for building graphics stage related vulkan objects.
@@ -427,7 +434,7 @@ public:
     /// @brief Submits the command frame's command buffers for drawing.
     /// @param image_index The current image index, retrieved from Swapchain::acquire_next_image
     /// @param cmd_buf The command buffer
-    void render(std::uint32_t image_index, const wrapper::CommandBuffer &cmd_buf);
+    void render(std::uint32_t image_index, const wrapper::commands::CommandBuffer &cmd_buf);
 };
 
 template <typename T>

--- a/include/inexor/vulkan-renderer/renderer.hpp
+++ b/include/inexor/vulkan-renderer/renderer.hpp
@@ -7,10 +7,13 @@
 #include "inexor/vulkan-renderer/time_step.hpp"
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
 #include "inexor/vulkan-renderer/wrapper/uniform_buffer.hpp"
-#include "inexor/vulkan-renderer/wrapper/window.hpp"
-#include "inexor/vulkan-renderer/wrapper/window_surface.hpp"
+#include "inexor/vulkan-renderer/wrapper/window/surface.hpp"
+#include "inexor/vulkan-renderer/wrapper/window/window.hpp"
 
 namespace inexor::vulkan_renderer {
+
+using wrapper::window::Window;
+using wrapper::window::WindowSurface;
 
 class VulkanRenderer {
 protected:
@@ -24,7 +27,7 @@ protected:
 
     std::uint32_t m_window_width{0};
     std::uint32_t m_window_height{0};
-    wrapper::Window::Mode m_window_mode{wrapper::Window::Mode::WINDOWED};
+    Window::Mode m_window_mode{Window::Mode::WINDOWED};
 
     std::string m_window_title;
 
@@ -34,10 +37,10 @@ protected:
 
     std::unique_ptr<Camera> m_camera;
 
-    std::unique_ptr<wrapper::Window> m_window;
+    std::unique_ptr<Window> m_window;
     std::unique_ptr<wrapper::Instance> m_instance;
     std::unique_ptr<wrapper::Device> m_device;
-    std::unique_ptr<wrapper::WindowSurface> m_surface;
+    std::unique_ptr<WindowSurface> m_surface;
     std::unique_ptr<wrapper::Swapchain> m_swapchain;
     std::unique_ptr<ImGUIOverlay> m_imgui_overlay;
     std::unique_ptr<RenderGraph> m_render_graph;

--- a/include/inexor/vulkan-renderer/tools/device_info.hpp
+++ b/include/inexor/vulkan-renderer/tools/device_info.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 /// Transform a ``VkPhysicalDeviceFeatures`` into a ``std::vector<VkBool32>``
 /// @note The size of the vector will be determined by the number of ``VkBool32`` variables in the
@@ -19,4 +19,4 @@ namespace inexor::vulkan_renderer::vk_tools {
 /// @return The name of the physical device
 [[nodiscard]] std::string get_physical_device_name(VkPhysicalDevice physical_device);
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/include/inexor/vulkan-renderer/tools/enumerate.hpp
+++ b/include/inexor/vulkan-renderer/tools/enumerate.hpp
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 /// All functions which contain the word "all" in it, call some vkEnumerate.. function,
 /// while all functions without it call vkGet..
@@ -45,4 +45,4 @@ namespace inexor::vulkan_renderer::vk_tools {
 [[nodiscard]] std::vector<VkPresentModeKHR> get_surface_present_modes(VkPhysicalDevice physical_device,
                                                                       VkSurfaceKHR surface);
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/include/inexor/vulkan-renderer/tools/representation.hpp
+++ b/include/inexor/vulkan-renderer/tools/representation.hpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 /// @brief This function returns a textual representation of the vulkan object T.
 template <typename T>
@@ -23,4 +23,4 @@ template <typename T>
 /// If you want to convert it into an std::string_view, see the matching ```as_string``` template
 [[nodiscard]] std::string_view result_to_description(VkResult result);
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/include/inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/fence.hpp"
 #include "inexor/vulkan-renderer/wrapper/gpu_memory_buffer.hpp"
+#include "inexor/vulkan-renderer/wrapper/synchronization/fence.hpp"
 
 #include <cassert>
 #include <memory>
@@ -10,14 +10,19 @@
 
 namespace inexor::vulkan_renderer::wrapper {
 // Forward declaration
-class wrapper::Device;
+class Device;
 } // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::synchronization {
+// Forward declaration
+class Fence;
+} // namespace inexor::vulkan_renderer::wrapper::synchronization
 
 namespace inexor::vulkan_renderer::wrapper::commands {
 
 // Using declarations
 using wrapper::Device;
-using wrapper::Fence;
+using wrapper::synchronization::Fence;
 
 /// @brief RAII wrapper class for VkCommandBuffer.
 /// @todo Make trivially copyable (this class doesn't really "own" the command buffer, more just an OOP wrapper).

--- a/include/inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp
@@ -9,9 +9,15 @@
 #include <vector>
 
 namespace inexor::vulkan_renderer::wrapper {
-
 // Forward declaration
-class Device;
+class wrapper::Device;
+} // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::commands {
+
+// Using declarations
+using wrapper::Device;
+using wrapper::Fence;
 
 /// @brief RAII wrapper class for VkCommandBuffer.
 /// @todo Make trivially copyable (this class doesn't really "own" the command buffer, more just an OOP wrapper).
@@ -364,4 +370,4 @@ public:
     const CommandBuffer &submit_and_wait() const; // NOLINT
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::commands

--- a/include/inexor/vulkan-renderer/wrapper/commands/command_pool.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/commands/command_pool.hpp
@@ -3,14 +3,16 @@
 #include <spdlog/spdlog.h>
 #include <volk.h>
 
-#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
+#include "inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp"
 
 #include <cassert>
 
 namespace inexor::vulkan_renderer::wrapper {
-
 // Forward declaration
 class Device;
+} // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::commands {
 
 /// @brief RAII wrapper class for VkCommandPool.
 class CommandPool {
@@ -49,4 +51,4 @@ public:
     [[nodiscard]] const CommandBuffer &request_command_buffer(const std::string &name);
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::commands

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
+#include "inexor/vulkan-renderer/wrapper/commands/command_pool.hpp"
 
 #include <array>
 #include <functional>
@@ -12,6 +12,9 @@ namespace inexor::vulkan_renderer::wrapper {
 
 // Forward declaration
 class Instance;
+
+using wrapper::commands::CommandBuffer;
+using wrapper::commands::CommandPool;
 
 /// A wrapper struct for physical device data
 struct DeviceInfo {

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
+#include "inexor/vulkan-renderer/wrapper/synchronization/semaphore.hpp"
 
 #include <cstdint>
 #include <limits>
@@ -8,11 +8,18 @@
 #include <optional>
 #include <vector>
 
+namespace inexor::vulkan_renderer::wrapper::synchronization {
+// Forward declaration
+class Semaphore;
+} // namespace inexor::vulkan_renderer::wrapper::synchronization
+
 namespace inexor::vulkan_renderer::wrapper {
 
-// Forward declarations
+// Forward declaration
 class Device;
-class Semaphore;
+
+// Using declaration
+using synchronization::Semaphore;
 
 /// RAII wrapper class for swapchains
 class Swapchain {

--- a/include/inexor/vulkan-renderer/wrapper/synchronization/fence.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/synchronization/fence.hpp
@@ -7,9 +7,11 @@
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
-
 // Forward declaration
 class Device;
+} // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::synchronization {
 
 /// @brief A RAII wrapper for VkFences.
 class Fence {
@@ -49,4 +51,4 @@ public:
     [[nodiscard]] VkResult status() const;
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::synchronization

--- a/include/inexor/vulkan-renderer/wrapper/synchronization/semaphore.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/synchronization/semaphore.hpp
@@ -5,9 +5,11 @@
 #include <string>
 
 namespace inexor::vulkan_renderer::wrapper {
-
 // Forward declaration
 class Device;
+} // namespace inexor::vulkan_renderer::wrapper
+
+namespace inexor::vulkan_renderer::wrapper::synchronization {
 
 /// RAII wrapper class for VkSemaphore
 class Semaphore {
@@ -32,4 +34,4 @@ public:
     }
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::synchronization

--- a/include/inexor/vulkan-renderer/wrapper/window/surface.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window/surface.hpp
@@ -3,7 +3,7 @@
 #include <GLFW/glfw3.h>
 #include <volk.h>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::window {
 
 /// @brief RAII wrapper class for VkSurfaceKHR.
 class WindowSurface {
@@ -29,4 +29,4 @@ public:
     }
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::window

--- a/include/inexor/vulkan-renderer/wrapper/window/window.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/window/window.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <string>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::window {
 
 /// @brief RAII wrapper class for GLFW windows.
 class Window {
@@ -93,4 +93,4 @@ public:
     }
 };
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::window

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,11 +16,10 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/io/nxoc_parser.cpp
 
     vulkan-renderer/tools/cla_parser.cpp
+    vulkan-renderer/tools/device_info.cpp
+    vulkan-renderer/tools/enumerate.cpp
     vulkan-renderer/tools/file.cpp
-
-    vulkan-renderer/vk_tools/device_info.cpp
-    vulkan-renderer/vk_tools/enumerate.cpp
-    vulkan-renderer/vk_tools/representation.cpp
+    vulkan-renderer/tools/representation.cpp
 
     vulkan-renderer/wrapper/command_buffer.cpp
     vulkan-renderer/wrapper/command_pool.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,8 +38,9 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/wrapper/shader.cpp
     vulkan-renderer/wrapper/swapchain.cpp
     vulkan-renderer/wrapper/uniform_buffer.cpp
-    vulkan-renderer/wrapper/window.cpp
-    vulkan-renderer/wrapper/window_surface.cpp
+
+    vulkan-renderer/wrapper/window/window.cpp
+    vulkan-renderer/wrapper/window/surface.cpp
 
     vulkan-renderer/world/collision.cpp
     vulkan-renderer/world/collision_query.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,14 +25,12 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/wrapper/descriptor.cpp
     vulkan-renderer/wrapper/descriptor_builder.cpp
     vulkan-renderer/wrapper/device.cpp
-    vulkan-renderer/wrapper/fence.cpp
     vulkan-renderer/wrapper/framebuffer.cpp
     vulkan-renderer/wrapper/gpu_memory_buffer.cpp
     vulkan-renderer/wrapper/gpu_texture.cpp
     vulkan-renderer/wrapper/image.cpp
     vulkan-renderer/wrapper/instance.cpp
     vulkan-renderer/wrapper/make_info.cpp
-    vulkan-renderer/wrapper/semaphore.cpp
     vulkan-renderer/wrapper/shader.cpp
     vulkan-renderer/wrapper/swapchain.cpp
     vulkan-renderer/wrapper/uniform_buffer.cpp
@@ -42,6 +40,9 @@ set(INEXOR_SOURCE_FILES
 
     vulkan-renderer/wrapper/window/window.cpp
     vulkan-renderer/wrapper/window/surface.cpp
+
+    vulkan-renderer/wrapper/synchronization/fence.cpp
+    vulkan-renderer/wrapper/synchronization/semaphore.cpp
 
     vulkan-renderer/world/collision.cpp
     vulkan-renderer/world/collision_query.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,6 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/tools/file.cpp
     vulkan-renderer/tools/representation.cpp
 
-    vulkan-renderer/wrapper/command_buffer.cpp
-    vulkan-renderer/wrapper/command_pool.cpp
     vulkan-renderer/wrapper/cpu_texture.cpp
     vulkan-renderer/wrapper/descriptor.cpp
     vulkan-renderer/wrapper/descriptor_builder.cpp
@@ -38,6 +36,9 @@ set(INEXOR_SOURCE_FILES
     vulkan-renderer/wrapper/shader.cpp
     vulkan-renderer/wrapper/swapchain.cpp
     vulkan-renderer/wrapper/uniform_buffer.cpp
+
+    vulkan-renderer/wrapper/commands/command_buffer.cpp
+    vulkan-renderer/wrapper/commands/command_pool.cpp
 
     vulkan-renderer/wrapper/window/window.cpp
     vulkan-renderer/wrapper/window/surface.cpp

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -44,7 +44,8 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     const auto &configuration_title = toml::find<std::string>(renderer_configuration, "title");
     spdlog::trace("Title: {}", configuration_title);
 
-    using WindowMode = ::inexor::vulkan_renderer::wrapper::Window::Mode;
+    using WindowMode = wrapper::window::Window::Mode;
+
     const auto &wmodestr = toml::find<std::string>(renderer_configuration, "application", "window", "mode");
     if (wmodestr == "windowed") {
         m_window_mode = WindowMode::WINDOWED;
@@ -336,8 +337,10 @@ Application::Application(int argc, char **argv) {
 
     spdlog::trace("Creating Vulkan instance");
 
-    m_window =
-        std::make_unique<wrapper::Window>(m_window_title, m_window_width, m_window_height, true, true, m_window_mode);
+    using wrapper::window::Window;
+    using wrapper::window::WindowSurface;
+
+    m_window = std::make_unique<Window>(m_window_title, m_window_width, m_window_height, true, true, m_window_mode);
 
     m_instance = std::make_unique<wrapper::Instance>(
         APP_NAME, ENGINE_NAME, VK_MAKE_API_VERSION(0, APP_VERSION[0], APP_VERSION[1], APP_VERSION[2]),
@@ -346,7 +349,7 @@ Application::Application(int argc, char **argv) {
 
     m_input = std::make_unique<input::Input>();
 
-    m_surface = std::make_unique<wrapper::WindowSurface>(m_instance->instance(), m_window->get());
+    m_surface = std::make_unique<WindowSurface>(m_instance->instance(), m_window->get());
 
     setup_window_and_input_callbacks();
 

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -6,7 +6,7 @@
 #include "inexor/vulkan-renderer/octree_gpu_vertex.hpp"
 #include "inexor/vulkan-renderer/standard_ubo.hpp"
 #include "inexor/vulkan-renderer/tools/cla_parser.hpp"
-#include "inexor/vulkan-renderer/vk_tools/enumerate.hpp"
+#include "inexor/vulkan-renderer/tools/enumerate.hpp"
 #include "inexor/vulkan-renderer/world/collision.hpp"
 #include "inexor/vulkan-renderer/wrapper/cpu_texture.hpp"
 #include "inexor/vulkan-renderer/wrapper/descriptor_builder.hpp"
@@ -405,7 +405,7 @@ Application::Application(int argc, char **argv) {
         enable_debug_marker_device_extension = false;
     }
 
-    const auto physical_devices = vk_tools::get_physical_devices(m_instance->instance());
+    const auto physical_devices = tools::get_physical_devices(m_instance->instance());
     if (preferred_graphics_card && *preferred_graphics_card >= physical_devices.size()) {
         spdlog::critical("GPU index {} out of range!", *preferred_graphics_card);
         throw std::runtime_error("Invalid GPU index");

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -98,24 +98,6 @@ void Application::load_toml_configuration_file(const std::string &file_name) {
     // TODO: Load more info from TOML file.
 }
 
-void Application::load_textures() {
-    assert(m_device->device());
-    assert(m_device->physical_device());
-    assert(m_device->allocator());
-
-    // Insert the new texture into the list of textures.
-    std::string texture_name = "unnamed texture";
-
-    spdlog::trace("Loading texture files:");
-
-    for (const auto &texture_file : m_texture_files) {
-        spdlog::trace("   - {}", texture_file);
-
-        wrapper::CpuTexture cpu_texture(texture_file, texture_name);
-        m_textures.emplace_back(*m_device, cpu_texture);
-    }
-}
-
 void Application::load_shaders() {
     assert(m_device->device());
 
@@ -460,7 +442,6 @@ Application::Application(int argc, char **argv) {
     m_swapchain = std::make_unique<wrapper::Swapchain>(*m_device, m_surface->get(), m_window->width(),
                                                        m_window->height(), m_vsync_enabled);
 
-    load_textures();
     load_shaders();
 
     m_uniform_buffers.emplace_back(*m_device, "matrices uniform buffer", sizeof(UniformBufferObject));

--- a/src/vulkan-renderer/application.cpp
+++ b/src/vulkan-renderer/application.cpp
@@ -302,13 +302,13 @@ void Application::initialize_spdlog() {
 Application::Application(int argc, char **argv) {
     initialize_spdlog();
 
-    tools::CommandLineArgumentParser cla_parser;
-    cla_parser.parse_args(argc, argv);
-
     spdlog::trace("Application version: {}.{}.{}", APP_VERSION[0], APP_VERSION[1], APP_VERSION[2]);
     spdlog::trace("Engine version: {}.{}.{}", ENGINE_VERSION[0], ENGINE_VERSION[1], ENGINE_VERSION[2]);
 
-    // Load the configuration from the TOML file.
+    // TODO (GH-558): Consider to use a command line argument parsing library.
+    tools::CommandLineArgumentParser cla_parser;
+    cla_parser.parse_args(argc, argv);
+
     load_toml_configuration_file("configuration/renderer.toml");
 
     bool enable_renderdoc_instance_layer = false;

--- a/src/vulkan-renderer/exception.cpp
+++ b/src/vulkan-renderer/exception.cpp
@@ -1,14 +1,14 @@
 #include "inexor/vulkan-renderer/exception.hpp"
 
-#include "inexor/vulkan-renderer/vk_tools/representation.hpp"
+#include "inexor/vulkan-renderer/tools/representation.hpp"
 
 namespace inexor::vulkan_renderer {
 
 VulkanException::VulkanException(std::string message, const VkResult result)
     : InexorException(message.append(" (")
-                          .append(vk_tools::as_string(result))
+                          .append(tools::as_string(result))
                           .append(": ")
-                          .append(vk_tools::result_to_description(result))
+                          .append(tools::result_to_description(result))
                           .append(")")) {}
 
 } // namespace inexor::vulkan_renderer

--- a/src/vulkan-renderer/imgui.cpp
+++ b/src/vulkan-renderer/imgui.cpp
@@ -164,7 +164,7 @@ void ImGUIOverlay::update() {
         return;
     }
 
-    m_stage->set_on_record([this](const PhysicalStage &physical, const wrapper::CommandBuffer &cmd_buf) {
+    m_stage->set_on_record([this](const PhysicalStage &physical, const wrapper::commands::CommandBuffer &cmd_buf) {
         ImDrawData *imgui_draw_data = ImGui::GetDrawData();
         if (imgui_draw_data == nullptr) {
             return;

--- a/src/vulkan-renderer/render_graph.cpp
+++ b/src/vulkan-renderer/render_graph.cpp
@@ -1,7 +1,7 @@
 #include "inexor/vulkan-renderer/render_graph.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
-#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
+#include "inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 #include "inexor/vulkan-renderer/wrapper/shader.hpp"
 
@@ -167,7 +167,7 @@ void RenderGraph::build_pipeline_layout(const RenderStage *stage, PhysicalStage 
     }
 }
 
-void RenderGraph::record_command_buffer(const RenderStage *stage, const wrapper::CommandBuffer &cmd_buf,
+void RenderGraph::record_command_buffer(const RenderStage *stage, const wrapper::commands::CommandBuffer &cmd_buf,
                                         const std::uint32_t image_index) const {
     const PhysicalStage &physical = *stage->m_physical;
 
@@ -528,7 +528,7 @@ void RenderGraph::compile(const RenderResource *target) {
     }
 }
 
-void RenderGraph::render(const std::uint32_t image_index, const wrapper::CommandBuffer &cmd_buf) {
+void RenderGraph::render(const std::uint32_t image_index, const wrapper::commands::CommandBuffer &cmd_buf) {
     // Update dynamic buffers.
     for (auto &buffer_resource : m_buffer_resources) {
         if (buffer_resource->m_data_upload_needed) {

--- a/src/vulkan-renderer/renderer.cpp
+++ b/src/vulkan-renderer/renderer.cpp
@@ -29,7 +29,7 @@ void VulkanRenderer::setup_render_graph() {
     main_stage->bind_buffer(m_vertex_buffer, 0);
     main_stage->set_clears_screen(true);
     main_stage->set_depth_options(true, true);
-    main_stage->set_on_record([&](const PhysicalStage &physical, const wrapper::CommandBuffer &cmd_buf) {
+    main_stage->set_on_record([&](const PhysicalStage &physical, const wrapper::commands::CommandBuffer &cmd_buf) {
         cmd_buf.bind_descriptor_sets(m_descriptors[0].descriptor_sets(), physical.pipeline_layout());
         cmd_buf.draw_indexed(static_cast<std::uint32_t>(m_octree_indices.size()));
     });

--- a/src/vulkan-renderer/tools/device_info.cpp
+++ b/src/vulkan-renderer/tools/device_info.cpp
@@ -1,9 +1,9 @@
-#include "inexor/vulkan-renderer/vk_tools/device_info.hpp"
+#include "inexor/vulkan-renderer/tools/device_info.hpp"
 
 #include <cassert>
 #include <cstring>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 std::vector<VkBool32> get_device_features_as_vector(const VkPhysicalDeviceFeatures &features) {
     std::vector<VkBool32> comparable_features(sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32));
@@ -18,4 +18,4 @@ std::string get_physical_device_name(const VkPhysicalDevice physical_device) {
     return properties.deviceName;
 }
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/enumerate.cpp
+++ b/src/vulkan-renderer/tools/enumerate.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/vk_tools/enumerate.hpp"
+#include "inexor/vulkan-renderer/tools/enumerate.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
 
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 std::vector<VkExtensionProperties> get_extension_properties(const VkPhysicalDevice physical_device) {
     assert(physical_device);
@@ -80,4 +80,4 @@ std::vector<VkPresentModeKHR> get_surface_present_modes(const VkPhysicalDevice p
     return present_modes;
 }
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/tools/representation.cpp
+++ b/src/vulkan-renderer/tools/representation.cpp
@@ -1,9 +1,9 @@
-#include "inexor/vulkan-renderer/vk_tools/representation.hpp"
+#include "inexor/vulkan-renderer/tools/representation.hpp"
 
 #include <array>
 #include <cassert>
 
-namespace inexor::vulkan_renderer::vk_tools {
+namespace inexor::vulkan_renderer::tools {
 
 // Please keep the functions in here in alphabetical order (sort by function names, then by parameter types)
 
@@ -970,4 +970,4 @@ std::string_view result_to_description(const VkResult result) {
     }
 }
 
-} // namespace inexor::vulkan_renderer::vk_tools
+} // namespace inexor::vulkan_renderer::tools

--- a/src/vulkan-renderer/wrapper/commands/command_buffer.cpp
+++ b/src/vulkan-renderer/wrapper/commands/command_buffer.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/command_buffer.hpp"
+#include "inexor/vulkan-renderer/wrapper/commands/command_buffer.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
@@ -8,7 +8,7 @@
 #include <memory>
 #include <utility>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::commands {
 
 CommandBuffer::CommandBuffer(const Device &device, const VkCommandPool cmd_pool, std::string name)
     : m_device(device), m_name(std::move(name)) {
@@ -325,4 +325,4 @@ const CommandBuffer &CommandBuffer::submit_and_wait() const {
     }));
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::commands

--- a/src/vulkan-renderer/wrapper/commands/command_pool.cpp
+++ b/src/vulkan-renderer/wrapper/commands/command_pool.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/command_pool.hpp"
+#include "inexor/vulkan-renderer/wrapper/commands/command_pool.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
@@ -8,7 +8,7 @@
 
 #include <thread>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::commands {
 
 CommandPool::CommandPool(const Device &device, std::string name) : m_device(device), m_name(std::move(name)) {
     const auto cmd_pool_ci = make_info<VkCommandPoolCreateInfo>({
@@ -56,4 +56,4 @@ const CommandBuffer &CommandPool::request_command_buffer(const std::string &name
     return *m_cmd_bufs.back();
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::commands

--- a/src/vulkan-renderer/wrapper/instance.cpp
+++ b/src/vulkan-renderer/wrapper/instance.cpp
@@ -1,7 +1,7 @@
 #include "inexor/vulkan-renderer/wrapper/instance.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
-#include "inexor/vulkan-renderer/vk_tools/representation.hpp"
+#include "inexor/vulkan-renderer/tools/representation.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
 #include <GLFW/glfw3.h>
@@ -95,7 +95,7 @@ Instance::Instance(const std::string &application_name, const std::string &engin
 
     std::uint32_t available_api_version = 0;
     if (const auto result = vkEnumerateInstanceVersion(&available_api_version); result != VK_SUCCESS) {
-        spdlog::error("Error: vkEnumerateInstanceVersion returned {}!", vk_tools::as_string(result));
+        spdlog::error("Error: vkEnumerateInstanceVersion returned {}!", tools::as_string(result));
         return;
     }
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -5,7 +5,7 @@
 #include "inexor/vulkan-renderer/tools/representation.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
+#include "inexor/vulkan-renderer/wrapper/synchronization/semaphore.hpp"
 
 #include <spdlog/spdlog.h>
 

--- a/src/vulkan-renderer/wrapper/swapchain.cpp
+++ b/src/vulkan-renderer/wrapper/swapchain.cpp
@@ -1,8 +1,8 @@
 #include "inexor/vulkan-renderer/wrapper/swapchain.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
-#include "inexor/vulkan-renderer/vk_tools/enumerate.hpp"
-#include "inexor/vulkan-renderer/vk_tools/representation.hpp"
+#include "inexor/vulkan-renderer/tools/enumerate.hpp"
+#include "inexor/vulkan-renderer/tools/representation.hpp"
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 #include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
@@ -64,7 +64,7 @@ Swapchain::choose_composite_alpha(const VkCompositeAlphaFlagBitsKHR request_comp
     for (const auto flag : composite_alpha_flags) {
         if ((flag & supported_composite_alpha) != 0u) {
             spdlog::trace("Swapchain composite alpha '{}' is not supported, selecting '{}'",
-                          vk_tools::as_string(request_composite_alpha), vk_tools::as_string(flag));
+                          tools::as_string(request_composite_alpha), tools::as_string(flag));
             return flag;
         }
     }
@@ -117,7 +117,7 @@ Swapchain::choose_surface_format(const std::vector<VkSurfaceFormatKHR> &availabl
                        requested_format.colorSpace == candidate.colorSpace;
             });
         if (format != available_formats.end()) {
-            spdlog::trace("Selecting swapchain surface format {}", vk_tools::as_string(*format));
+            spdlog::trace("Selecting swapchain surface format {}", tools::as_string(*format));
             return *format;
         }
     }
@@ -141,7 +141,7 @@ Swapchain::choose_surface_format(const std::vector<VkSurfaceFormatKHR> &availabl
                          });
 
         if (format != default_surface_format_priority_list.end()) {
-            spdlog::trace("Selecting swapchain image format {}", vk_tools::as_string(*format));
+            spdlog::trace("Selecting swapchain image format {}", tools::as_string(*format));
             chosen_format = *format;
         }
     }
@@ -182,7 +182,7 @@ void Swapchain::present(const std::uint32_t img_index) {
 
 void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t height, const bool vsync_enabled) {
     const auto caps = m_device.get_surface_capabilities(m_surface);
-    m_surface_format = choose_surface_format(vk_tools::get_surface_formats(m_device.physical_device(), m_surface));
+    m_surface_format = choose_surface_format(tools::get_surface_formats(m_device.physical_device(), m_surface));
     const VkExtent2D requested_extent{.width = width, .height = height};
 
     static const std::vector<VkPresentModeKHR> default_present_mode_priorities{
@@ -216,13 +216,13 @@ void Swapchain::setup_swapchain(const std::uint32_t width, const std::uint32_t h
                             ? VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR
                             : caps.currentTransform,
         .compositeAlpha = composite_alpha.value(),
-        .presentMode = choose_present_mode(vk_tools::get_surface_present_modes(m_device.physical_device(), m_surface),
+        .presentMode = choose_present_mode(tools::get_surface_present_modes(m_device.physical_device(), m_surface),
                                            default_present_mode_priorities, vsync_enabled),
         .clipped = VK_TRUE,
         .oldSwapchain = old_swapchain,
     });
 
-    spdlog::trace("Using swapchain surface transform {}", vk_tools::as_string(swapchain_ci.preTransform));
+    spdlog::trace("Using swapchain surface transform {}", tools::as_string(swapchain_ci.preTransform));
 
     spdlog::trace("Creating swapchain");
 

--- a/src/vulkan-renderer/wrapper/synchronization/fence.cpp
+++ b/src/vulkan-renderer/wrapper/synchronization/fence.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/fence.hpp"
+#include "inexor/vulkan-renderer/wrapper/synchronization/fence.hpp"
 
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <utility>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::synchronization {
 
 Fence::Fence(const Device &device, const std::string &name, const bool in_signaled_state)
     : m_device(device), m_name(name) {
@@ -42,4 +42,4 @@ VkResult Fence::status() const {
     return vkGetFenceStatus(m_device.device(), m_fence);
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::synchronization

--- a/src/vulkan-renderer/wrapper/synchronization/semaphore.cpp
+++ b/src/vulkan-renderer/wrapper/synchronization/semaphore.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/semaphore.hpp"
+#include "inexor/vulkan-renderer/wrapper/synchronization/semaphore.hpp"
 
 #include "inexor/vulkan-renderer/wrapper/device.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <utility>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::synchronization {
 
 Semaphore::Semaphore(const Device &device, const std::string &name) : m_device(device), m_name(name) {
     assert(!name.empty());
@@ -22,4 +22,4 @@ Semaphore::~Semaphore() {
     vkDestroySemaphore(m_device.device(), m_semaphore, nullptr);
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::synchronization

--- a/src/vulkan-renderer/wrapper/window/surface.cpp
+++ b/src/vulkan-renderer/wrapper/window/surface.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/window_surface.hpp"
+#include "inexor/vulkan-renderer/wrapper/window/surface.hpp"
 
 #include "inexor/vulkan-renderer/exception.hpp"
 
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <utility>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::window {
 
 WindowSurface::WindowSurface(const VkInstance instance, GLFWwindow *window) : m_instance(instance) {
     assert(instance);
@@ -29,4 +29,4 @@ WindowSurface::~WindowSurface() {
     vkDestroySurfaceKHR(m_instance, m_surface, nullptr);
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::window

--- a/src/vulkan-renderer/wrapper/window/window.cpp
+++ b/src/vulkan-renderer/wrapper/window/window.cpp
@@ -1,4 +1,4 @@
-#include "inexor/vulkan-renderer/wrapper/window.hpp"
+#include "inexor/vulkan-renderer/wrapper/window/window.hpp"
 
 #include <GLFW/glfw3.h>
 #include <spdlog/spdlog.h>
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <stdexcept>
 
-namespace inexor::vulkan_renderer::wrapper {
+namespace inexor::vulkan_renderer::wrapper::window {
 
 Window::Window(const std::string &title, const std::uint32_t width, const std::uint32_t height, const bool visible,
                const bool resizable, const Mode mode)
@@ -99,4 +99,4 @@ bool Window::should_close() {
     return glfwWindowShouldClose(m_window) == GLFW_TRUE;
 }
 
-} // namespace inexor::vulkan_renderer::wrapper
+} // namespace inexor::vulkan_renderer::wrapper::window


### PR DESCRIPTION
# Once this gets merged, we should release `v0.1.0-alpha.4`

## Major Changes
- [x] https://github.com/inexorgame/vulkan-renderer/issues/312
- [ ] Add a reference page about the rendergraph to our docs
- [x] Rewrite rendergraph from scratch and simplify it by removing polymorphism
- [x] #438
- [x] #203
- [x] #530
- [x] #526
- [x] #430
- [x] #405
- [x] #285
- [x] #277
- [x] #204
- [x] #546
- [x] #547
- [x] #537
- [x] #359
- [x] #297
- [x] #510
- [x] #486
- [x] #222
- [x] #468
- [x] #562 
- [x] #348
- [x] #511 
- [x] #411
- [x] Use `VK_API_VERSION_1_3` for Vulkan Memory Allocator
- [x] Remove unused `msaa_target.hpp`
- [x] Add more methods in `make_info.cpp`
- [x] Add wrapper for `VkPipelineLayout`
- [x] Add wrapper for `VkGraphicsPipeline`
- [x] Add wrapper for `VkSampler`

## Minor Changes
- Throw exception if name is empty in every RAII wrapper class
- Do not call `.reset()` explicitely before smart pointer reassignment (this is redundant)

## Outlook (rendergraph3)
- Automatic double or triple buffering of all rendergraph resources to manage frames in flight automatically
- Parallelize command buffer recording
- Implement Vulkan performance query pools
- Improve barrier placement
- Improve `VkWriteDescriptorSet` updating mechanism
- Pre-fill `VkRenderingAttachmentInfo` instead of doing it per-frame
- Internal descriptor performance metrics based on `cmd_buf.bind_descriptor_set` wrapper function
- [SPIR-V](https://www.khronos.org/spir/) shader metadata reflection by parsing with [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross)
- Maybe rendergraph can reason about descriptor pool sizes ahead of descriptor pool allocation?
- Batch calls to vkCreateGraphicsPipelines (in `GraphicsPipelineBuilder` and `GraphicsPass`)
