### PR TITLE
Check if mentioning parallel flag for CMake improves CI speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,13 +135,13 @@ jobs:
             ${{ matrix.config.cmake_configure_options }}
 
       - name: Build Main Code
-        run: cmake --build build --target inexor-vulkan-renderer-example
+        run: cmake --build build --target inexor-vulkan-renderer-example --parallel
 
       - name: Build Tests
-        run: cmake --build build --target inexor-vulkan-renderer-tests
+        run: cmake --build build --target inexor-vulkan-renderer-tests --parallel
 
       - name: Build Benchmarks
-        run: cmake --build build --target inexor-vulkan-renderer-benchmarks
+        run: cmake --build build --target inexor-vulkan-renderer-benchmarks --parallel
 
       - name: Run Tests
         run: |
@@ -279,13 +279,13 @@ jobs:
             ${{ matrix.config.cmake_configure_options }}
 
       - name: Build Main Code
-        run: cmake --build build --target inexor-vulkan-renderer-example
+        run: cmake --build build --target inexor-vulkan-renderer-example --parallel
 
       - name: Build Tests
-        run: cmake --build build --target inexor-vulkan-renderer-tests
+        run: cmake --build build --target inexor-vulkan-renderer-tests --parallel
 
       - name: Build Benchmarks
-        run: cmake --build build --target inexor-vulkan-renderer-benchmarks
+        run: cmake --build build --target inexor-vulkan-renderer-benchmarks --parallel
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
The build should already be parallel due to Ninja and out CMake setup, but let's be explicit and see how it works.