### PR TITLE
[ci] Cache CMake build folders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,6 @@ jobs:
         with:
           path: ${{ env.INEXOR_VULKAN_SDK_PATH }}
           key: vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-${{ runner.os }}
-          restore-keys: |
-            vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-
 
       - name: Download Vulkan SDK
         if: steps.cache-vulkan-sdk.outputs.cache-hit != 'true'
@@ -106,6 +104,12 @@ jobs:
           mkdir -p ${{ env.INEXOR_VULKAN_SDK_PATH }}
           wget -O vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_SDK_VERSION }}/linux/vulkan-sdk.tar.xz
           tar -xJf vulkansdk.tar.xz -C ${{ env.INEXOR_VULKAN_SDK_PATH }}
+
+      - name: Load CMake Setup from Cache
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: cmake-${{ runner.os }}-${{ matrix.config.compiler }}-${{ matrix.config.build_type }}-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: Configure CMake
         run: |
@@ -214,13 +218,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.INEXOR_VULKAN_SDK_PATH }}
-          key: vulkansdk-windows-${{ env.INEXOR_VULKAN_SDK_VERSION }}
+          key: vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-${{ runner.os }}
 
       - name: Download Vulkan SDK
         if: steps.cache-vulkan.outputs.cache-hit != 'true'
         run: |
           curl -LS -o vulkansdk.exe https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_SDK_VERSION }}/windows/VulkanSDK-${{ env.INEXOR_VULKAN_SDK_VERSION }}-Installer.exe
           7z x -y vulkansdk.exe -o"${{ env.INEXOR_VULKAN_SDK_PATH }}"
+
+      - name: Load CMake Setup from Cache
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: cmake-${{ runner.os }}-${{ matrix.config.compiler }}-${{ matrix.config.build_type }}-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static_analysis_clang_tidy.yml
+++ b/.github/workflows/static_analysis_clang_tidy.yml
@@ -65,8 +65,6 @@ jobs:
         with:
           path: ${{ env.INEXOR_VULKAN_SDK_PATH }}
           key: vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-${{ runner.os }}
-          restore-keys: |
-            vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-
 
       - name: Download Vulkan SDK
         if: steps.cache-vulkan-sdk.outputs.cache-hit != 'true'

--- a/.github/workflows/static_analysis_cppcheck.yaml
+++ b/.github/workflows/static_analysis_cppcheck.yaml
@@ -66,8 +66,6 @@ jobs:
         with:
           path: ${{ env.INEXOR_VULKAN_SDK_PATH }}
           key: vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-${{ runner.os }}
-          restore-keys: |
-            vulkan-sdk-${{ env.INEXOR_VULKAN_SDK_VERSION }}-
 
       - name: Download Vulkan SDK
         if: steps.cache-vulkan-sdk.outputs.cache-hit != 'true'
@@ -75,6 +73,12 @@ jobs:
           mkdir -p ${{ env.INEXOR_VULKAN_SDK_PATH }}
           wget -O vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/${{ env.INEXOR_VULKAN_SDK_VERSION }}/linux/vulkan-sdk.tar.xz
           tar -xJf vulkansdk.tar.xz -C ${{ env.INEXOR_VULKAN_SDK_PATH }}
+
+      - name: Load CMake Setup from Cache
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: cmake-${{ runner.os }}-${{ matrix.config.compiler }}-${{ matrix.config.build_type }}-${{ hashFiles('CMakeLists.txt', '**/CMakeLists.txt', '**/*.cmake') }}
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
* Cache the entire CMake build folder in Github actions cache (use checksum of all CMake files as key).
* Apply this to build and to static code analysis.
* Do not specify restore keys for caches.

This helps to drastically reduce build time (previously like 10 min)
<img width="314" height="504" alt="grafik" src="https://github.com/user-attachments/assets/9a8e6167-1d09-4528-b31d-0d3c33ef5845" />
