### PR TITLE
[*] Include gpu name and pipeline UUID in Vulkan pipeline cache file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,4 @@ documentation/source/exhale-generated/
 *.log
 
 # Vulkan pipeline cache
-*.bin
+*.cache

--- a/include/inexor/vulkan-renderer/wrapper/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/device.hpp
@@ -5,6 +5,7 @@
 #include "inexor/vulkan-renderer/wrapper/commands/command_pool.hpp"
 #include "inexor/vulkan-renderer/wrapper/make_info.hpp"
 
+#include <array>
 #include <functional>
 #include <optional>
 #include <shared_mutex>
@@ -39,6 +40,7 @@ private:
     VmaAllocator m_allocator{VK_NULL_HANDLE};
     std::string m_gpu_name;
     VkPhysicalDeviceFeatures m_enabled_features{};
+    std::array<std::uint8_t, VK_UUID_SIZE> m_pipeline_cache_uuid{};
 
     VkQueue m_graphics_queue{VK_NULL_HANDLE};
     VkQueue m_transfer_queue{VK_NULL_HANDLE};
@@ -130,6 +132,12 @@ public:
 
     [[nodiscard]] const std::string &gpu_name() const {
         return m_gpu_name;
+    }
+
+    /// Get the pipeline cache UUID for the physical device
+    /// @return A span view of the pipeline cache UUID bytes
+    [[nodiscard]] std::span<const std::uint8_t, VK_UUID_SIZE> pipeline_cache_uuid() const {
+        return m_pipeline_cache_uuid;
     }
 
     [[nodiscard]] bool has_any_compute_queue() const {

--- a/src/vulkan-renderer/wrapper/device.cpp
+++ b/src/vulkan-renderer/wrapper/device.cpp
@@ -43,6 +43,11 @@ Device::Device(const Instance &inst, const VkSurfaceKHR surface, const VkPhysica
         m_gpu_name = gpu_info.name;
     }
 
+    // Get the device properties
+    VkPhysicalDeviceProperties device_properties{};
+    vkGetPhysicalDeviceProperties(m_physical_device, &device_properties);
+    std::memcpy(m_pipeline_cache_uuid.data(), device_properties.pipelineCacheUUID, VK_UUID_SIZE);
+
     spdlog::trace("Creating Vulkan queues");
 
     const auto props = tools::get_queue_family_properties(m_physical_device);


### PR DESCRIPTION
In this pull request, we use a sanitized gpu name and the pipeline UUID as file name for the Vulkan cache.
We also changed the file extension to `.cache`