### PR TITLE
[cmake] Put dependencies.cmake into root folder instead of extra subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(INEXOR_APP_VERSION_MINOR 1)
 set(INEXOR_APP_VERSION_PATCH 0)
 
 # Download dependencies through CMake
-include(cmake/dependencies.cmake)
+include(dependencies.cmake)
 
 # Enable GCC/clang ANSI-colored terminal output using Ninja build tool
 # TODO: Switch to `CMAKE_COLOR_DIAGNOSTICS` with cmake 3.24 in the future

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -87,7 +87,6 @@ FetchContent_Declare(volk
     GIT_PROGRESS ON
     FIND_PACKAGE_ARGS 1.3.270)
 
-# is not be used because we install the whole Vulkan SDK, but stays here for fallback
 FetchContent_Declare(Vulkan
     GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers
     GIT_TAG v1.3.283


### PR DESCRIPTION
* [x] Move `dependencies.cmake` to root folder