### PR TITLE
[ci] Attach latest source code to nightly build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Get latest workflow run artifacts
         id: download-artifacts
@@ -96,6 +98,8 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+          git tag nightly
+          git push -f origin tag nightly
 
       - name: List existing releases
         env:


### PR DESCRIPTION
While the artifacts work now, it doesn't use the latest HEAD from main branch as attached source code.