### PR TITLE
Fix PipelineCache double destruction and Device transfer fallback

### DIFF
--- a/include/inexor/vulkan-renderer/wrapper/core/device.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/core/device.hpp
@@ -102,8 +102,6 @@ private:
     /// @note This method will create a command pool for the thread if it doesn't already exist.
     CommandPool &get_thread_command_pool(VkQueueFlagBits queue_type) const;
 
-    // @TODO Implement get_thread_command_pool with "transfer if available, graphics otherwise" for copy operations.
-
 public:
     /// Default constructor
     /// @param inst The Vulkan instance

--- a/include/inexor/vulkan-renderer/wrapper/pipelines/pipeline_cache.hpp
+++ b/include/inexor/vulkan-renderer/wrapper/pipelines/pipeline_cache.hpp
@@ -46,6 +46,10 @@ public:
     /// Default constructor
     /// @param cache_file_name The name of the pipeline cache file to load
     PipelineCache(const Device &device);
+    PipelineCache(const PipelineCache &) = delete;
+    PipelineCache(PipelineCache &&) = delete;
+    PipelineCache &operator=(const PipelineCache &) = delete;
+    PipelineCache &operator=(PipelineCache &&) = delete;
 
     /// Write the Vulkan pipeline cache to file and destroy it with vkDestroyPipelineCache
     ~PipelineCache();

--- a/src/vulkan-renderer/wrapper/core/device.cpp
+++ b/src/vulkan-renderer/wrapper/core/device.cpp
@@ -419,10 +419,10 @@ CommandPool &Device::get_thread_command_pool(const VkQueueFlagBits queue_type) c
         return *thread_compute_cmd_pool;
     }
     case VK_QUEUE_TRANSFER_BIT: {
+        if (!has_any_transfer_queue()) {
+            return get_thread_command_pool(VK_QUEUE_GRAPHICS_BIT);
+        }
         if (thread_transfer_cmd_pool == nullptr) {
-            if (!has_any_transfer_queue()) {
-                throw std::runtime_error("Error: GPU '" + m_gpu_name + "' has no transfer queue!");
-            }
             auto cmd_pool = std::make_unique<CommandPool>(*this, queue_type, m_transfer_queue_family_index.value(),
                                                           "thread_transfer_cmd_pool");
             std::unique_lock lock(m_mutex);

--- a/src/vulkan-renderer/wrapper/pipelines/pipeline_cache.cpp
+++ b/src/vulkan-renderer/wrapper/pipelines/pipeline_cache.cpp
@@ -76,9 +76,11 @@ PipelineCache::PipelineCache(const core::Device &device) : m_device(device) {
 }
 
 PipelineCache::~PipelineCache() {
-    // @TODO Bug: The destructor is invoked twice? Why?
     save_cache_data_to_disk();
-    vkDestroyPipelineCache(m_device.device(), m_pipeline_cache, nullptr);
+    if (m_pipeline_cache != VK_NULL_HANDLE) {
+        vkDestroyPipelineCache(m_device.device(), m_pipeline_cache, nullptr);
+        m_pipeline_cache = VK_NULL_HANDLE;
+    }
 }
 
 std::vector<uint8_t> PipelineCache::read_cache_data_from_disk() {


### PR DESCRIPTION
This commit fixes two bugs/TODOs in the wrapper classes:
1. PipelineCache: Fixed a double-destruction bug in the destructor by nulling the Vulkan handle, and prevented unintended copies by explicitly deleting copy and move semantics in the RAII wrapper.
2. Device: Implemented the requested fallback logic in get_thread_command_pool so that if a dedicated transfer queue isn't available on the GPU, the system will safely fallback to using the main graphics queue (which natively supports transfer operations).