### PR TITLE
Fix double-free crash on shutdown due to incorrect destruction order

### DIFF
--- a/example-app/renderer.hpp
+++ b/example-app/renderer.hpp
@@ -85,12 +85,14 @@ namespace inexor::example_app {
 /// The base class of the Inexor vulkan-renderer example app.
 class ExampleAppBase {
 protected:
-    // Make sure to declare the instance before the debug utils messenger callback
-    // to ensure the correct order of destruction.
+    // Make sure to declare members in dependency order to ensure correct destruction order.
+    // Dependencies must be declared before dependents (destroyed in reverse order).
     std::unique_ptr<Instance> m_instance;
     std::unique_ptr<VulkanDebugUtilsCallback> m_dbg_callback;
     std::unique_ptr<WindowSurface> m_surface;
     std::unique_ptr<Device> m_device;
+    std::unique_ptr<Window> m_window;
+    std::unique_ptr<Swapchain> m_swapchain;
     std::unique_ptr<RenderGraph> m_render_graph;
 
     void setup_render_graph();
@@ -99,10 +101,6 @@ protected:
 
     // TODO Everything below needs to be abstracted further so that it's no longer
     // part of ExampleAppBase, meaning the rendergraph requires further abstraction.
-    // @TODO Swapchains will be decoupled from rendergraph again in the future
-    // The rendergraph will be able to handle an arbitrary number of windows and swapchains.
-    std::unique_ptr<Swapchain> m_swapchain;
-    std::unique_ptr<Window> m_window;
     TextureResource *m_back_buffer{nullptr};
     BufferResource *m_index_buffer{nullptr};
     BufferResource *m_vertex_buffer{nullptr};


### PR DESCRIPTION
## Summary
- Reorder member declarations so that `m_swapchain` and `m_window` are declared before `m_render_graph`
- C++ destroys members in reverse declaration order, so this ensures the render graph (which holds a reference to the swapchain) is destroyed before the swapchain itself

## Problem
Previously, `m_swapchain` was destroyed first, leaving `m_render_graph` with a dangling reference. When `~RenderGraph()` ran and tried to save the pipeline cache, this caused undefined behavior resulting in a double-free crash:

```
double free or corruption (!prev)
Aborted
```

## Test plan
- [x] Build the project
- [x] Run the example application
- [x] Close the window normally
- [x] Verify no crash occurs on shutdown