### PR TITLE
[ci] Cache Vulkan SDK download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,14 @@ name: Build Code
 
 on:
   push:
+    branches:
+        - main
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 env:
   INEXOR_VULKAN_VERSION: "1.3.283.0"
-  INEXOR_VULKAN_SDK_PATH: "$GITHUB_WORKSPACE/../vulkan_sdk/"
+  INEXOR_VULKAN_SDK_PATH: "${{ github.workspace }}/vulkan_sdk"
   INEXOR_VULKAN_SDK_CHECKSUM_LINUX: "8005e2cf3e89c80cbe1c0d0a259c88248de3257b4fc6fdefb47409edb3e43ecb"
   INEXOR_VULKAN_SDK_CHECKSUM_WINDOWS: "811fcb9b43d09248520b2f38ae9a3763fc81df950fdab874f23bd762b07a9b12"
 
@@ -15,7 +17,6 @@ jobs:
   linux:
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' && !github.event.pull_request.merged || github.event_name == 'push' }}
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"
@@ -53,6 +54,9 @@ jobs:
             }
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
       - name: Update environment
         shell: bash
         run: |
@@ -91,19 +95,36 @@ jobs:
             xorg-dev
           pip3 install --break-system-packages wheel setuptools
 
-      - name: Install Vulkan SDK
+      - name: Ensure Vulkan SDK folder exists (Linux only)
         shell: bash
         run: |
-          curl -LS -o vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.xz
+          mkdir -p "${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}"
+          # Add a placeholder so the cache action doesn’t complain about an empty path
+          touch "${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/.cache-placeholder"
+          echo "==== Vulkan SDK folder contents before cache lookup ===="
+          ls -R "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+
+      - name: Lookup Vulkan SDK in cache
+        id: cache-vulkan
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}
+          key: vulkansdk-linux-${{ env.INEXOR_VULKAN_VERSION }}
+
+      - name: Download and install Vulkan SDK
+        if: steps.cache-vulkan.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+          curl -LS -o vulkansdk.tar.xz \
+            https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.INEXOR_VULKAN_VERSION }}.tar.xz
           echo "${{ env.INEXOR_VULKAN_SDK_CHECKSUM_LINUX }} vulkansdk.tar.xz" | sha256sum --check
-          mkdir -p ${{ env.INEXOR_VULKAN_SDK_PATH }}
           tar xf vulkansdk.tar.xz -C "${{ env.INEXOR_VULKAN_SDK_PATH }}"
-          rm -rf vulkansdk.tar.xz
+          rm vulkansdk.tar.xz
           apt-get -y install qtbase5-dev libxcb-xinput0 libxcb-xinerama0
           rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_VERSION }}/x86_64/lib/cmake/volk/
-
-      - name: Checkout
-        uses: actions/checkout@v4
+          echo "==== Afer: Download and install Vulkan SDK ===="
+          ls -Ra "${{ env.INEXOR_VULKAN_SDK_PATH }}"
 
       - name: Configure CMake
         shell: bash
@@ -217,11 +238,23 @@ jobs:
           choco install llvm --no-progress --yes
           $env:Path += ";C:\Program Files\LLVM\bin"
 
-      - name: Install Vulkan SDK
+      - name: Ensure Vulkan SDK folder exists
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path "${{ env.INEXOR_VULKAN_SDK_PATH }}"
+
+      - name: Lookup Vulkan SDK in cache
+        id: cache-vulkan
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.INEXOR_VULKAN_SDK_PATH }}
+          key: vulkansdk-windows-${{ env.INEXOR_VULKAN_VERSION }}
+
+      - name: Download and install Vulkan SDK
+        if: steps.cache-vulkan.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           curl -LS -o vulkansdk.exe https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_VERSION }}/windows/VulkanSDK-${{ env.INEXOR_VULKAN_VERSION }}-Installer.exe
-          7z x vulkansdk.exe -o"${{ env.INEXOR_VULKAN_SDK_PATH }}"
+          7z x -y vulkansdk.exe -o"${{ env.INEXOR_VULKAN_SDK_PATH }}"
 
       - name: Configure CMake
         shell: pwsh

--- a/.github/workflows/static_analysis_clang_tidy.yml
+++ b/.github/workflows/static_analysis_clang_tidy.yml
@@ -2,6 +2,8 @@ name: Static Analysis
 
 on:
   push:
+    branches:
+        - main
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -9,7 +11,6 @@ jobs:
   clang-tidy:
     name: Clang-Tidy
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' && !github.event.pull_request.merged || github.event_name == 'push' }}
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/static_analysis_cppcheck.yaml
+++ b/.github/workflows/static_analysis_cppcheck.yaml
@@ -2,6 +2,8 @@ name: Static Analysis
 
 on:
   push:
+    branches:
+        - main
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -9,7 +11,6 @@ jobs:
   cppcheck:
     name: Cppcheck
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' && !github.event.pull_request.merged || github.event_name == 'push' }}
     container: ubuntu:rolling
     env:
       DEBIAN_FRONTEND: "noninteractive"


### PR DESCRIPTION
* [x] Use a cache instead of downloading Vulkan SDK every time (this currently works on Windows only)
* [x] Small optimization in rules when to run workflows

Originally I thought I should cache the CMake build files as well, but this turns out to be a little more complex than I thought. For example, if any of the CMakeLists.txt anywhere in `src` would be updated, I would have to clear the cache. We can do this, but for now the easy solution is just to regenerate CMake build files every run.

The biggest open problem right now is that Linux CI does not cache Vulkan SDK for whatever reason. I will try to come up with a minimal example that works, maybe I can learn from that.

The "Post Lookup Vulkan SDK in cache" step says:
```
Post job cleanup.
/usr/bin/docker exec  5c344ee47a419455a5fafd506a0141655dc1e66c31424fbf0ddb5781fdf620e2 sh -c "cat /etc/*release | grep ^ID"
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

This means something is really wrong with the cache setup in the Github action workflow. From what I can see the folders of Vulkan SDK don't seem to be cached correctly. Also, it looks like attempting to cache an empty folder on Linux is a problem.

**Nonetheless, the build works fine!**