### PR TITLE
Fix broken Linux build which was undetected by CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Configure CMake
         if: steps.cache-cmake.outputs.cache-hit != 'true'
         run: |
-          rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64/lib/cmake/volk/
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Configure CMake
         if: steps.cache-cmake.outputs.cache-hit != 'true'
         run: |
-          rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64/lib/cmake/volk/
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64"
@@ -308,7 +307,6 @@ jobs:
       - name: Configure CMake
         if: steps.cache-cmake.outputs.cache-hit != 'true'
         run: |
-          rm -rf ${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64/lib/cmake/volk/
           export CC=${{ matrix.config.cc }}
           export CXX=${{ matrix.config.cxx }}
           export VULKAN_SDK="${{ env.INEXOR_VULKAN_SDK_PATH }}/${{ env.INEXOR_VULKAN_SDK_VERSION }}/x86_64"

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -110,7 +110,9 @@ FetchContent_Declare(volk
     GIT_TAG 1.3.270
     GIT_SHALLOW ON
     GIT_PROGRESS ON
-    FIND_PACKAGE_ARGS 1.3.270)
+    # Do not specify FIND_PACKAGE_ARGS here because this will fail Linux build!
+    # What happens is that CMake will try to find volk::volk in Vulkan SDK instead of using the repository.
+)
 
 # The Vulkan API headers
 FetchContent_Declare(Vulkan


### PR DESCRIPTION
That's interesting: I was not testing on my Linux machine for quite some time because I trusted the CI.
However, the CI setup is slightly different because it downloads the Vulkan SDK. Because the Vulkan SDK
contains the volk library, it creates a conflict between the Vulkan SDK's version of volk and the CMake dependency.
This was only visible on Linux machines and not in the Linux CI.