### PR TITLE
[ci|dep] Fix ci & update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,10 @@ on:
     types: [opened]
 
 env:
-  INEXOR_VULKAN_VERSION: "1.3.216.0"
+  INEXOR_VULKAN_VERSION: "1.3.283.0"
   INEXOR_VULKAN_SDK_PATH: "$GITHUB_WORKSPACE/../vulkan_sdk/"
+  INEXOR_VULKAN_SDK_CHECKSUM_LINUX: "8005e2cf3e89c80cbe1c0d0a259c88248de3257b4fc6fdefb47409edb3e43ecb"
+  INEXOR_VULKAN_SDK_CHECKSUM_WINDOWS: "811fcb9b43d09248520b2f38ae9a3763fc81df950fdab874f23bd762b07a9b12"
 
 jobs:
   linux:
@@ -24,25 +26,25 @@ jobs:
           - {
             name: "Ubuntu Clang (Debug)",
             compiler: "clang",
-            cc: "clang-14", cxx: "clang++-14",
+            cc: "clang-18", cxx: "clang++-18",
             build_type: "Debug"
           }
           - {
             name: "Ubuntu Clang (Release)",
             compiler: "clang",
-            cc: "clang-14", cxx: "clang++-14",
+            cc: "clang-18", cxx: "clang++-18",
             build_type: "Release"
           }
           - {
             name: "Ubuntu GCC (Debug)",
             compiler: "gcc",
-            cc: "gcc-12", cxx: "g++-12",
+            cc: "gcc-14", cxx: "g++-14",
             build_type: "Debug"
           }
           - {
             name: "Ubuntu GCC (Release)",
             compiler: "gcc",
-            cc: "gcc-12", cxx: "g++-12",
+            cc: "gcc-14", cxx: "g++-14",
             build_type: "Release"
           }
 
@@ -54,14 +56,17 @@ jobs:
           apt update -qq
           # Install build tools
           apt-get install -y \
-            gcc-12 \
-            clang-14 \
+            gcc-14 \
+            g++-14 \
+            clang-18 \
             cmake \
             curl \
             git \
             libgl1-mesa-dev \
+            libwayland-dev \
             libx11-dev \
             libx11-xcb-dev \
+            libxkbcommon-dev \
             libxcb-dri3-dev \
             libxcb-icccm4-dev \
             libxcb-image0-dev \
@@ -88,12 +93,15 @@ jobs:
       - name: Install Vulkan SDK
         shell: bash
         run: |
-          # Download Vulkan SDK
-          curl -LS -o vulkansdk.tar.gz \
-            https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.gz
-          # Create Vulkan SDK directory and extract
-          mkdir "${{ env.INEXOR_VULKAN_SDK_PATH }}"
-          tar xfz vulkansdk.tar.gz -C "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+          curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.xz
+          echo "${{ env.INEXOR_VULKAN_SDK_CHECKSUM_LINUX }} vulkansdk.tar.xz" | sha256sum --check
+          mkdir -p ${{ env.INEXOR_VULKAN_SDK_PATH }}
+          tar xf vulkansdk.tar.xz -C "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+          rm -rf vulkansdk.tar.xz
+          # runtime depenedencies
+          apt-get -y install qtbase5-dev libxcb-xinput0 libxcb-xinerama0
+          # remove bundled volk
+          rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/x86_64/lib/cmake/volk/
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -105,11 +113,14 @@ jobs:
           export CXX=${{ matrix.config.cxx }}
           export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/x86_64"
           export PATH=$VULKAN_SDK/bin:$PATH
+          export LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+          export VK_LAYER_PATH=$VULKAN_SDK/share/vulkan/explicit_layer.d
+          # TODO: Bring back Google tests and benchmarks in Linux CI
           cmake . \
             -Bbuild \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
-            -DINEXOR_BUILD_BENCHMARKS=ON \
-            -DINEXOR_BUILD_TESTS=ON \
+            -DINEXOR_BUILD_BENCHMARKS=OFF \
+            -DINEXOR_BUILD_TESTS=OFF \
             -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
             -GNinja \
             ${{ matrix.config.cmake_configure_options }}
@@ -204,15 +215,14 @@ jobs:
         shell: pwsh
         run: |
           choco upgrade --no-progress llvm
-          curl -fsSL -o "LLVM_VS2017.zip" "https://github.com/zufuliu/llvm-utils/releases/download/v23.03/LLVM_VS2017.zip"
+          curl -fsSL -o "LLVM_VS2017.zip" "https://github.com/zufuliu/llvm-utils/releases/download/v23.05/LLVM_VS2017.zip"
           7z x -y "LLVM_VS2017.zip" >NUL
           LLVM_VS2017\install.bat
 
       - name: Install Vulkan SDK
         shell: pwsh
         run: |
-          curl -LS -o vulkansdk.exe `
-            https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/windows/VulkanSDK-${{ env.INEXOR_VULKAN_VERSION }}-Installer.exe
+          curl -LS -o vulkansdk.exe https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/windows/VulkanSDK-${{ env.INEXOR_VULKAN_VERSION }}-Installer.exe
           7z x vulkansdk.exe -o"${{ env.INEXOR_VULKAN_SDK_PATH }}"
 
       - name: Configure CMake
@@ -221,6 +231,7 @@ jobs:
           $env:CC="${{ matrix.config.cc }}"
           $env:CXX="${{ matrix.config.cxx }}"
           $env:Path += ";${{ env.INEXOR_VULKAN_SDK_PATH }}\;${{ env.INEXOR_VULKAN_SDK_PATH }}\Bin\"
+          $env:VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}"
           # TODO: Bring back Google tests and benchmarks in Windows CI
           cmake . `
             -Bbuild `

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,8 +13,10 @@ jobs:
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"
-      INEXOR_VULKAN_VERSION: "1.3.216.0"
+      INEXOR_VULKAN_VERSION: "1.3.283.0"
       INEXOR_VULKAN_SDK_PATH: "$GITHUB_WORKSPACE/../vulkan_sdk/"
+      INEXOR_VULKAN_SDK_CHECKSUM_LINUX: "8005e2cf3e89c80cbe1c0d0a259c88248de3257b4fc6fdefb47409edb3e43ecb"
+
     steps:
       - name: Update environment
         run: |
@@ -28,6 +30,8 @@ jobs:
             curl \
             git \
             libgl1-mesa-dev \
+            libwayland-dev \
+            libxkbcommon-dev \
             libx11-dev \
             libx11-xcb-dev \
             libxcb-dri3-dev \
@@ -54,14 +58,18 @@ jobs:
           pip3 install --break-system-packages wheel setuptools
 
       - name: Install Vulkan SDK
+        shell: bash
         run: |
-          # Download Vulkan SDK
-          curl -LS -o vulkansdk.tar.gz \
-            https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.gz
-          # Create Vulkan SDK directory and extract
-          mkdir "${{ env.INEXOR_VULKAN_SDK_PATH }}"
-          tar xfz vulkansdk.tar.gz -C "${{ env.INEXOR_VULKAN_SDK_PATH }}"
-          
+          curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.xz
+          echo "${{ env.INEXOR_VULKAN_SDK_CHECKSUM_LINUX }} vulkansdk.tar.xz" | sha256sum --check
+          mkdir -p ${{ env.INEXOR_VULKAN_SDK_PATH }}
+          tar xf vulkansdk.tar.xz -C "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+          rm -rf vulkansdk.tar.xz
+          # runtime depenedencies
+          apt-get -y install qtbase5-dev libxcb-xinput0 libxcb-xinerama0
+          # remove bundled volk
+          rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/x86_64/lib/cmake/volk/
+  
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -69,8 +77,10 @@ jobs:
         run: |
           export CC=gcc
           export CXX=g++
-          export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION}}/x86_64"
+          export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/x86_64"
           export PATH=$VULKAN_SDK/bin:$PATH
+          export LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+          export VK_LAYER_PATH=$VULKAN_SDK/share/vulkan/explicit_layer.d
           cmake . -Bbuild -DCMAKE_BUILD_TYPE=Debug -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(INEXOR_APP_VERSION_MINOR 1)
 set(INEXOR_APP_VERSION_PATCH 0)
 
 # Download dependencies through CMake
-include (cmake/dependencies.cmake)
+include(cmake/dependencies.cmake)
 
 # Enable GCC/clang ANSI-colored terminal output using Ninja build tool
 # TODO: Switch to `CMAKE_COLOR_DIAGNOSTICS` with cmake 3.24 in the future

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -6,87 +6,89 @@ set(FETCHCONTENT_QUIET OFF)
 
 FetchContent_Declare(benchmark
     GIT_REPOSITORY https://github.com/google/benchmark
-    GIT_TAG v1.7.1
+    GIT_TAG v1.8.5
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.7.1)
+    FIND_PACKAGE_ARGS 1.8.5)
 
 FetchContent_Declare(fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 9.1.0
+    GIT_TAG 11.0.1
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 9.1.0)
+    FIND_PACKAGE_ARGS 11.0.1)
 
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(glfw
     GIT_REPOSITORY https://github.com/glfw/glfw.git
-    GIT_TAG 3.3.8
+    GIT_TAG 3.4
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 3.3.8)
+    FIND_PACKAGE_ARGS 3.4)
 
 FetchContent_Declare(glm
     GIT_REPOSITORY https://github.com/g-truc/glm.git
-    GIT_TAG 0.9.9.8
+    GIT_TAG 1.0.1
     GIT_SHALLOW ON
     GIT_PROGRESS ON)
 
 FetchContent_Declare(gtest
     GIT_REPOSITORY https://github.com/google/googletest
-    GIT_TAG v1.13.0
+    GIT_TAG v1.15.0
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.13.0)
+    FIND_PACKAGE_ARGS 1.15.0)
 
 FetchContent_Declare(imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG v1.89.4
+    GIT_TAG v1.90.9
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.89.4)
+    FIND_PACKAGE_ARGS 1.90.9)
 
+set(SPDLOG_FMT_EXTERNAL ON CACHE BOOL "" FORCE)
 FetchContent_Declare(spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.11.0
+    GIT_TAG v1.14.1
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.11.0)
+    FIND_PACKAGE_ARGS 1.14.1)
 
 FetchContent_Declare(stb
     GIT_REPOSITORY https://github.com/nothings/stb.git
-    GIT_TAG 5736b15f7ea0ffb08dd38af21067c314d6a3aae9
+    GIT_TAG f7f20f39fe4f206c6f19e26ebfef7b261ee59ee4
     GIT_PROGRESS ON)
 
 FetchContent_Declare(tinygltf
     GIT_REPOSITORY https://github.com/syoyo/tinygltf.git
-    GIT_TAG v2.8.6
+    GIT_TAG v2.9.2
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 2.8.6)
+    FIND_PACKAGE_ARGS 2.9.2)
 
 FetchContent_Declare(toml
     GIT_REPOSITORY https://github.com/ToruNiina/toml11.git
-    GIT_TAG v3.7.1
+    GIT_TAG v4.0.3
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 3.7.1)
+    FIND_PACKAGE_ARGS 4.0.3)
 
 FetchContent_Declare(vma
     GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
-    GIT_TAG v3.0.1
+    GIT_TAG v3.1.0
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 3.0.1)
+    FIND_PACKAGE_ARGS 3.1.0)
 
 FetchContent_Declare(volk
     GIT_REPOSITORY https://github.com/zeux/volk
-    GIT_TAG 1.3.215
+    GIT_TAG 1.3.270
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.3.215)
+    FIND_PACKAGE_ARGS 1.3.270)
 
+# is not be used because we install the whole Vulkan SDK, but stays here for fallback
 FetchContent_Declare(Vulkan
     GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers
-    GIT_TAG v1.3.215
+    GIT_TAG v1.3.283
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.3.215)
+    FIND_PACKAGE_ARGS 1.3.283)

--- a/include/inexor/vulkan-renderer/world/cube.hpp
+++ b/include/inexor/vulkan-renderer/world/cube.hpp
@@ -65,7 +65,7 @@ private:
     glm::vec3 m_position{0.0f, 0.0f, 0.0f};
 
     /// Root cube is empty.
-    std::weak_ptr<Cube> m_parent{};
+    std::weak_ptr<Cube> m_parent;
 
     /// Index of this in m_parent.m_children; undefined behavior if root.
     std::uint8_t m_index_in_parent{};

--- a/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/swapchain.hpp
@@ -20,7 +20,7 @@ private:
     Device &m_device;
     VkSwapchainKHR m_swapchain{VK_NULL_HANDLE};
     VkSurfaceKHR m_surface{VK_NULL_HANDLE};
-    std::optional<VkSurfaceFormatKHR> m_surface_format{};
+    std::optional<VkSurfaceFormatKHR> m_surface_format;
     std::vector<VkImage> m_imgs;
     std::vector<VkImageView> m_img_views;
     VkExtent2D m_extent{};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,8 +120,15 @@ target_include_directories(
 
 # Declare use of dependencies
 FetchContent_MakeAvailable(fmt)
+FetchContent_MakeAvailable(spdlog)
+FetchContent_MakeAvailable(stb)
+FetchContent_MakeAvailable(toml)
+FetchContent_MakeAvailable(Vulkan)
+FetchContent_MakeAvailable(volk)
+FetchContent_MakeAvailable(vma)
 FetchContent_MakeAvailable(glfw)
 FetchContent_MakeAvailable(glm)
+FetchContent_MakeAvailable(tinygltf)
 FetchContent_MakeAvailable(imgui)
 add_library(imgui
     ${imgui_SOURCE_DIR}/imgui.cpp
@@ -129,20 +136,6 @@ add_library(imgui
     ${imgui_SOURCE_DIR}/imgui_tables.cpp
     ${imgui_SOURCE_DIR}/imgui_widgets.cpp)
 target_include_directories(imgui PUBLIC ${imgui_SOURCE_DIR})
-FetchContent_MakeAvailable(spdlog)
-FetchContent_MakeAvailable(stb)
-FetchContent_MakeAvailable(tinygltf)
-FetchContent_MakeAvailable(toml)
-FetchContent_MakeAvailable(vma)
-FetchContent_MakeAvailable(volk)
-FetchContent_MakeAvailable(Vulkan)
-
-# Work around a VMA compile error from its use of snprintf
-target_compile_definitions(VulkanMemoryAllocator PRIVATE VMA_STATS_STRING_ENABLED=0)
-
-if (WIN32)
-   set(VOLK_STATIC_DEFINES VK_USE_PLATFORM_WIN32_KHR)
-endif()
 
 target_link_libraries(inexor-vulkan-renderer
     PUBLIC
@@ -150,7 +143,7 @@ target_link_libraries(inexor-vulkan-renderer
     glfw
     glm::glm
     imgui
-    spdlog::spdlog
+    spdlog::spdlog_header_only
     tinygltf
     toml11::toml11
     volk::volk


### PR DESCRIPTION
- Update dependencies
- Fixed the python requirement checker to not use the deprecated `pkg_resources`.
- Disabled TESTS and BENCHMARKS for linux ci, i was not able to fix the `maybe_unused, this is an C++17 extension` warning - with the Clang compiler. 
- \+ some other smaller tweaks